### PR TITLE
INC-305: Provision S3 buckets with testing data in `dev` and `preprod` environments

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -156,6 +156,29 @@ jobs:
       - store_artifacts:
           path: integration-tests/screenshots
 
+  upload_test_data_to_s3:
+    executor:
+      name: hmpps/default_small
+    steps:
+      - checkout
+      - hmpps/k8s_setup
+      - hmpps/install_aws_cli
+      - run:
+          name: Upload test data to S3 bucket
+          command: |
+            S3_BUCKET_NAME=$(kubectl --namespace="${KUBE_ENV_NAMESPACE}" get secret analytical-platform-s3-bucket-output -o go-template='{{.data.bucket_name|base64decode}}')
+            export AWS_ACCESS_KEY_ID=$(kubectl --namespace="${KUBE_ENV_NAMESPACE}" get secret analytical-platform-s3-bucket-output -o go-template='{{.data.access_key_id|base64decode}}')
+            export AWS_SECRET_ACCESS_KEY=$(kubectl --namespace="${KUBE_ENV_NAMESPACE}" get secret analytical-platform-s3-bucket-output -o go-template='{{.data.secret_access_key|base64decode}}')
+            aws s3 sync server/testData/s3Bucket s3://${S3_BUCKET_NAME} || export UPLOAD_FAILED=1
+            unset AWS_ACCESS_KEY_ID
+            unset AWS_SECRET_ACCESS_KEY
+            [ -n "$UPLOAD_FAILED" ] && {
+              echo 'Failed to upload test data'
+              exit 1
+            }
+          environment:
+            AWS_DEFAULT_REGION: eu-west-2
+
 workflows:
   version: 2
   build-test-and-deploy:
@@ -192,6 +215,12 @@ workflows:
             - unit_test
             - integration_test
             - build_docker
+      - upload_test_data_to_s3:
+          name: upload_test_data_to_s3_dev
+          context:
+            - hmpps-common-vars
+          requires:
+            - deploy_dev
       - request-preprod-approval:
           type: approval
           requires:
@@ -206,6 +235,13 @@ workflows:
             - hmpps-incentives-ui-preprod
           requires:
             - request-preprod-approval
+      - upload_test_data_to_s3:
+          name: upload_test_data_to_s3_preprod
+          context:
+            - hmpps-common-vars
+            - hmpps-incentives-ui-preprod
+          requires:
+            - deploy_preprod
       - request-prod-approval:
           type: approval
           requires:


### PR DESCRIPTION
This will allow CircleCI to provision test S3 buckets with the same testing data as is packaged in this repo. When deploying to `dev` or `preprod`, CircleCI will read the appropriate k8s secret with S3 details and use AWS cli to synchronise the bucket, ensuring it is up to date and matches what would run locally and during integration tests.