### PR TITLE
INC-437: Make form instances usable when data was not submitted

### DIFF
--- a/server/routes/analyticsRouter.test.ts
+++ b/server/routes/analyticsRouter.test.ts
@@ -293,6 +293,7 @@ describe.each(analyticsPages)(
             expect(res.text).toContain(`#${graphId}-mainNoReason`) // link to field
             expect(res.text).toContain('Select a reason for your answer') // error message
             expect(res.text).toContain(`id="${graphId}-mainNoReason"`) // field with error
+            expect(res.text).toContain('Do I have to choose only one reason?') // comment not forgotten
             expect(mockedZendeskClientClass).not.toHaveBeenCalled()
           })
       })

--- a/server/routes/forms/chartFeedbackForm.test.ts
+++ b/server/routes/forms/chartFeedbackForm.test.ts
@@ -1,61 +1,125 @@
 import ChartFeedbackForm, { type ChartFeedbackData } from './chartFeedbackForm'
 
 describe('ChartFeedbackForm', () => {
-  const correctData: Partial<ChartFeedbackData>[] = [
-    { chartUseful: 'yes' },
-    { chartUseful: 'yes', yesComments: 'Would be good to see a history too' },
-    { chartUseful: 'no', mainNoReason: 'does-not-show-enough' },
-    { chartUseful: 'no', mainNoReason: 'what-to-do-with-info', noComments: 'How can I act on this?' },
-  ]
-  describe.each(correctData)('validates correct forms', data => {
-    it(`with valid fields: ${Object.keys(data).join(' ')}`, () => {
-      const form = new ChartFeedbackForm(data)
-      expect(form.hasErrors).toBeFalsy()
-      expect(form.fieldErrors).toEqual({})
-      expect(form.errorSummary).toEqual([])
+  const formId = 'test-form-1'
+
+  const unsubmittedForm = () => new ChartFeedbackForm(formId)
+  const submittedForm = (data: Partial<ChartFeedbackData>) => {
+    const form = unsubmittedForm()
+    form.submit(data)
+    return form
+  }
+
+  describe('when not submitted', () => {
+    it('has no errors', () => {
+      const form = unsubmittedForm()
+      expect(form.formId).toEqual(formId)
+      expect(form.submitted).toEqual(false)
+      expect(form.hasErrors).toEqual(false)
+      expect(form.getField('chartUseful').error).toBeUndefined()
+      expect(form.getField('yesComments').error).toBeUndefined()
+      expect(form.getField('mainNoReason').error).toBeUndefined()
+      expect(form.getField('noComments').error).toBeUndefined()
+      expect(form.errorList).toEqual([])
+    })
+
+    it('has no field values', () => {
+      const form = unsubmittedForm()
+      expect(form.getField('chartUseful').value).toBeUndefined()
+      expect(form.getField('yesComments').value).toBeUndefined()
+      expect(form.getField('mainNoReason').value).toBeUndefined()
+      expect(form.getField('noComments').value).toBeUndefined()
     })
   })
 
-  const incorrectData: [unknown, (keyof ChartFeedbackData)[]][] = [
-    [{}, ['chartUseful']],
-    [{ chartUseful: '' }, ['chartUseful']],
-    [{ chartUseful: 'yep' }, ['chartUseful']],
-    [{ chartUseful: 'no' }, ['mainNoReason']],
-    [{ chartUseful: 'no', mainNoReason: '' }, ['mainNoReason']],
-    [{ chartUseful: 'no', mainNoReason: 'help' }, ['mainNoReason']],
-  ]
-  describe.each(incorrectData)('validates incorrect forms', (data, invalidFields) => {
-    it(`with invalid fields: ${invalidFields.join(' ')}`, () => {
-      const form = new ChartFeedbackForm(data)
-      expect(form.hasErrors).toBeTruthy()
-      expect(new Set(Object.keys(form.fieldErrors))).toEqual(new Set(invalidFields))
-      expect(form.errorSummary).toHaveLength(invalidFields.length)
+  describe('when submitted', () => {
+    it('throws without the right formId', () => {
+      expect(() => submittedForm({})).toThrow('Data not submitted by this form')
+      expect(() => submittedForm({ formId: 'incorrect' })).toThrow('Data not submitted by this form')
     })
-  })
 
-  const untrimmedData: [Partial<ChartFeedbackData>, string?, string?][] = [
-    [
-      { chartUseful: 'yes', yesComments: '\nWould be good to see a history too   ' },
-      'Would be good to see a history too',
-    ],
-    [
-      { chartUseful: 'no', mainNoReason: 'other', noComments: '  Who can help me with a query?  ' },
-      undefined,
-      'Who can help me with a query?',
-    ],
-  ]
-  describe.each(untrimmedData)('trims comment fields', (data, yesComments, noComments) => {
-    const form = new ChartFeedbackForm(data)
-    expect(form.hasErrors).toBeFalsy()
-    if (typeof yesComments !== 'undefined') {
-      expect(form.data.yesComments).toEqual(yesComments)
-    } else {
-      expect(form.data.yesComments).toBeUndefined()
-    }
-    if (typeof noComments !== 'undefined') {
-      expect(form.data.noComments).toEqual(noComments)
-    } else {
-      expect(form.data.noComments).toBeUndefined()
-    }
+    const correctData: Partial<ChartFeedbackData>[] = [
+      { chartUseful: 'yes' },
+      { chartUseful: 'yes', yesComments: 'Would be good to see a history too' },
+      { chartUseful: 'no', mainNoReason: 'does-not-show-enough' },
+      { chartUseful: 'no', mainNoReason: 'what-to-do-with-info', noComments: 'How can I act on this?' },
+    ]
+    describe.each(correctData)('with valid data', data => {
+      it(`has no errors when provided correct: ${Object.keys(data).join(' ')}`, () => {
+        const form = submittedForm({ formId, ...data })
+        expect(form.formId).toEqual(formId)
+        expect(form.submitted).toEqual(true)
+        expect(form.hasErrors).toEqual(false)
+        expect(form.getField('chartUseful').error).toBeUndefined()
+        expect(form.getField('yesComments').error).toBeUndefined()
+        expect(form.getField('mainNoReason').error).toBeUndefined()
+        expect(form.getField('noComments').error).toBeUndefined()
+        expect(form.errorList).toEqual([])
+      })
+
+      it(`remembers field values when provided correct: ${Object.keys(data).join(' ')}`, () => {
+        const form = submittedForm({ formId, ...data })
+        Object.keys(data).forEach((field: keyof ChartFeedbackData) => {
+          expect(form.getField(field).value).toEqual(data[field])
+        })
+      })
+    })
+
+    const incorrectData: [string, unknown, (keyof ChartFeedbackData)[]][] = [
+      ['chartUseful is missing', {}, ['chartUseful']],
+      ['chartUseful is empty', { chartUseful: '' }, ['chartUseful']],
+      ['chartUseful is not valid', { chartUseful: 'yep' }, ['chartUseful']],
+      ['mainNoReason is missing', { chartUseful: 'no' }, ['mainNoReason']],
+      ['mainNoReason is empty', { chartUseful: 'no', mainNoReason: '' }, ['mainNoReason']],
+      ['mainNoReason is invalid', { chartUseful: 'no', mainNoReason: 'help' }, ['mainNoReason']],
+    ]
+    describe.each(incorrectData)('with invalid data', (description, data, invalidFields) => {
+      // pretend that the input data had the correct type so typescript does not get in the way of form logic testing
+      const typedData = data as Partial<ChartFeedbackData>
+
+      it(`has errors when ${description}`, () => {
+        const form = new ChartFeedbackForm(formId)
+        form.submit({ formId, ...typedData })
+        expect(form.hasErrors).toEqual(true)
+        invalidFields.forEach(field => {
+          expect(form.getField(field).error).toBeTruthy()
+          expect(form.getField(field).error).toEqual(expect.any(String))
+        })
+        expect(form.errorList).toHaveLength(invalidFields.length)
+      })
+
+      if (typedData.chartUseful === 'no') {
+        it(`still remembers comments field when ${description}`, () => {
+          const form = new ChartFeedbackForm(formId)
+          form.submit({ formId, noComments: 'Who can I speak to?', ...typedData })
+          expect(form.getField('noComments').value).toEqual('Who can I speak to?')
+        })
+      }
+    })
+
+    const untrimmedData: [Partial<ChartFeedbackData>, string?, string?][] = [
+      [
+        { chartUseful: 'yes', yesComments: '\nWould be good to see a history too   ', noComments: '?' },
+        'Would be good to see a history too',
+      ],
+      [
+        { chartUseful: 'no', yesComments: '?', mainNoReason: 'other', noComments: '  Who can help me with a query?  ' },
+        'Who can help me with a query?',
+      ],
+    ]
+    describe.each(untrimmedData)('trims or deletes comment fields', (data, comments) => {
+      it(`if chart was useful: ${data.chartUseful}`, () => {
+        const form = new ChartFeedbackForm(formId)
+        form.submit({ formId, ...data })
+        expect(form.hasErrors).toBeFalsy()
+        if (data.chartUseful === 'yes') {
+          expect(form.getField('yesComments').value).toEqual(comments)
+          expect(form.getField('noComments').value).toBeUndefined()
+        } else {
+          expect(form.getField('yesComments').value).toBeUndefined()
+          expect(form.getField('noComments').value).toEqual(comments)
+        }
+      })
+    })
   })
 })

--- a/server/routes/forms/chartFeedbackForm.ts
+++ b/server/routes/forms/chartFeedbackForm.ts
@@ -1,21 +1,16 @@
-import Form from './forms'
+import Form, { type BaseFormData } from './forms'
 
-export interface ChartFeedbackData {
-  // form
+export interface ChartFeedbackData extends BaseFormData {
   chartUseful: 'yes' | 'no'
   yesComments: string
   mainNoReason: 'not-relevant' | 'do-not-understand' | 'does-not-show-enough' | 'what-to-do-with-info' | 'other'
   noComments: string
-  // context
-  formId: string
 }
 
 export default class ChartFeedbackForm extends Form<ChartFeedbackData> {
   protected validate(): void {
     const { chartUseful, mainNoReason } = this.data
-    if (!['yes', 'no'].includes(chartUseful)) {
-      this.fieldErrors.chartUseful = 'Tell us if you found the chart useful'
-    } else if (chartUseful === 'yes') {
+    if (chartUseful === 'yes') {
       this.data.yesComments = (this.data.yesComments ?? '').trim()
       delete this.data.noComments
       delete this.data.mainNoReason
@@ -27,8 +22,12 @@ export default class ChartFeedbackForm extends Form<ChartFeedbackData> {
           mainNoReason
         )
       ) {
-        this.fieldErrors.mainNoReason = 'Select a reason for your answer'
+        this.addError('mainNoReason', 'Select a reason for your answer')
+        delete this.data.mainNoReason
       }
+    } else {
+      this.addError('chartUseful', 'Tell us if you found the chart useful')
+      delete this.data.chartUseful
     }
   }
 }

--- a/server/views/pages/analytics/behaviour-entries/entries-by-location.njk
+++ b/server/views/pages/analytics/behaviour-entries/entries-by-location.njk
@@ -23,7 +23,6 @@
       }
     }) }}
 
-    {% set form = formsWithErrors[graphId] | default({}) %}
     {% set chartFeedback %}
       {% include "../../../partials/analytics/chartFeedbackForm.njk" %}
     {% endset %}
@@ -32,7 +31,7 @@
       html: chartFeedback,
       id: "chart-feedback-" + graphId,
       classes: "govuk-!-display-none-print",
-      open: form.hasErrors,
+      open: chartFeedbackForm.hasErrors,
       attributes: {
         "data-qa": "chart-feedback",
         "data-ga-category": "Is this chart useful > Behaviour entries by wing",

--- a/server/views/pages/analytics/behaviour-entries/index.njk
+++ b/server/views/pages/analytics/behaviour-entries/index.njk
@@ -1,5 +1,4 @@
 {% extends "../graph-layout.njk" %}
-{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 
 {% set graphPageId = "behaviour-entries" %}
 {% set graphTitle = "Behaviour entries in the last 28 days" %}
@@ -13,13 +12,7 @@
 
       {% include "../../../partials/messages.njk" %}
 
-      {% set errorSummary = formsWithErrors["entries-by-location"].errorSummary | default(formsWithErrors["prisoners-with-entries-by-location"].errorSummary) %}
-      {% if errorSummary.length %}
-        {{ govukErrorSummary({
-          titleText: "There is a problem",
-          errorList: errorSummary
-        }) }}
-      {% endif %}
+      {% include "../../../partials/formErrorSummary.njk" %}
 
       <h1 class="govuk-heading-xl">
         {{ graphTitle }}
@@ -32,6 +25,7 @@
     <section class="govuk-grid-column-one-half govuk-!-margin-bottom-9">
 
       {% set graphId = "entries-by-location" %}
+      {% set chartFeedbackForm = forms[graphId] %}
       {% set report = behaviourEntries %}
       {% include "./entries-by-location.njk" %}
 
@@ -39,6 +33,7 @@
     <section class="govuk-grid-column-one-half govuk-!-margin-bottom-9">
 
       {% set graphId = "prisoners-with-entries-by-location" %}
+      {% set chartFeedbackForm = forms[graphId] %}
       {% set report = prisonersWithEntries %}
       {% include "./prisoners-with-entries-by-location.njk" %}
 

--- a/server/views/pages/analytics/behaviour-entries/prisoners-with-entries-by-location.njk
+++ b/server/views/pages/analytics/behaviour-entries/prisoners-with-entries-by-location.njk
@@ -23,7 +23,6 @@
       }
     }) }}
 
-    {% set form = formsWithErrors[graphId] | default({}) %}
     {% set chartFeedback %}
       {% include "../../../partials/analytics/chartFeedbackForm.njk" %}
     {% endset %}
@@ -32,7 +31,7 @@
       html: chartFeedback,
       id: "chart-feedback-" + graphId,
       classes: "govuk-!-display-none-print",
-      open: form.hasErrors,
+      open: chartFeedbackForm.hasErrors,
       attributes: {
         "data-qa": "chart-feedback",
         "data-ga-category": "Is this chart useful > Prisoners with behaviour entries by wing",

--- a/server/views/pages/analytics/incentive-levels/index.njk
+++ b/server/views/pages/analytics/incentive-levels/index.njk
@@ -1,5 +1,4 @@
 {% extends "../graph-layout.njk" %}
-{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 
 {% set graphPageId = "incentive-levels" %}
 {% set graphTitle = "Incentive levels" %}
@@ -13,13 +12,7 @@
 
       {% include "../../../partials/messages.njk" %}
 
-      {% set errorSummary = formsWithErrors["incentive-levels-by-location"].errorSummary %}
-      {% if errorSummary %}
-        {{ govukErrorSummary({
-          titleText: "There is a problem",
-          errorList: errorSummary
-        }) }}
-      {% endif %}
+      {% include "../../../partials/formErrorSummary.njk" %}
 
       <h1 class="govuk-heading-xl">
         {{ graphTitle }}
@@ -32,6 +25,7 @@
     <section class="govuk-grid-column-two-thirds govuk-!-margin-bottom-9">
 
       {% set graphId = "incentive-levels-by-location" %}
+      {% set chartFeedbackForm = forms[graphId] %}
       {% set report = prisonersOnLevels %}
       {% include "./prisoners-by-location.njk" %}
 

--- a/server/views/pages/analytics/incentive-levels/prisoners-by-location.njk
+++ b/server/views/pages/analytics/incentive-levels/prisoners-by-location.njk
@@ -24,7 +24,6 @@
       }
     }) }}
 
