### PR TITLE
INC-339: Change heat map to a tint of GDS "light purple" colour

### DIFF
--- a/server/views/pages/analytics/behaviour-entries/prisoners-with-entries-by-location.njk
+++ b/server/views/pages/analytics/behaviour-entries/prisoners-with-entries-by-location.njk
@@ -7,14 +7,14 @@
 {{ dataSource(report.dataSource, report.lastUpdated, {"classes": "govuk-!-margin-bottom-6"}) }}
 
 {% macro heatMapColour(percentage) -%}
-  {#- heat map ranges from white at 0% to GDS yellow at 100% -#}
-  {#- at 0% the colour is 0% GDS yellow tint; i.e. white -#}
-  {#- however, at 1% the colour is 3% GDS yellow tint to allow 0% be markedly different from 1% -#}
-  {#- at 100% the colour is 100% GDS yellow tint -#}
+  {#- heat map ranges from white at 0% to (almost) GDS light purple at 100% -#}
+  {#- at 0% the colour is 0% GDS light purple tint; i.e. white -#}
+  {#- however, at 1% the colour is 3% GDS light purple tint to allow 0% be markedly different from 1% -#}
+  {#- at 100% the colour is 90% GDS light purple with 10% white -#}
   {%- if percentage == 0 -%}
     #fff
   {%- else -%}
-    hsl(52,100%,{{ 50 + 47 * (100 - percentage) / 100 }}%)
+    hsl(237,29%,{{ 65 + 32 * (100 - percentage) / 100 }}%)
   {%- endif -%}
 {%- endmacro %}
 


### PR DESCRIPTION
…so that users read less into the specific colour. Yellow could indicate warning or focus.