### PR TITLE
INC-391: Present in-context error messages when graph data is unavailable

### DIFF
--- a/server/routes/analyticsRouter.test.ts
+++ b/server/routes/analyticsRouter.test.ts
@@ -160,7 +160,7 @@ describe.each(analyticsPages)(
         .expect(200)
         .expect(res => {
           expect(res.text).toContain(expectedHeading)
-          expect(res.text).toContain('There is no data available')
+          expect(res.text).toContain('There is a problem with this data – try again later')
         })
     })
 
@@ -172,7 +172,7 @@ describe.each(analyticsPages)(
         .expect(200)
         .expect(res => {
           expect(res.text).toContain(expectedHeading)
-          expect(res.text).toContain('There is no data available')
+          expect(res.text).toContain('There is a problem with this data – try again later')
         })
     })
 

--- a/server/routes/analyticsRouter.test.ts
+++ b/server/routes/analyticsRouter.test.ts
@@ -157,9 +157,10 @@ describe.each(analyticsPages)(
 
       return request(app)
         .get(url)
-        .expect(500)
+        .expect(200)
         .expect(res => {
-          expect(res.text).toContain('Sorry, there is a problem with the service')
+          expect(res.text).toContain(expectedHeading)
+          expect(res.text).toContain('There is no data available')
         })
     })
 
@@ -168,9 +169,10 @@ describe.each(analyticsPages)(
 
       return request(app)
         .get(url)
-        .expect(500)
+        .expect(200)
         .expect(res => {
-          expect(res.text).toContain('Sorry, there is a problem with the service')
+          expect(res.text).toContain(expectedHeading)
+          expect(res.text).toContain('There is no data available')
         })
     })
 

--- a/server/services/analyticsServiceTypes.ts
+++ b/server/services/analyticsServiceTypes.ts
@@ -44,6 +44,7 @@ export type Report<Row extends Record<string, unknown>> = {
   rows: Row[]
   lastUpdated: Date
   dataSource: string
+  hasErrors?: boolean
 }
 
 /**

--- a/server/views/pages/analytics/behaviour-entries/entries-by-location.njk
+++ b/server/views/pages/analytics/behaviour-entries/entries-by-location.njk
@@ -5,6 +5,8 @@
   Behaviour entries – comparison of positive and negative behaviour entries by wing
 </h2>
 
+{% if not report.hasErrors %}
+
 {{ dataSource(report.dataSource, report.lastUpdated, {"classes": "govuk-!-margin-bottom-6"}) }}
 
 <div class="govuk-grid-row">
@@ -127,3 +129,9 @@
     </tr>
   </tfoot>
 </table>
+
+{% else %}
+
+  {% include "../no-data-partial.njk" %}
+
+{% endif %}

--- a/server/views/pages/analytics/behaviour-entries/prisoners-with-entries-by-location.njk
+++ b/server/views/pages/analytics/behaviour-entries/prisoners-with-entries-by-location.njk
@@ -5,6 +5,8 @@
   Prisoners – percentage and number of prisoners by behaviour entry on each wing
 </h2>
 
+{% if not report.hasErrors %}
+
 {{ dataSource(report.dataSource, report.lastUpdated, {"classes": "govuk-!-margin-bottom-6"}) }}
 
 <div class="govuk-grid-row">
@@ -141,3 +143,9 @@
     {% endfor %}
   </tbody>
 </table>
+
+{% else %}
+
+  {% include "../no-data-partial.njk" %}
+
+{% endif %}

--- a/server/views/pages/analytics/incentive-levels/prisoners-by-location.njk
+++ b/server/views/pages/analytics/incentive-levels/prisoners-by-location.njk
@@ -5,6 +5,8 @@
   Percentage and number of prisoners on each incentive level by wing
 </h2>
 
+{% if not report.hasErrors %}
+
 {{ dataSource(report.dataSource, report.lastUpdated, {"classes": "govuk-!-margin-bottom-6"}) }}
 
 <div class="govuk-grid-row">
@@ -130,3 +132,9 @@
     </tr>
   </tfoot>
 </table>
+
+{% else %}
+
+  {% include "../no-data-partial.njk" %}
+
+{% endif %}

--- a/server/views/pages/analytics/no-data-partial.njk
+++ b/server/views/pages/analytics/no-data-partial.njk
@@ -1,6 +1,10 @@
-{% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
+{%- from "moj/components/banner/macro.njk" import mojBanner -%}
 
-{{ govukWarningText({
-  text: "There is no data available.",
-  iconFallbackText: "Warning"
-}) }}
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-three-quarters">
+    {{ mojBanner({
+        type: 'information',
+        text: 'There is a problem with this data – try again later'
+    }) }}
+  </div>
+</div>

--- a/server/views/pages/analytics/no-data-partial.njk
+++ b/server/views/pages/analytics/no-data-partial.njk
@@ -1,0 +1,6 @@
+{% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
+
+{{ govukWarningText({
+  text: "There is no data available.",
+  iconFallbackText: "Warning"
+}) }}

--- a/server/views/pages/analytics/protected-characteristics/prisoners-by-age-group.njk
+++ b/server/views/pages/analytics/protected-characteristics/prisoners-by-age-group.njk
@@ -5,6 +5,8 @@
   Percentage and number of prisoners on each incentive level by age group
 </h2>
 
+{% if not report.hasErrors %}
+
 {{ dataSource(report.dataSource, report.lastUpdated, {"classes": "govuk-!-margin-bottom-6"}) }}
 
 <div class="govuk-grid-row">
@@ -126,3 +128,9 @@
     </tr>
   </tfoot>
 </table>
+
+{% else %}
+
+  {% include "../no-data-partial.njk" %}
+
+{% endif %}

--- a/server/views/pages/analytics/protected-characteristics/prisoners-by-ethnicity.njk
+++ b/server/views/pages/analytics/protected-characteristics/prisoners-by-ethnicity.njk
@@ -5,6 +5,8 @@
   Percentage and number of prisoners on each incentive level by ethnicity
 </h2>
 
+{% if not report.hasErrors %}
+
 {{ dataSource(report.dataSource, report.lastUpdated, {"classes": "govuk-!-margin-bottom-6"}) }}
 
 <div class="govuk-grid-row">
@@ -126,3 +128,9 @@
     </tr>
   </tfoot>
 </table>
+
+{% else %}
+
+  {% include "../no-data-partial.njk" %}
+
+{% endif %}


### PR DESCRIPTION
Minor enhancement: If source data tables for analytics charts
• cannot be found
• cannot be downloaded
• cannot be parsed
• results in an empty table
…then a message is presented to the user in place of the missing chart, rather than the generic 500 page.