-    {% set form = formsWithErrors[graphId] | default({}) %}
     {% set chartFeedback %}
       {% include "../../../partials/analytics/chartFeedbackForm.njk" %}
     {% endset %}
@@ -33,7 +32,7 @@
       html: chartFeedback,
       id: "chart-feedback-" + graphId,
       classes: "govuk-!-display-none-print",
-      open: form.hasErrors,
+      open: chartFeedbackForm.hasErrors,
       attributes: {
         "data-qa": "chart-feedback",
         "data-ga-category": "Is this chart useful > Incentive level by wing",

--- a/server/views/pages/analytics/protected-characteristics/index.njk
+++ b/server/views/pages/analytics/protected-characteristics/index.njk
@@ -1,5 +1,4 @@
 {% extends "../graph-layout.njk" %}
-{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 
 {% set graphPageId = "protected-characteristics" %}
 {% set graphTitle = "Protected characteristics" %}
@@ -13,13 +12,7 @@
 
       {% include "../../../partials/messages.njk" %}
 
-      {% set errorSummary = formsWithErrors["incentive-levels-by-ethnicity"].errorSummary | default(formsWithErrors["incentive-levels-by-age"].errorSummary) | default(formsWithErrors["incentive-levels-by-religion"].errorSummary) | default(formsWithErrors["incentive-levels-by-disability"].errorSummary) %}
-      {% if errorSummary %}
-        {{ govukErrorSummary({
-          titleText: "There is a problem",
-          errorList: errorSummary
-        }) }}
-      {% endif %}
+      {% include "../../../partials/formErrorSummary.njk" %}
 
       <h1 class="govuk-heading-xl">
         {{ graphTitle }}
@@ -32,6 +25,7 @@
     <section class="govuk-grid-column-two-thirds govuk-!-margin-bottom-9">
 
       {% set graphId = "incentive-levels-by-ethnicity" %}
+      {% set chartFeedbackForm = forms[graphId] %}
       {% set report = prisonersByEthnicity %}
       {% include "./prisoners-by-ethnicity.njk" %}
 
@@ -42,6 +36,7 @@
     <section class="govuk-grid-column-two-thirds govuk-!-margin-bottom-9">
 
       {% set graphId = "incentive-levels-by-age" %}
+      {% set chartFeedbackForm = forms[graphId] %}
       {% set report = prisonersByAge %}
       {% include "./prisoners-by-age.njk" %}
 
@@ -52,6 +47,7 @@
     <section class="govuk-grid-column-two-thirds govuk-!-margin-bottom-9">
 
       {% set graphId = "incentive-levels-by-religion" %}
+      {% set chartFeedbackForm = forms[graphId] %}
       {% set report = prisonersByReligion %}
       {% include "./prisoners-by-religion.njk" %}
 
@@ -62,6 +58,7 @@
     <section class="govuk-grid-column-two-thirds govuk-!-margin-bottom-9">
 
       {% set graphId = "incentive-levels-by-disability" %}
+      {% set chartFeedbackForm = forms[graphId] %}
       {% set report = prisonersByDisability %}
       {% include "./prisoners-by-disability.njk" %}
 

--- a/server/views/pages/analytics/protected-characteristics/prisoners-by-age.njk
+++ b/server/views/pages/analytics/protected-characteristics/prisoners-by-age.njk
@@ -24,7 +24,6 @@
       }
     }) }}
 
