### PR TITLE
INC-329: Removed (unused) jQuery UI and simplified CSP

### DIFF
--- a/server/middleware/setUpWebSecurity.ts
+++ b/server/middleware/setUpWebSecurity.ts
@@ -19,17 +19,15 @@ export default function setUpWebSecurity(): Router {
           defaultSrc: ["'self'"],
           scriptSrc: [
             "'self'",
-            'code.jquery.com',
             'https://www.google-analytics.com',
             (req: Request, res: Response) => `'nonce-${res.locals.cspNonce}'`,
           ],
-          styleSrc: ["'self'", 'code.jquery.com', (req: Request, res: Response) => `'nonce-${res.locals.cspNonce}'`],
+          styleSrc: ["'self'", (req: Request, res: Response) => `'nonce-${res.locals.cspNonce}'`],
           fontSrc: ["'self'"],
           connectSrc: ['https://www.google-analytics.com'],
           imgSrc: ["'self'", 'https://www.google-analytics.com'],
         },
       },
-      crossOriginEmbedderPolicy: true,
     })
   )
 

--- a/server/views/partials/layout.njk
+++ b/server/views/partials/layout.njk
@@ -18,10 +18,6 @@
 
   <link href="/assets/stylesheets/application.css?{{ version }}" rel="stylesheet" />
   <script src="/assets/js/jquery.min.js"></script>
-  <script src="https://code.jquery.com/ui/1.12.1/jquery-ui.min.js"
-          integrity="sha256-VazP97ZCwtekAsvgPBSUwPFKdrwD3unUfSGVYrahUqU="
-          crossorigin="anonymous"></script>
-  <link href="https://code.jquery.com/ui/1.12.1/themes/ui-lightness/jquery-ui.css" rel="stylesheet" />
 
 {% endblock %}
 


### PR DESCRIPTION
jQuery UI was included in all pages (as it was part of the layout
template) but it doesn't seem to be used anywhere.

Even worse, the js/css wasn't served by the application itself which is
a potential security issue.

Remove these means we can remove the CSP rules to allow requests to
code.jquery.com. It also means we can remove the
`crossOriginEmbedderPolicy: true` option which was added to avoid the
related CSP error.