### PR TITLE
INC-391: Analytics graph errors

### DIFF
--- a/server/routes/analyticsRouter.test.ts
+++ b/server/routes/analyticsRouter.test.ts
@@ -4,7 +4,7 @@ import request from 'supertest'
 import config from '../config'
 import { TableType } from '../services/analyticsServiceTypes'
 import { appWithAllRoutes } from './testutils/appSetup'
-import { mockSdkS3ClientReponse } from '../testData/s3Bucket'
+import { MockTable, mockSdkS3ClientReponse } from '../testData/s3Bucket'
 
 jest.mock('@aws-sdk/client-s3')
 
@@ -130,6 +130,28 @@ describe.each(analyticsPages)(
         .expect(res => {
           expect(res.text).not.toContain(expectedHeading)
           expect(res.text).toContain('Page not found')
+        })
+    })
+
+    it(`error is presented on ${name} page if no source table was found`, () => {
+      mockSdkS3ClientReponse(s3.send, sourceTable, MockTable.Missing)
+
+      return request(app)
+        .get(url)
+        .expect(500)
+        .expect(res => {
+          expect(res.text).toContain('Sorry, there is a problem with the service')
+        })
+    })
+
+    it(`error is presented on ${name} page if source table contains no data`, () => {
+      mockSdkS3ClientReponse(s3.send, sourceTable, MockTable.Empty)
+
+      return request(app)
+        .get(url)
+        .expect(500)
+        .expect(res => {
+          expect(res.text).toContain('Sorry, there is a problem with the service')
         })
     })
 

--- a/server/services/analyticsService.test.ts
+++ b/server/services/analyticsService.test.ts
@@ -2,7 +2,7 @@ import S3Client from '../data/s3Client'
 import AnalyticsService, { compareLocations, compareCharacteristics, removeLevelPrefix } from './analyticsService'
 import { AnalyticsError, TableType, ProtectedCharacteristic, Ethnicities, AgeGroups } from './analyticsServiceTypes'
 import type { PrisonersOnLevelsByProtectedCharacteristic } from './analyticsServiceTypes'
-import { mockAppS3ClientResponse } from '../testData/s3Bucket'
+import { MockTable, mockAppS3ClientResponse } from '../testData/s3Bucket'
 
 jest.mock('@aws-sdk/client-s3')
 jest.mock('../data/s3Client')
@@ -203,6 +203,12 @@ describe('AnalyticsService', () => {
       expect(prisonTotal.entriesNegative).toEqual(sumNegative)
     })
 
