### PR TITLE
Increased Incentives API timeouts to 60s

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "record-build-info": "node ./bin/record-build-info",
     "lint": "eslint . --cache --max-warnings 0",
     "typecheck": "tsc && tsc -p integration_tests",
-    "test": "jest",
+    "test": "jest --detectOpenHandles --restoreMocks",
     "security_audit": "npx audit-ci --config audit-ci.json",
     "int-test": "cypress run --config video=false",
     "int-test-ui": "cypress open",

--- a/server/config.ts
+++ b/server/config.ts
@@ -62,8 +62,8 @@ export default {
       url: get('HMPPS_INCENTIVES_API_URL', 'http://localhost:2999', requiredInProduction),
       externalUrl: get('HMPPS_PRISON_API_EXTERNAL_URL', get('HMPPS_INCENTIVES_API_URL', 'http://localhost:2999')),
       timeout: {
-        response: Number(get('HMPPS_INCENTIVES_API_TIMEOUT_RESPONSE', 10000)),
-        deadline: Number(get('HMPPS_INCENTIVES_API_TIMEOUT_DEADLINE', 10000)),
+        response: Number(get('HMPPS_INCENTIVES_API_TIMEOUT_RESPONSE', 60000)),
+        deadline: Number(get('HMPPS_INCENTIVES_API_TIMEOUT_DEADLINE', 60000)),
       },
       agent: new AgentConfig(),
     },


### PR DESCRIPTION
Some requests, expecially while API cache is not warm, can take a bit long
so we're increasing the timeouts to try and reduce/avoid them.