-    {% set form = formsWithErrors[graphId] | default({}) %}
     {% set chartFeedback %}
       {% include "../../../partials/analytics/chartFeedbackForm.njk" %}
     {% endset %}
@@ -33,7 +32,7 @@
       html: chartFeedback,
       id: "chart-feedback-" + graphId,
       classes: "govuk-!-display-none-print",
-      open: form.hasErrors,
+      open: chartFeedbackForm.hasErrors,
       attributes: {
         "data-qa": "chart-feedback",
         "data-ga-category": "Is this chart useful > Incentive level by age",

--- a/server/views/pages/analytics/protected-characteristics/prisoners-by-disability.njk
+++ b/server/views/pages/analytics/protected-characteristics/prisoners-by-disability.njk
@@ -24,7 +24,6 @@
       }
     }) }}
 
-    {% set form = formsWithErrors[graphId] | default({}) %}
     {% set chartFeedback %}
       {% include "../../../partials/analytics/chartFeedbackForm.njk" %}
     {% endset %}
@@ -33,7 +32,7 @@
       html: chartFeedback,
       id: "chart-feedback-" + graphId,
       classes: "govuk-!-display-none-print",
-      open: form.hasErrors,
+      open: chartFeedbackForm.hasErrors,
       attributes: {
         "data-qa": "chart-feedback",
         "data-ga-category": "Is this chart useful > Incentive level by disability",

--- a/server/views/pages/analytics/protected-characteristics/prisoners-by-ethnicity.njk
+++ b/server/views/pages/analytics/protected-characteristics/prisoners-by-ethnicity.njk
@@ -24,7 +24,6 @@
       }
     }) }}
 
