### PR TITLE
INC-463: Copy change to 'analytics' tile heading

### DIFF
--- a/server/views/pages/home.njk
+++ b/server/views/pages/home.njk
@@ -33,7 +33,7 @@
         {{ card({
           "href": "/analytics/incentive-levels",
           "clickable": "true",
-          "heading": "Incentives level and behaviour entry data",
+          "heading": "Incentive level and behaviour entry data",
           "description": "See incentive level and behaviour entry data visualisations.",
           "id": "incentive-analytics"
         }) }}


### PR DESCRIPTION
Linsey pointed out the 's' in the word 'Incentives' also needs to go:

> It should say:
> Incentive level and behaviour entry data.