+    it('throws an error when the table is empty', async () => {
+      mockAppS3ClientResponse(s3Client, TableType.behaviourEntries, MockTable.Empty)
+
+      await expect(analyticsService.getBehaviourEntriesByLocation('MDI')).rejects.toThrow(AnalyticsError)
+    })
+
     describe.each(prisonLocations)(
       'lists locations in the correct order',
       (prison: string, expectedLocations: string[]) => {
@@ -241,6 +247,12 @@ describe('AnalyticsService', () => {
       expect(prisonTotal.prisonersWithNeither).toEqual(sumNeither)
     })
 
+    it('throws an error when the table is empty', async () => {
+      mockAppS3ClientResponse(s3Client, TableType.behaviourEntries, MockTable.Empty)
+
+      await expect(analyticsService.getPrisonersWithEntriesByLocation('MDI')).rejects.toThrow(AnalyticsError)
+    })
+
     describe.each(prisonLocations)(
       'lists locations in the correct order',
       (prison: string, expectedLocations: string[]) => {
@@ -275,6 +287,12 @@ describe('AnalyticsService', () => {
       for (let i = 0; i < columns.length; i += 1) {
         expect(prisonTotal.prisonersOnLevels[i]).toEqual(totals[i])
       }
+    })
+
+    it('throws an error when the table is empty', async () => {
+      mockAppS3ClientResponse(s3Client, TableType.behaviourEntries, MockTable.Empty)
+
+      await expect(analyticsService.getIncentiveLevelsByLocation('MDI')).rejects.toThrow(AnalyticsError)
     })
 
     describe.each(prisonLocations)(
@@ -323,6 +341,14 @@ describe('AnalyticsService', () => {
       for (let i = 0; i < columns.length; i += 1) {
         expect(prisonTotal.prisonersOnLevels[i]).toEqual(totals[i])
       }
+    })
+
+    it(`[${characteristic}]: throws an error when the table is empty`, async () => {
+      mockAppS3ClientResponse(s3Client, TableType.behaviourEntries, MockTable.Empty)
+
+      await expect(analyticsService.getIncentiveLevelsByProtectedCharacteristic('MDI', characteristic)).rejects.toThrow(
+        AnalyticsError
+      )
     })
 
     it(`[${characteristic}]: lists groups in the correct order`, async () => {

--- a/server/services/analyticsService.test.ts
+++ b/server/services/analyticsService.test.ts
@@ -1,6 +1,6 @@
 import S3Client from '../data/s3Client'
 import AnalyticsService, { compareLocations, compareCharacteristics, removeLevelPrefix } from './analyticsService'
-import { TableType, ProtectedCharacteristic, Ethnicities, AgeGroups } from './analyticsServiceTypes'
+import { AnalyticsError, TableType, ProtectedCharacteristic, Ethnicities, AgeGroups } from './analyticsServiceTypes'
 import type { PrisonersOnLevelsByProtectedCharacteristic } from './analyticsServiceTypes'
 import { mockAppS3ClientResponse } from '../testData/s3Bucket'
 
@@ -73,7 +73,7 @@ describe('AnalyticsService', () => {
     it('throws an error when it cannot find a table', async () => {
       s3Client.listObjects.mockResolvedValue([])
 
-      await expect(analyticsService.findTable(TableType.behaviourEntries)).rejects.toThrow()
+      await expect(analyticsService.findTable(TableType.behaviourEntries)).rejects.toThrow(AnalyticsError)
     })
 
     it('throws an error when object contents cannot be parsed', async () => {
@@ -81,7 +81,7 @@ describe('AnalyticsService', () => {
       s3Client.listObjects.mockResolvedValue([{ key: 'behaviour_entries/2022-03-13.json', modified }])
       s3Client.getObject.mockResolvedValue('{"column":')
 
-      await expect(analyticsService.findTable(TableType.behaviourEntries)).rejects.toThrow()
+      await expect(analyticsService.findTable(TableType.behaviourEntries)).rejects.toThrow(AnalyticsError)
     })
   })
 

--- a/server/services/analyticsService.ts
+++ b/server/services/analyticsService.ts
@@ -98,6 +98,9 @@ export default class AnalyticsService {
     const stitchedTable = this.stitchTable<CaseEntriesTable, StitchedRow>(table, columnsToStitch)
 
     const filteredTables = stitchedTable.filter(([somePrison]) => somePrison === prison)
+    if (filteredTables.length === 0) {
+      throw new AnalyticsError(AnalyticsErrorType.EmptyTable, 'Filtered BehaviourEntriesByLocation report has no rows')
+    }
 
     const columns = ['Positive', 'Negative']
     type AggregateRow = [string, number, number]
@@ -125,6 +128,12 @@ export default class AnalyticsService {
     const stitchedTable = this.stitchTable<CaseEntriesTable, StitchedRow>(table, columnsToStitch)
 
     const filteredTables = stitchedTable.filter(([somePrison]) => somePrison === prison)
+    if (filteredTables.length === 0) {
+      throw new AnalyticsError(
+        AnalyticsErrorType.EmptyTable,
+        'Filtered PrisonersWithEntriesByLocation report has no rows'
+      )
+    }
 
     const columns = ['Positive', 'Negative', 'Both', 'None']
     type AggregateRow = [string, number, number, number, number]
@@ -165,6 +174,9 @@ export default class AnalyticsService {
     const filteredTables = stitchedTable.filter(
       ([somePrison, _wing, _incentive, characteristic]) => somePrison === prison && characteristic === 'age_group_10yr'
     )
+    if (filteredTables.length === 0) {
+      throw new AnalyticsError(AnalyticsErrorType.EmptyTable, 'Filtered PrisonersOnLevelsByLocation report has no rows')
+    }
 
     let columns = Array.from(new Set(Object.values(table.incentive)))
     columns.sort() // NB: levels sort naturally because they include a prefix
@@ -205,6 +217,12 @@ export default class AnalyticsService {
         return somePrison === prison && characteristic === protectedCharacteristic && characteristicGroup
       }
     )
+    if (filteredTables.length === 0) {
+      throw new AnalyticsError(
+        AnalyticsErrorType.EmptyTable,
+        `Filtered PrisonersOnLevelsByProtectedCharacteristic report for ${protectedCharacteristic} has no rows`
+      )
+    }
 
     let columns = Array.from(new Set(Object.values(table.incentive)))
     columns.sort() // NB: levels sort naturally because they include a prefix

--- a/server/services/analyticsServiceTypes.ts
+++ b/server/services/analyticsServiceTypes.ts
@@ -123,6 +123,7 @@ export function knownGroupsFor(characteristic: ProtectedCharacteristic): Readonl
 export enum AnalyticsErrorType {
   MissingTable,
   MalformedTable,
+  EmptyTable,
 }
 
 /**

--- a/server/services/analyticsServiceTypes.ts
+++ b/server/services/analyticsServiceTypes.ts
@@ -116,3 +116,20 @@ export function knownGroupsFor(characteristic: ProtectedCharacteristic): Readonl
       throw new Error('Unknown characteristic')
   }
 }
+
+/**
+ * Types of errors thrown by the analytics service
+ */
+export enum AnalyticsErrorType {
+  MissingTable,
+  MalformedTable,
+}
+
+/**
+ * Thrown by the analytics service when a categorisable error ocurred
+ */
+export class AnalyticsError extends Error {
+  constructor(readonly type: AnalyticsErrorType, message?: string) {
+    super(message)
+  }
+}

--- a/server/testData/s3Bucket.ts
+++ b/server/testData/s3Bucket.ts
@@ -8,35 +8,65 @@ import type { GetObjectOutput, ListObjectsV2Output } from '@aws-sdk/client-s3'
 import type S3Client from '../data/s3Client'
 import type { TableType } from '../services/analyticsServiceTypes'
 
-export function mockAppS3ClientResponse(s3Client: jest.Mocked<S3Client>, tableType: TableType, emptyTable = false) {
-  s3Client.listObjects.mockResolvedValue([
-    {
-      key: `${tableType}/2022-03-13.json`,
-      modified: new Date('2022-03-14T12:00:00Z'),
-    },
-  ])
-  s3Client.getObject.mockReturnValue(
-    fs.readFile(path.resolve(__dirname, `./s3Bucket/${tableType}/${emptyTable ? 'empty' : '2022-03-13'}.json`), {
-      encoding: 'utf8',
-    })
-  )
+export enum MockTable {
+  /** mimics a normal table */
+  Sample,
+  /** mimics when no table is found */
+  Missing,
+  /** mimics empty table */
+  Empty,
 }
 
+/**
+ * Mocks the response for the S3Client in this application (for testing the consumers of this client)
+ */
+export function mockAppS3ClientResponse(
+  s3Client: jest.Mocked<S3Client>,
+  tableType: TableType,
+  tableResponse = MockTable.Sample
+) {
+  s3Client.listObjects.mockResolvedValue(
+    tableResponse === MockTable.Missing
+      ? []
+      : [{ key: `${tableType}/2022-03-13.json`, modified: new Date('2022-03-14T12:00:00Z') }]
+  )
+  if (tableResponse !== MockTable.Missing) {
+    s3Client.getObject.mockReturnValue(
+      fs.readFile(
+        path.resolve(
+          __dirname,
+          `./s3Bucket/${tableType}/${tableResponse === MockTable.Empty ? 'empty' : '2022-03-13'}.json`
+        ),
+        { encoding: 'utf8' }
+      )
+    )
+  }
+}
+
+/**
+ * Mocks the response for the S3Client in the AWS SDK (for testing the S3Client in this application)
+ */
 export function mockSdkS3ClientReponse(
   send: jest.Mock<Promise<GetObjectOutput | ListObjectsV2Output>, [GetObjectCommand | ListObjectsV2Command]>,
   tableType: TableType,
-  emptyTable = false
+  tableResponse = MockTable.Sample
 ) {
   const listObjectsResponse: ListObjectsV2Output = {
-    Contents: [{ Key: `${tableType}/2022-03-13.json`, LastModified: new Date('2022-03-14T12:00:00Z') }],
+    Contents:
+      tableResponse === MockTable.Missing
+        ? []
+        : [{ Key: `${tableType}/2022-03-13.json`, LastModified: new Date('2022-03-14T12:00:00Z') }],
   }
   send.mockImplementation(async command => {
     if (command instanceof ListObjectsV2Command) {
       return listObjectsResponse
     }
-    if (command instanceof GetObjectCommand) {
+    if (command instanceof GetObjectCommand && tableResponse !== MockTable.Missing) {
       const stream = createReadStream(
-        path.resolve(__dirname, `../testData/s3Bucket/${tableType}/${emptyTable ? 'empty' : '2022-03-13'}.json`)
+        path.resolve(
+          __dirname,
+          `../testData/s3Bucket/${tableType}/${tableResponse === MockTable.Empty ? 'empty' : '2022-03-13'}.json`
+        )
       )
       return { Body: stream }
     }


### PR DESCRIPTION
Present a generic 500 error page when:

- source data is missing
- source data fails to load or is malformed
- aggregated data is empty 🆕

… because it is better to show a message than show a broken-looking table with no contents.