### PR TITLE
INC-167: Tweaks to behaviour entries table's links

### DIFF
--- a/integration_tests/integration/incentivesTable.spec.ts
+++ b/integration_tests/integration/incentivesTable.spec.ts
@@ -3,11 +3,6 @@ import LocationSelectionPage from '../pages/locationSelection'
 import BehaviourEntriesPage from '../pages/behaviourEntriesPage'
 import config from '../../server/config'
 
-const threeMonthsAgo = new Date()
-threeMonthsAgo.setDate(threeMonthsAgo.getDate() - 90)
-
-const fromDate = `${threeMonthsAgo.getDate()}/${threeMonthsAgo.getMonth() + 1}/${threeMonthsAgo.getFullYear()}`
-
 context('Wing incentives table page', () => {
   let locationSelectionPage: LocationSelectionPage
   let behaviourEntriesPage: BehaviourEntriesPage
@@ -57,17 +52,17 @@ context('Wing incentives table page', () => {
         expect(entries[0]).to.deep.equal({
           imageSrc: '/prisoner-images/222222.jpeg',
           name: 'Doe, Jane (A1234AB)',
-          nameLink: `${config.dpsUrl}/prisoner/A1234AB`,
+          nameLink: caseNotesLink('A1234AB'),
           daysOnLevel: '50',
           daysSinceLastReview: '10',
           positiveBehaviours: '100',
-          positiveBehavioursLink: caseNotesLink('A1234AB', 'POS'),
+          positiveBehavioursLink: caseNotesLink('A1234AB', { type: 'POS' }),
           incentiveEncouragements: '99',
-          incentiveEncouragementsLink: caseNotesLink('A1234AB', 'POS', 'IEP_ENC'),
+          incentiveEncouragementsLink: caseNotesLink('A1234AB', { type: 'POS', subType: 'IEP_ENC' }),
           negativeBehaviours: '10',
-          negativeBehavioursLink: caseNotesLink('A1234AB', 'NEG'),
+          negativeBehavioursLink: caseNotesLink('A1234AB', { type: 'NEG' }),
           incentiveWarnings: '9',
-          incentiveWarningsLink: caseNotesLink('A1234AB', 'NEG', 'IEP_WARN'),
+          incentiveWarningsLink: caseNotesLink('A1234AB', { type: 'NEG', subType: 'IEP_WARN' }),
           provenAdjudications: '1',
           provenAdjudicationsLink: provenAdjudicationsLink('A1234AB'),
         })
@@ -88,34 +83,34 @@ context('Wing incentives table page', () => {
         expect(entries[0]).to.deep.equal({
           imageSrc: '/prisoner-images/333333.jpeg',
           name: 'Dean, James (B1234CD)',
-          nameLink: 'http://localhost:3000/prisoner/B1234CD',
+          nameLink: caseNotesLink('B1234CD'),
           daysOnLevel: '100',
           daysSinceLastReview: '10',
           positiveBehaviours: '123',
-          positiveBehavioursLink: caseNotesLink('B1234CD', 'POS'),
+          positiveBehavioursLink: caseNotesLink('B1234CD', { type: 'POS' }),
           incentiveEncouragements: '100',
-          incentiveEncouragementsLink: caseNotesLink('B1234CD', 'POS', 'IEP_ENC'),
+          incentiveEncouragementsLink: caseNotesLink('B1234CD', { type: 'POS', subType: 'IEP_ENC' }),
           negativeBehaviours: '1',
-          negativeBehavioursLink: caseNotesLink('B1234CD', 'NEG'),
+          negativeBehavioursLink: caseNotesLink('B1234CD', { type: 'NEG' }),
           incentiveWarnings: '0',
-          incentiveWarningsLink: caseNotesLink('B1234CD', 'NEG', 'IEP_WARN'),
+          incentiveWarningsLink: caseNotesLink('B1234CD', { type: 'NEG', subType: 'IEP_WARN' }),
           provenAdjudications: '0',
           provenAdjudicationsLink: provenAdjudicationsLink('B1234CD'),
         })
         expect(entries[1]).to.deep.equal({
           imageSrc: '/prisoner-images/444444.jpeg',
           name: 'Doe, John (C1234EF)',
-          nameLink: 'http://localhost:3000/prisoner/C1234EF',
+          nameLink: caseNotesLink('C1234EF'),
           daysOnLevel: '10',
           daysSinceLastReview: '10',
           positiveBehaviours: '80',
-          positiveBehavioursLink: caseNotesLink('C1234EF', 'POS'),
+          positiveBehavioursLink: caseNotesLink('C1234EF', { type: 'POS' }),
           incentiveEncouragements: '79',
-          incentiveEncouragementsLink: caseNotesLink('C1234EF', 'POS', 'IEP_ENC'),
+          incentiveEncouragementsLink: caseNotesLink('C1234EF', { type: 'POS', subType: 'IEP_ENC' }),
           negativeBehaviours: '0',
-          negativeBehavioursLink: caseNotesLink('C1234EF', 'NEG'),
+          negativeBehavioursLink: caseNotesLink('C1234EF', { type: 'NEG' }),
           incentiveWarnings: '0',
-          incentiveWarningsLink: caseNotesLink('C1234EF', 'NEG', 'IEP_WARN'),
+          incentiveWarningsLink: caseNotesLink('C1234EF', { type: 'NEG', subType: 'IEP_WARN' }),
           provenAdjudications: '0',
           provenAdjudicationsLink: provenAdjudicationsLink('C1234EF'),
         })
@@ -124,18 +119,27 @@ context('Wing incentives table page', () => {
   })
 })
 
-function caseNotesLink(prisonerNumber: string, type: string, subType: string = null) {
-  let link = `${config.dpsUrl}/prisoner/${prisonerNumber}/case-notes?type=${type}`
+function caseNotesLink(prisonerNumber: string, params: Record<string, string> = {}) {
+  let link = `${config.dpsUrl}/prisoner/${prisonerNumber}/case-notes?`
 
-  if (subType) {
-    link += `&subType=${subType}`
+  const parts = []
+  // eslint-disable-next-line no-restricted-syntax
+  for (const [key, value] of Object.entries(params)) {
+    parts.push(`${key}=${value}`)
   }
 
-  link += `&fromDate=${fromDate}`
+  const threeMonthsAgo = new Date()
+  threeMonthsAgo.setDate(threeMonthsAgo.getDate() - 90)
+
+  const fromDate = `${threeMonthsAgo.getDate()}/${threeMonthsAgo.getMonth() + 1}/${threeMonthsAgo.getFullYear()}`
+
+  parts.push(`fromDate=${fromDate}`)
+
+  link += parts.join('&')
 
   return link
 }
 
 function provenAdjudicationsLink(prisonerNumber: string) {
-  return `${config.dpsUrl}/prisoner/${prisonerNumber}/adjudications?finding=PROVED&fromDate=${fromDate}`
+  return `${config.dpsUrl}/prisoner/${prisonerNumber}/adjudications?finding=PROVED`
 }

--- a/integration_tests/integration/incentivesTable.spec.ts
+++ b/integration_tests/integration/incentivesTable.spec.ts
@@ -51,7 +51,7 @@ context('Wing incentives table page', () => {
 
         expect(entries[0]).to.deep.equal({
           imageSrc: '/prisoner-images/222222.jpeg',
-          name: 'Doe, Jane (A1234AB)',
+          name: 'Doe, Jane<br>A1234AB',
           nameLink: caseNotesLink('A1234AB'),
           daysOnLevel: '50',
           daysSinceLastReview: '10',
@@ -82,7 +82,7 @@ context('Wing incentives table page', () => {
 
         expect(entries[0]).to.deep.equal({
           imageSrc: '/prisoner-images/333333.jpeg',
-          name: 'Dean, James (B1234CD)',
+          name: 'Dean, James<br>B1234CD',
           nameLink: caseNotesLink('B1234CD'),
           daysOnLevel: '100',
           daysSinceLastReview: '10',
@@ -99,7 +99,7 @@ context('Wing incentives table page', () => {
         })
         expect(entries[1]).to.deep.equal({
           imageSrc: '/prisoner-images/444444.jpeg',
-          name: 'Doe, John (C1234EF)',
+          name: 'Doe, John<br>C1234EF',
           nameLink: caseNotesLink('C1234EF'),
           daysOnLevel: '10',
           daysSinceLastReview: '10',

--- a/integration_tests/pages/behaviourEntriesPage.ts
+++ b/integration_tests/pages/behaviourEntriesPage.ts
@@ -14,7 +14,7 @@ export default class BehaviourEntriesPage extends Page {
           const tds = Cypress.$(element).find('td.govuk-table__cell')
           return {
             imageSrc: Cypress.$(tds[0]).find('img').attr('src'),
-            name: Cypress.$(tds[1]).text(),
+            name: Cypress.$(tds[1]).find('a').html(),
             nameLink: Cypress.$(tds[1]).find('a').attr('href'),
             daysOnLevel: Cypress.$(tds[2]).text(),
             daysSinceLastReview: Cypress.$(tds[3]).text(),

--- a/server/routes/index.test.ts
+++ b/server/routes/index.test.ts
@@ -42,7 +42,7 @@ describe('GET /', () => {
       .expect(res => {
         expect(res.text).toContain('Houseblock 2 incentive levels and behaviour')
         expect(res.text).toContain('Behaviour entries since last review')
-        expect(res.text).toContain('Doe, Jane (A1234AB)')
+        expect(res.text).toContain('Doe, Jane<br>A1234AB')
       })
   })
 

--- a/server/views/pages/incentives-table.njk
+++ b/server/views/pages/incentives-table.njk
@@ -68,7 +68,7 @@
 
             {% set _ = rows.push([
             { html: '<img src="' + imageUrl + '" alt="' + prisoner.lastName + ', ' + prisoner.firstName + '\'s photo" width="90" />' },
-            { html: '<a href="' + dpsHome + '/prisoner/' + prisoner.prisonerNumber + '/case-notes?fromDate=' + threeMonthsAgo | dateParam + '" class="govuk-link">' + prisoner.lastName + ', ' + prisoner.firstName + ' (' + prisoner.prisonerNumber + ')</a>' },
+            { html: '<a href="' + dpsHome + '/prisoner/' + prisoner.prisonerNumber + '/case-notes?fromDate=' + threeMonthsAgo | dateParam + '" class="govuk-link">' + prisoner.lastName + ', ' + prisoner.firstName + '<br>' + prisoner.prisonerNumber + '</a>' },
             { html: '<a href="' + dpsHome + '/prisoner/' + prisoner.prisonerNumber + '/incentive-level-details?agencyId=' + entries.prisonId + '" class="govuk-link">' + prisoner.daysOnLevel + '</a>' },
             { html: '<a href="' + dpsHome + '/prisoner/' + prisoner.prisonerNumber + '/incentive-level-details?agencyId=' + entries.prisonId + '" class="govuk-link">' + prisoner.daysSinceLastReview + '</a>' },
             { html: '<a href="' + dpsHome + '/prisoner/' + prisoner.prisonerNumber + '/case-notes?type=POS&fromDate=' + threeMonthsAgo | dateParam + '" class="govuk-link">' + prisoner.positiveBehaviours + '</a>' },

--- a/server/views/pages/incentives-table.njk
+++ b/server/views/pages/incentives-table.njk
@@ -68,14 +68,14 @@
 
             {% set _ = rows.push([
             { html: '<img src="' + imageUrl + '" alt="' + prisoner.lastName + ', ' + prisoner.firstName + '\'s photo" width="90" />' },
-            { html: '<a href="' + dpsHome + '/prisoner/' + prisoner.prisonerNumber + '" class="govuk-link">' + prisoner.lastName + ', ' + prisoner.firstName + ' (' + prisoner.prisonerNumber + ')</a>' },
-            { html: '<a href="' + dpsHome + '/prisoner/' + prisoner.prisonerNumber + '/incentive-level-details?agencyId=' + entries.prisonId + '&incentiveLevel=' + level.levelDescription + '" class="govuk-link">' + prisoner.daysOnLevel + '</a>' },
-            { html: '<a href="' + dpsHome + '/prisoner/' + prisoner.prisonerNumber + '/incentive-level-details?agencyId=' + entries.prisonId + '&incentiveLevel=' + level.levelDescription + '" class="govuk-link">' + prisoner.daysSinceLastReview + '</a>' },
+            { html: '<a href="' + dpsHome + '/prisoner/' + prisoner.prisonerNumber + '/case-notes?fromDate=' + threeMonthsAgo | dateParam + '" class="govuk-link">' + prisoner.lastName + ', ' + prisoner.firstName + ' (' + prisoner.prisonerNumber + ')</a>' },
+            { html: '<a href="' + dpsHome + '/prisoner/' + prisoner.prisonerNumber + '/incentive-level-details?agencyId=' + entries.prisonId + '" class="govuk-link">' + prisoner.daysOnLevel + '</a>' },
+            { html: '<a href="' + dpsHome + '/prisoner/' + prisoner.prisonerNumber + '/incentive-level-details?agencyId=' + entries.prisonId + '" class="govuk-link">' + prisoner.daysSinceLastReview + '</a>' },
             { html: '<a href="' + dpsHome + '/prisoner/' + prisoner.prisonerNumber + '/case-notes?type=POS&fromDate=' + threeMonthsAgo | dateParam + '" class="govuk-link">' + prisoner.positiveBehaviours + '</a>' },
             { html: '<a href="' + dpsHome + '/prisoner/' + prisoner.prisonerNumber + '/case-notes?type=POS&subType=IEP_ENC&fromDate=' + threeMonthsAgo | dateParam + '" class="govuk-link">' + prisoner.incentiveEncouragements + '</a>' },
             { html: '<a href="' + dpsHome + '/prisoner/' + prisoner.prisonerNumber + '/case-notes?type=NEG&fromDate=' + threeMonthsAgo | dateParam + '" class="govuk-link">' + prisoner.negativeBehaviours + '</a>' },
             { html: '<a href="' + dpsHome + '/prisoner/' + prisoner.prisonerNumber + '/case-notes?type=NEG&subType=IEP_WARN&fromDate=' + threeMonthsAgo | dateParam + '" class="govuk-link">' + prisoner.incentiveWarnings + '</a>' },
-            { html: '<a href="' + dpsHome + '/prisoner/' + prisoner.prisonerNumber + '/adjudications?finding=PROVED&fromDate=' + threeMonthsAgo | dateParam + '" class="govuk-link">' + prisoner.provenAdjudications + '</a>' }
+            { html: '<a href="' + dpsHome + '/prisoner/' + prisoner.prisonerNumber + '/adjudications?finding=PROVED" class="govuk-link">' + prisoner.provenAdjudications + '</a>' }
             ]) %}
         {% endfor %}
 


### PR DESCRIPTION
- Prisoner name links to DPS 'case notes' tab (and with `fromDate` set to 3 months ago)
- links to DPS Incentive Level Details don't filter by level
- Adjudications links don't have the `fromDate` filter (as this is likely to not show proven adjudications because the date they were recorded is older than 3 months)

Also, showing Prisoner Number below their last name/first name as in prototype(s).