### PR TITLE
INC-162: unnecessary API calls when getting prisoner images

### DIFF
--- a/integration_tests/integration/prisonerImages.spec.ts
+++ b/integration_tests/integration/prisonerImages.spec.ts
@@ -1,0 +1,31 @@
+context('Getting a prisoner image', () => {
+  beforeEach(() => {
+    cy.task('reset')
+    cy.task('stubSignIn')
+  })
+
+  context('when authenticated', () => {
+    beforeEach(() => {
+      cy.task('stubAuthUser')
+      cy.task('stubPrisonApiImages')
+
+      cy.signIn()
+    })
+
+    it('responds 200 OK', () => {
+      cy.request('/prisoner-images/123.jpeg').then(resp => {
+        expect(resp.redirectedToUrl).to.eq(undefined)
+        expect(resp.status).to.eq(200)
+        expect(resp.headers['content-type']).to.eq('images/jpeg')
+      })
+    })
+  })
+
+  context('when not authenticated', () => {
+    it('redirects to login page', () => {
+      cy.request('/prisoner-images/123.jpeg')
+        .its('headers.location')
+        .should('equal', 'http://localhost:3007/sign-in/callback?code=codexxxx&state=stateyyyy')
+    })
+  })
+})

--- a/server/app.ts
+++ b/server/app.ts
@@ -38,10 +38,10 @@ export default function createApp(userService: UserService): express.Application
   app.use(authorisationMiddleware())
 
   // App routes
-  app.use('/', homeRoutes(standardRouter(userService)))
   app.use('/select-location', selectLocationRoutes(standardRouter(userService)))
   app.use('/incentive-summary/:locationPrefix', incentivesTableRoutes(standardRouter(userService)))
   app.use('/prisoner-images/:imageId.jpeg', prisonerImagesRoutes(imageRouter()))
+  app.use('/', homeRoutes(standardRouter(userService)))
 
   app.use((req, res, next) => next(createError(404, 'Not found')))
   app.use(errorHandler(process.env.NODE_ENV === 'production'))


### PR DESCRIPTION
The prisoner images route was initially using the `standardRouter` which
was populating the current user/caseloads making additional requests.

This is useful when showing a page but a waste when a browser is getting
prisoner images' raw data.

That route now uses a simpler `imageRouter` which doesn't use the
`populateUser` middleware...however, these API calls were still happening.

The reason for this is order of the routes wiring. The `/` route (which
still uses the `standardRouter`) was still running because it was more
generic. Move it last means these unnecessary requests are not made anymore.

NOTE: I've added a regression test - which would fail if the
`app.use('/', ...` is moved back above the prisoner images route) -
and also a test for the authentication requirement of this endpoint.