### PR TITLE
INC-352: Rename "age group" protected characteristic to simply "age"

### DIFF
--- a/integration_tests/integration/analytics.spec.ts
+++ b/integration_tests/integration/analytics.spec.ts
@@ -191,7 +191,7 @@ context('Analytics section', () => {
         expect(location).to.contain('920')
       })
 
-      page.incentivesByAgeGroup.first().then(totalsRow => {
+      page.incentivesByAge.first().then(totalsRow => {
         const location = totalsRow.find('td:first-child').text()
         expect(location).to.contain('All')
         expect(location).to.contain('921')
@@ -227,16 +227,12 @@ context('Analytics section', () => {
           gaSpy.shouldHaveSentEvent('How you can use this chart > Incentive level by ethnicity', 'closed', 'MDI')
         )
 
-      page.incentivesByAgeGroupGuidance
+      page.incentivesByAgeGuidance
         .click()
-        .then(() =>
-          gaSpy.shouldHaveSentEvent('How you can use this chart > Incentive level by age group', 'opened', 'MDI')
-        )
-      page.incentivesByAgeGroupGuidance
+        .then(() => gaSpy.shouldHaveSentEvent('How you can use this chart > Incentive level by age', 'opened', 'MDI'))
+      page.incentivesByAgeGuidance
         .click()
-        .then(() =>
-          gaSpy.shouldHaveSentEvent('How you can use this chart > Incentive level by age group', 'closed', 'MDI')
-        )
+        .then(() => gaSpy.shouldHaveSentEvent('How you can use this chart > Incentive level by age', 'closed', 'MDI'))
 
       page.incentivesByReligionGuidance
         .click()
@@ -274,12 +270,12 @@ context('Analytics section', () => {
         .click()
         .then(() => gaSpy.shouldHaveSentEvent('Is this chart useful > Incentive level by ethnicity', 'closed', 'MDI'))
 
-      page.incentivesByAgeGroupFeedback
+      page.incentivesByAgeFeedback
         .click()
-        .then(() => gaSpy.shouldHaveSentEvent('Is this chart useful > Incentive level by age group', 'opened', 'MDI'))
-      page.incentivesByAgeGroupFeedback
+        .then(() => gaSpy.shouldHaveSentEvent('Is this chart useful > Incentive level by age', 'opened', 'MDI'))
+      page.incentivesByAgeFeedback
         .click()
-        .then(() => gaSpy.shouldHaveSentEvent('Is this chart useful > Incentive level by age group', 'closed', 'MDI'))
+        .then(() => gaSpy.shouldHaveSentEvent('Is this chart useful > Incentive level by age', 'closed', 'MDI'))
 
       page.incentivesByReligionFeedback
         .click()
@@ -299,7 +295,7 @@ context('Analytics section', () => {
     it('users can submit feedback on charts', () => {
       testValidFeedbackSubmission(AnalyticsProtectedCharacteristics, [
         ['incentivesByEthnicityFeedback', 'incentivesByEthnicityFeedbackForm'],
-        ['incentivesByAgeGroupFeedback', 'incentivesByAgeGroupFeedbackForm'],
+        ['incentivesByAgeFeedback', 'incentivesByAgeFeedbackForm'],
         ['incentivesByReligionFeedback', 'incentivesByReligionFeedbackForm'],
         ['incentivesByDisabilityFeedback', 'incentivesByDisabilityFeedbackForm'],
       ])
@@ -308,7 +304,7 @@ context('Analytics section', () => {
     it('users will see errors if they submit invalid feedback on chart', () => {
       testInvalidFeedbackSubmission(AnalyticsProtectedCharacteristics, [
         ['incentivesByEthnicityFeedback', 'incentivesByEthnicityFeedbackForm'],
-        ['incentivesByAgeGroupFeedback', 'incentivesByAgeGroupFeedbackForm'],
+        ['incentivesByAgeFeedback', 'incentivesByAgeFeedbackForm'],
         ['incentivesByReligionFeedback', 'incentivesByReligionFeedbackForm'],
         ['incentivesByDisabilityFeedback', 'incentivesByDisabilityFeedbackForm'],
       ])

--- a/integration_tests/pages/analyticsProtectedCharacteristics.ts
+++ b/integration_tests/pages/analyticsProtectedCharacteristics.ts
@@ -10,8 +10,8 @@ export default class AnalyticsProtectedCharacteristics extends AnalyticsPage {
     return cy.get('#table-incentive-levels-by-ethnicity tbody tr')
   }
 
-  get incentivesByAgeGroup(): PageElement<HTMLTableRowElement> {
-    return cy.get('#table-incentive-levels-by-age-group tbody tr')
+  get incentivesByAge(): PageElement<HTMLTableRowElement> {
+    return cy.get('#table-incentive-levels-by-age tbody tr')
   }
 
   get incentivesByReligion(): PageElement<HTMLTableRowElement> {
@@ -26,8 +26,8 @@ export default class AnalyticsProtectedCharacteristics extends AnalyticsPage {
     return this.chartGuidanceBoxes.filter('#guidance-incentive-levels-by-ethnicity').find('.govuk-details__summary')
   }
 
-  get incentivesByAgeGroupGuidance(): PageElement<HTMLDetailsElement> {
-    return this.chartGuidanceBoxes.filter('#guidance-incentive-levels-by-age-group').find('.govuk-details__summary')
+  get incentivesByAgeGuidance(): PageElement<HTMLDetailsElement> {
+    return this.chartGuidanceBoxes.filter('#guidance-incentive-levels-by-age').find('.govuk-details__summary')
   }
 
   get incentivesByReligionGuidance(): PageElement<HTMLDetailsElement> {
@@ -44,10 +44,8 @@ export default class AnalyticsProtectedCharacteristics extends AnalyticsPage {
       .find('.govuk-details__summary')
   }
 
-  get incentivesByAgeGroupFeedback(): PageElement<HTMLDetailsElement> {
-    return this.chartFeedbackBoxes
-      .filter('#chart-feedback-incentive-levels-by-age-group')
-      .find('.govuk-details__summary')
+  get incentivesByAgeFeedback(): PageElement<HTMLDetailsElement> {
+    return this.chartFeedbackBoxes.filter('#chart-feedback-incentive-levels-by-age').find('.govuk-details__summary')
   }
 
   get incentivesByReligionFeedback(): PageElement<HTMLDetailsElement> {
@@ -66,8 +64,8 @@ export default class AnalyticsProtectedCharacteristics extends AnalyticsPage {
     return cy.get('#form-incentive-levels-by-ethnicity')
   }
 
-  get incentivesByAgeGroupFeedbackForm(): PageElement<HTMLFormElement> {
-    return cy.get('#form-incentive-levels-by-age-group')
+  get incentivesByAgeFeedbackForm(): PageElement<HTMLFormElement> {
+    return cy.get('#form-incentive-levels-by-age')
   }
 
   get incentivesByReligionFeedbackForm(): PageElement<HTMLFormElement> {

--- a/server/routes/analyticsRouter.test.ts
+++ b/server/routes/analyticsRouter.test.ts
@@ -120,7 +120,7 @@ const analyticsPages = [
     sourceTable: TableType.incentiveLevels,
     graphIds: [
       'incentive-levels-by-ethnicity',
-      'incentive-levels-by-age-group',
+      'incentive-levels-by-age',
       'incentive-levels-by-religion',
       'incentive-levels-by-disability',
     ],

--- a/server/routes/analyticsRouter.ts
+++ b/server/routes/analyticsRouter.ts
@@ -138,18 +138,16 @@ export default function routes(router: Router): Router {
 
     const charts = [
       analyticsService.getIncentiveLevelsByProtectedCharacteristic(activeCaseLoad, ProtectedCharacteristic.Ethnicity),
-      analyticsService.getIncentiveLevelsByProtectedCharacteristic(activeCaseLoad, ProtectedCharacteristic.AgeGroup),
+      analyticsService.getIncentiveLevelsByProtectedCharacteristic(activeCaseLoad, ProtectedCharacteristic.Age),
       analyticsService.getIncentiveLevelsByProtectedCharacteristic(activeCaseLoad, ProtectedCharacteristic.Religion),
       analyticsService.getIncentiveLevelsByProtectedCharacteristic(activeCaseLoad, ProtectedCharacteristic.Disability),
     ].map(transformAnalyticsError)
-    const [prisonersByEthnicity, prisonersByAgeGroup, prisonersByReligion, prisonersByDisability] = await Promise.all(
-      charts
-    )
+    const [prisonersByEthnicity, prisonersByAge, prisonersByReligion, prisonersByDisability] = await Promise.all(charts)
 
     res.render('pages/analytics/protected-characteristics/index', {
       ...templateContext(req),
       prisonersByEthnicity,
-      prisonersByAgeGroup,
+      prisonersByAge,
       prisonersByReligion,
       prisonersByDisability,
     })

--- a/server/services/analyticsService.test.ts
+++ b/server/services/analyticsService.test.ts
@@ -5,7 +5,7 @@ import {
   TableType,
   ProtectedCharacteristic,
   Ethnicities,
-  AgeGroups,
+  Ages,
   Religions,
   Disabilities,
 } from './analyticsServiceTypes'
@@ -324,7 +324,7 @@ describe('AnalyticsService', () => {
 
   describe.each([
     [ProtectedCharacteristic.Ethnicity, ['All', ...Ethnicities]],
-    [ProtectedCharacteristic.AgeGroup, ['All', ...AgeGroups]],
+    [ProtectedCharacteristic.Age, ['All', ...Ages]],
     [ProtectedCharacteristic.Religion, ['All', ...Religions]],
     [ProtectedCharacteristic.Disability, ['All', ...Disabilities]],
   ])('getIncentiveLevelsByProtectedCharacteristic()', (characteristic, expectedCharacteristics) => {
@@ -367,7 +367,7 @@ describe('AnalyticsService', () => {
       expect(characteristics).toEqual(expectedCharacteristics)
     })
 
-    if (characteristic === ProtectedCharacteristic.AgeGroup) {
+    if (characteristic === ProtectedCharacteristic.Age) {
       it(`[${characteristic}]: adds missing group with all zeros`, async () => {
         const { rows } = await analyticsService.getIncentiveLevelsByProtectedCharacteristic('MDI', characteristic)
         const zeroRows = rows.filter(({ characteristic: someCharacteristic }) => someCharacteristic === '15-17')

--- a/server/services/analyticsService.test.ts
+++ b/server/services/analyticsService.test.ts
@@ -162,6 +162,7 @@ describe('AnalyticsService', () => {
       { a: { characteristic: 'White' }, b: { characteristic: 'All' }, expected: 1 },
       { a: { characteristic: 'Asian or Asian British' }, b: { characteristic: 'Other' }, expected: -1 },
       { a: { characteristic: 'Asian or Asian British' }, b: { characteristic: 'Unknown' }, expected: -1 },
+      { a: { characteristic: 'Yes' }, b: { characteristic: 'Unknown' }, expected: -1 },
     ])('compareCharacteristics()', ({ a, b, expected }) => {
       let compares = '='
       if (expected > 0) {

--- a/server/services/analyticsService.test.ts
+++ b/server/services/analyticsService.test.ts
@@ -159,10 +159,13 @@ describe('AnalyticsService', () => {
       { a: { characteristic: 'All' }, b: { characteristic: 'Asian or Asian British' }, expected: -1 },
       { a: { characteristic: 'Black or Black British' }, b: { characteristic: 'Mixed' }, expected: -1 },
       { a: { characteristic: 'Unknown' }, b: { characteristic: 'All' }, expected: 1 },
+      { a: { characteristic: 'Other' }, b: { characteristic: 'All' }, expected: 1 },
       { a: { characteristic: 'White' }, b: { characteristic: 'All' }, expected: 1 },
       { a: { characteristic: 'Asian or Asian British' }, b: { characteristic: 'Other' }, expected: -1 },
       { a: { characteristic: 'Asian or Asian British' }, b: { characteristic: 'Unknown' }, expected: -1 },
       { a: { characteristic: 'Yes' }, b: { characteristic: 'Unknown' }, expected: -1 },
+      { a: { characteristic: 'Other' }, b: { characteristic: 'Yes' }, expected: 1 },
+      { a: { characteristic: 'Unknown' }, b: { characteristic: 'Other' }, expected: 1 },
     ])('compareCharacteristics()', ({ a, b, expected }) => {
       let compares = '='
       if (expected > 0) {

--- a/server/services/analyticsService.ts
+++ b/server/services/analyticsService.ts
@@ -337,6 +337,12 @@ export function compareCharacteristics(
   if (characteristic2 === 'Unknown') {
     return -1
   }
+  if (characteristic1 === 'Other') {
+    return 1
+  }
+  if (characteristic2 === 'Other') {
+    return -1
+  }
   return characteristic1.localeCompare(characteristic2)
 }
 

--- a/server/services/analyticsService.ts
+++ b/server/services/analyticsService.ts
@@ -301,6 +301,12 @@ export function compareLocations({ location: location1 }: LocationRow, { locatio
   if (location2 === 'All') {
     return 1
   }
+  if (location1 === 'Unknown') {
+    return 1
+  }
+  if (location2 === 'Unknown') {
+    return -1
+  }
   if (location1.length === 1 && location2.length !== 1) {
     return -1
   }
@@ -324,6 +330,12 @@ export function compareCharacteristics(
   }
   if (characteristic2 === 'All') {
     return 1
+  }
+  if (characteristic1 === 'Unknown') {
+    return 1
+  }
+  if (characteristic2 === 'Unknown') {
+    return -1
   }
   return characteristic1.localeCompare(characteristic2)
 }

--- a/server/services/analyticsServiceTypes.ts
+++ b/server/services/analyticsServiceTypes.ts
@@ -100,7 +100,7 @@ export enum ProtectedCharacteristic {
  * Known protected characteristic groups
  * NB: must match source table values
  */
-export const Ethnicities = ['Asian or Asian British', 'Black or Black British', 'Mixed', 'Other', 'White'] as const
+export const Ethnicities = ['Asian or Asian British', 'Black or Black British', 'Mixed', 'White', 'Other'] as const
 
 /**
  * Known protected characteristic groups
@@ -112,7 +112,7 @@ export const Ages = ['15-17', '18-25', '26-35', '36-45', '46-55', '56-65', '66+'
  * Known protected characteristic groups
  * NB: must match source table values
  */
-export const Religions = ['Buddhist', 'Christian', 'Hindu', 'Jewish', 'Muslim', 'No Religion', 'Other', 'Sikh'] as const
+export const Religions = ['Buddhist', 'Christian', 'Hindu', 'Jewish', 'Muslim', 'No Religion', 'Sikh', 'Other'] as const
 
 /**
  * Known protected characteristic groups

--- a/server/services/analyticsServiceTypes.ts
+++ b/server/services/analyticsServiceTypes.ts
@@ -118,7 +118,7 @@ export const Religions = ['Buddhist', 'Christian', 'Hindu', 'Jewish', 'Muslim', 
  * Known protected characteristic groups
  * NB: must match source table values
  */
-export const Disabilities = ['NO', 'Unknown', 'YES'] as const
+export const Disabilities = ['NO', 'YES', 'Unknown'] as const
 
 /**
  * Returns list of known groups for given protected characteristic

--- a/server/services/analyticsServiceTypes.ts
+++ b/server/services/analyticsServiceTypes.ts
@@ -91,7 +91,7 @@ export type PrisonersOnLevelsByProtectedCharacteristic = {
  */
 export enum ProtectedCharacteristic {
   Ethnicity = 'ethnic_group',
-  AgeGroup = 'age_group_10yr',
+  Age = 'age_group_10yr',
   Religion = 'religion_group',
   Disability = 'disability',
 }
@@ -106,7 +106,7 @@ export const Ethnicities = ['Asian or Asian British', 'Black or Black British', 
  * Known protected characteristic groups
  * NB: must match source table values
  */
-export const AgeGroups = ['15-17', '18-25', '26-35', '36-45', '46-55', '56-65', '66+'] as const
+export const Ages = ['15-17', '18-25', '26-35', '36-45', '46-55', '56-65', '66+'] as const
 
 /**
  * Known protected characteristic groups
@@ -127,8 +127,8 @@ export function knownGroupsFor(characteristic: ProtectedCharacteristic): Readonl
   switch (characteristic) {
     case ProtectedCharacteristic.Ethnicity:
       return Ethnicities
-    case ProtectedCharacteristic.AgeGroup:
-      return AgeGroups
+    case ProtectedCharacteristic.Age:
+      return Ages
     case ProtectedCharacteristic.Religion:
       return Religions
     case ProtectedCharacteristic.Disability:

--- a/server/views/pages/analytics/protected-characteristics/index.njk
+++ b/server/views/pages/analytics/protected-characteristics/index.njk
@@ -13,7 +13,7 @@
 
       {% include "../../../partials/messages.njk" %}
 
-      {% set errorSummary = formsWithErrors["incentive-levels-by-ethnicity"].errorSummary | default(formsWithErrors["incentive-levels-by-age-group"].errorSummary) | default(formsWithErrors["incentive-levels-by-religion"].errorSummary) | default(formsWithErrors["incentive-levels-by-disability"].errorSummary) %}
+      {% set errorSummary = formsWithErrors["incentive-levels-by-ethnicity"].errorSummary | default(formsWithErrors["incentive-levels-by-age"].errorSummary) | default(formsWithErrors["incentive-levels-by-religion"].errorSummary) | default(formsWithErrors["incentive-levels-by-disability"].errorSummary) %}
       {% if errorSummary %}
         {{ govukErrorSummary({
           titleText: "There is a problem",
@@ -41,9 +41,9 @@
   <div class="govuk-grid-row">
     <section class="govuk-grid-column-two-thirds govuk-!-margin-bottom-9">
 
-      {% set graphId = "incentive-levels-by-age-group" %}
-      {% set report = prisonersByAgeGroup %}
-      {% include "./prisoners-by-age-group.njk" %}
+      {% set graphId = "incentive-levels-by-age" %}
+      {% set report = prisonersByAge %}
+      {% include "./prisoners-by-age.njk" %}
 
     </section>
   </div>

--- a/server/views/pages/analytics/protected-characteristics/prisoners-by-age.njk
+++ b/server/views/pages/analytics/protected-characteristics/prisoners-by-age.njk
@@ -3,7 +3,7 @@
 {% from "../../../components/palette.njk" import colourChoices %}
 
 <h2 class="govuk-heading-m">
-  Percentage and number of prisoners on each incentive level by age group
+  Percentage and number of prisoners on each incentive level by age
 </h2>
 
 {% if not report.hasErrors %}
@@ -19,7 +19,7 @@
       classes: "govuk-!-margin-bottom-2 govuk-!-display-none-print",
       attributes: {
         "data-qa": "guidance",
-        "data-ga-category": "How you can use this chart > Incentive level by age group",
+        "data-ga-category": "How you can use this chart > Incentive level by age",
         "data-ga-label": user.activeCaseload.id | default("")
       }
     }) }}
@@ -36,7 +36,7 @@
       open: form.hasErrors,
       attributes: {
         "data-qa": "chart-feedback",
-        "data-ga-category": "Is this chart useful > Incentive level by age group",
+        "data-ga-category": "Is this chart useful > Incentive level by age",
         "data-ga-label": user.activeCaseload.id | default("")
       }
     }) }}
@@ -58,12 +58,12 @@
 
 <table class="app-chart-table app-chart-table--bars" id="table-{{ graphId }}">
   <caption class="govuk-visually-hidden">
-    Percentage and number of prisoners on each incentive level by age group
+    Percentage and number of prisoners on each incentive level by age
   </caption>
 
   <thead>
     <tr>
-      <th scope="col">Age group</th>
+      <th scope="col">Age</th>
       {% for level in report.columns %}
         <th scope="col">{{ level }} <span class="govuk-visually-hidden">level</span></th>
       {% endfor %}


### PR DESCRIPTION
…and ensure that “Other” or “Unknown” rows always comes last in protected characteristics charts