### PR TITLE
INC-249: Middleware refactoring

### DIFF
--- a/server/app.ts
+++ b/server/app.ts
@@ -3,13 +3,9 @@ import express from 'express'
 import path from 'path'
 import createError from 'http-errors'
 
-import homeRoutes from './routes/home'
-import incentivesTableRoutes from './routes/incentivesTable'
-import selectLocationRoutes from './routes/selectLocation'
-import prisonerImagesRoutes from './routes/prisonerImages'
+import allRoutes from './routes/all'
 import nunjucksSetup from './utils/nunjucksSetup'
 import errorHandler from './errorHandler'
-import standardRouter from './routes/standardRouter'
 import type UserService from './services/userService'
 
 import setUpWebSession from './middleware/setUpWebSession'
@@ -19,7 +15,6 @@ import setUpAuthentication from './middleware/setUpAuthentication'
 import setUpHealthChecks from './middleware/setUpHealthChecks'
 import setUpWebRequestParsing from './middleware/setupRequestParsing'
 import authorisationMiddleware from './middleware/authorisationMiddleware'
-import imageRouter from './routes/imageRouter'
 
 export default function createApp(userService: UserService): express.Application {
   const app = express()
@@ -38,10 +33,7 @@ export default function createApp(userService: UserService): express.Application
   app.use(authorisationMiddleware())
 
   // App routes
-  app.use('/select-location', selectLocationRoutes(standardRouter(userService)))
-  app.use('/incentive-summary/:locationPrefix', incentivesTableRoutes(standardRouter(userService)))
-  app.use('/prisoner-images/:imageId.jpeg', prisonerImagesRoutes(imageRouter()))
-  app.use('/', homeRoutes(standardRouter(userService)))
+  app.use('/', allRoutes(userService))
 
   app.use((req, res, next) => next(createError(404, 'Not found')))
   app.use(errorHandler(process.env.NODE_ENV === 'production'))

--- a/server/routes/all.ts
+++ b/server/routes/all.ts
@@ -1,0 +1,20 @@
+import { Router } from 'express'
+
+import type UserService from '../services/userService'
+import homeRoutes from './home'
+import imageRouter from './imageRouter'
+import incentivesTableRoutes from './incentivesTable'
+import prisonerImagesRoutes from './prisonerImages'
+import selectLocationRoutes from './selectLocation'
+import standardRouter from './standardRouter'
+
+export default function routes(userService: UserService): Router {
+  const router = Router({ mergeParams: true })
+
+  router.use('/select-location', selectLocationRoutes(standardRouter(userService)))
+  router.use('/incentive-summary/:locationPrefix', incentivesTableRoutes(standardRouter(userService)))
+  router.use('/prisoner-images/:imageId.jpeg', prisonerImagesRoutes(imageRouter()))
+  router.use('/', homeRoutes(standardRouter(userService)))
+
+  return router
+}

--- a/server/routes/testutils/appSetup.ts
+++ b/server/routes/testutils/appSetup.ts
@@ -3,18 +3,13 @@ import { Cookie, Session, SessionData } from 'express-session'
 import createError from 'http-errors'
 import path from 'path'
 
-import homeRoutes from '../home'
-import incentivesTableRoutes from '../incentivesTable'
-import selectLocationRoutes from '../selectLocation'
-import prisonerImagesRoutes from '../prisonerImages'
+import allRoutes from '../all'
 import nunjucksSetup from '../../utils/nunjucksSetup'
 import errorHandler from '../../errorHandler'
-import standardRouter from '../standardRouter'
 import UserService from '../../services/userService'
 import * as auth from '../../authentication/auth'
 import { Location, PrisonApi } from '../../data/prisonApi'
 import { getTestLocation } from '../../testData/prisonApi'
-import imageRouter from '../imageRouter'
 
 jest.mock('../../data/prisonApi')
 
@@ -88,10 +83,7 @@ function appSetup(production: boolean, testSession: Session, mockUserService: Us
   app.use(express.urlencoded({ extended: true }))
 
   // App routes
-  app.use('/select-location', selectLocationRoutes(standardRouter(mockUserService)))
-  app.use('/incentive-summary/:locationPrefix', incentivesTableRoutes(standardRouter(mockUserService)))
-  app.use('/prisoner-images/:imageId.jpeg', prisonerImagesRoutes(imageRouter()))
-  app.use('/', homeRoutes(standardRouter(mockUserService)))
+  app.use('/', allRoutes(mockUserService))
 
   app.use((req, res, next) => next(createError(404, 'Not found')))
   app.use(errorHandler(production))


### PR DESCRIPTION
Removed duplication between real express app and test express app.

The test express app should be as similar as possible to the real expess
app (the one determining how users' traffic is handled). This should
reduce chances of tests running against a different version of the routing
as before.

In addition, now to add a route only one file needs to change instead of
two (easy to miss)