### PR TITLE
INC-412: Tag analytics feedback with chart id

### DIFF
--- a/server/routes/analyticsRouter.test.ts
+++ b/server/routes/analyticsRouter.test.ts
@@ -205,7 +205,7 @@ describe.each(analyticsPages)(
               subject: `Feedback on chart ${graphId}`,
               comment: { body: expect.any(String) },
               type: 'task',
-              tags: ['hmpps-incentives', 'chart-feedback', 'useful-yes'],
+              tags: ['hmpps-incentives', 'chart-feedback', `chart-${graphId}`, 'useful-yes'],
               custom_fields: [
                 // Service
                 { id: 23757677, value: 'hmpps_incentives' },
@@ -242,7 +242,13 @@ describe.each(analyticsPages)(
               subject: expect.any(String),
               comment: { body: expect.any(String) },
               type: 'task',
-              tags: ['hmpps-incentives', 'chart-feedback', 'useful-no', 'not-useful-do-not-understand'],
+              tags: [
+                'hmpps-incentives',
+                'chart-feedback',
+                `chart-${graphId}`,
+                'useful-no',
+                'not-useful-do-not-understand',
+              ],
               custom_fields: expect.anything(),
             })
             expect(mockedZendeskClientClass).toHaveBeenCalled()

--- a/server/routes/analyticsRouter.ts
+++ b/server/routes/analyticsRouter.ts
@@ -147,7 +147,7 @@ async function chartFeedbackHandler(req: Request, res: Response, next: NextFunct
 
   logger.info(`Submitting feedback to Zendesk: Chart ${form.data.formId} was useful=${form.data.chartUseful}`)
 
-  const tags = ['hmpps-incentives', 'chart-feedback', `useful-${form.data.chartUseful}`]
+  const tags = ['hmpps-incentives', 'chart-feedback', `chart-${form.data.formId}`, `useful-${form.data.chartUseful}`]
   if (form.data.chartUseful === 'no') {
     tags.push(`not-useful-${form.data.mainNoReason}`)
   }


### PR DESCRIPTION
… so that it's easier to collate feedback per-chart in Zendesk