-    {% set form = formsWithErrors[graphId] | default({}) %}
     {% set chartFeedback %}
       {% include "../../../partials/analytics/chartFeedbackForm.njk" %}
     {% endset %}
@@ -33,7 +32,7 @@
       html: chartFeedback,
       id: "chart-feedback-" + graphId,
       classes: "govuk-!-display-none-print",
-      open: form.hasErrors,
+      open: chartFeedbackForm.hasErrors,
       attributes: {
         "data-qa": "chart-feedback",
         "data-ga-category": "Is this chart useful > Incentive level by ethnicity",

--- a/server/views/pages/analytics/protected-characteristics/prisoners-by-religion.njk
+++ b/server/views/pages/analytics/protected-characteristics/prisoners-by-religion.njk
@@ -24,7 +24,6 @@
       }
     }) }}
 
-    {% set form = formsWithErrors[graphId] | default({}) %}
     {% set chartFeedback %}
       {% include "../../../partials/analytics/chartFeedbackForm.njk" %}
     {% endset %}
@@ -33,7 +32,7 @@
       html: chartFeedback,
       id: "chart-feedback-" + graphId,
       classes: "govuk-!-display-none-print",
-      open: form.hasErrors,
+      open: chartFeedbackForm.hasErrors,
       attributes: {
         "data-qa": "chart-feedback",
         "data-ga-category": "Is this chart useful > Incentive level by religion",

--- a/server/views/partials/analytics/chartFeedbackForm.njk
+++ b/server/views/partials/analytics/chartFeedbackForm.njk
@@ -2,14 +2,13 @@
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 {% from "govuk/components/textarea/macro.njk" import govukTextarea %}
 
-{# Required variables: graphId, csrfToken #}
-{# Optional variables: form (if there are errors) #}
+{# Required variables: chartFeedbackForm, csrfToken #}
 
-{% macro commentTextarea(graphId, id) %}
+{% macro commentTextarea(chartFeedbackForm, id) %}
   {{ govukTextarea({
-    id: graphId + "-" + id + "Comments",
+    id: chartFeedbackForm.formId + "-" + id + "Comments",
     name: id + "Comments",
-    value: form.data[id + "Comments"] | default(""),
+    value: chartFeedbackForm.getField(id + "Comments").value,
     label: {
       text: "Comments (optional)"
     },
@@ -18,12 +17,13 @@
 {% endmacro %}
 
 {% set chartUsefulHtml %}
-  {{ commentTextarea(graphId, "yes") }}
+  {{ commentTextarea(chartFeedbackForm, "yes") }}
 {% endset %}
 
 {% set chartNotUsefulHtml %}
+  {% set mainNoReasonField = chartFeedbackForm.getField("mainNoReason") %}
   {{ govukRadios({
-    idPrefix: graphId + "-mainNoReason",
+    idPrefix: chartFeedbackForm.formId + "-mainNoReason",
     name: "mainNoReason",
     classes: "govuk-radios--small",
     fieldset: {
@@ -36,37 +36,39 @@
       {
         value: "not-relevant",
         text: "It’s not relevant to me",
-        checked: form.data.mainReason === "not-relevant"
+        checked: mainNoReasonField.value === "not-relevant"
       },
       {
         value: "do-not-understand",
         text: "I don’t understand it",
-        checked: form.data.mainReason === "do-not-understand"
+        checked: mainNoReasonField.value === "do-not-understand"
       },
       {
         value: "does-not-show-enough",
         text: "It doesn’t show me enough",
-        checked: form.data.mainReason === "does-not-show-enough"
+        checked: mainNoReasonField.value === "does-not-show-enough"
       },
       {
         value: "what-to-do-with-info",
         text: "I don’t know what to do with the information",
-        checked: form.data.mainReason === "what-to-do-with-info"
+        checked: mainNoReasonField.value === "what-to-do-with-info"
       },
       {
         value: "other",
         text: "Other",
-        checked: form.data.mainReason === "other"
+        checked: mainNoReasonField.value === "other"
       }
     ],
-    errorMessage: { text: form.fieldErrors.mainNoReason } if form.fieldErrors.mainNoReason else undefined
+    errorMessage: { text: mainNoReasonField.error } if mainNoReasonField.error else undefined
   }) }}
-  {{ commentTextarea(graphId, "no") }}
+
+  {{ commentTextarea(chartFeedbackForm, "no") }}
 {% endset %}
 
-<form id="form-{{ graphId }}" method="post" novalidate>
+<form id="form-{{ chartFeedbackForm.formId }}" method="post" novalidate>
+  {% set chartUsefulField = chartFeedbackForm.getField("chartUseful") %}
   {{ govukRadios({
-    idPrefix: graphId + "-chartUseful",
+    idPrefix: chartFeedbackForm.formId + "-chartUseful",
     name: "chartUseful",
     fieldset: {
       legend: {
@@ -78,7 +80,7 @@
       {
         value: "yes",
         text: "Yes",
-        checked: form.data.chartUseful === "yes",
+        checked: chartUsefulField.value === "yes",
         conditional: {
           html: chartUsefulHtml
         }
@@ -86,16 +88,16 @@
       {
         value: "no",
         text: "No",
-        checked: form.data.chartUseful === "no",
+        checked: chartUsefulField.value === "no",
         conditional: {
           html: chartNotUsefulHtml
         }
       }
     ],
-    errorMessage: { text: form.fieldErrors.chartUseful } if form.fieldErrors.chartUseful else undefined
+    errorMessage: { text: chartUsefulField.error } if chartUsefulField.error else undefined
   }) }}
 
-  <input type="hidden" name="formId" value="{{ graphId }}" />
+  <input type="hidden" name="formId" value="{{ chartFeedbackForm.formId }}" />
   <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
 
   {{ govukButton({

--- a/server/views/partials/formErrorSummary.njk
+++ b/server/views/partials/formErrorSummary.njk
@@ -1,0 +1,12 @@
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+
+{% set errorList = [] %}
+{% for formId, form in forms %}
+  {% set errorList = errorList.concat(form.errorList) %}
+{% endfor %}
+{% if errorList.length %}
+  {{ govukErrorSummary({
+    titleText: "There is a problem",
+    errorList: errorList
+  }) }}
+{% endif %}


### PR DESCRIPTION
…so that templates can always rely on their existence and their methods. Previously, the only situation when a form variable was passed into the page template was when the form was submitted but did not pass validation. This made templates unintuitive (most of the time the form variable did not exist).

This paves the way to allow forms to preset initial values before a form submission.