### PR TITLE
Updated analytics tile copy

### DIFF
--- a/server/views/pages/home.njk
+++ b/server/views/pages/home.njk
@@ -33,7 +33,7 @@
         {{ card({
           "href": "/analytics/incentive-levels",
           "clickable": "true",
-          "heading": "Incentives levels and behaviour entry data",
+          "heading": "Incentives level and behaviour entry data",
           "description": "See incentive level and behaviour entry data visualisations.",
           "id": "incentive-analytics"
         }) }}


### PR DESCRIPTION
Tile heading should say 'Incentives level and behaviour entry data'
(level, not levels)