### PR TITLE
INC-314: Don't show empty 15-17 age group in non-YCS prisons

### DIFF
--- a/server/data/prisonRegister.ts
+++ b/server/data/prisonRegister.ts
@@ -1,0 +1,34 @@
+export const youthCustodyServicePrisons: ReadonlyArray<string> = [
+  // Youth Custody Service, all YOIs
+  // 15-17 year olds - young people
+  'CKI', // HMYOI Cookham Wood
+  'FYI', // HMYOI Feltham
+  'PYI', // HMP/YOI Parc A
+  'WNI', // HMYOI Werrington
+  'WYI', // HMYOI Wetherby
+  // TODO: cannot currently use prison register for this set
+
+  // Other YOIs hold only 18-24 year olds - young adults
+  // apart from Feltham which has 2 parts with YCS in one, YAs in the other.
+  // Female prisons which could have girls (15-17)
+
+  // Women’s Estate
+  'AGI', // HMP/YOI Askham Grange
+  'BZI', // HMP/YOI Bronzefield
+  'DHI', // HMP/YOI Drake Hall
+  'DWI', // HMP/YOI Downview
+  'ESI', // HMP/YOI East Sutton Park
+  'EWI', // HMP/YOI Eastwood Park
+  'FHI', // HMP/YOI Foston Hall
+  'LNI', // HMP/YOI Low Newton
+  'NHI', // HMP/YOI New Hall
+  'PFI', // HMP/YOI Peterborough Female
+  'SDI', // HMP/YOI Send
+  'STI', // HMP/YOI Styal
+  // TODO: can likely use prison register for this set
+]
+export default class PrisonRegister {
+  static isYouthCustodyService(prison: string): boolean {
+    return youthCustodyServicePrisons.includes(prison)
+  }
+}

--- a/server/services/analyticsService.ts
+++ b/server/services/analyticsService.ts
@@ -2,17 +2,24 @@ import type S3Client from '../data/s3Client'
 import logger from '../../logger'
 
 import type {
-  Table,
+  BehaviourEntriesByLocation,
   CaseEntriesTable,
   IncentiveLevelsTable,
-  Report,
-  BehaviourEntriesByLocation,
-  PrisonersWithEntriesByLocation,
   PrisonersOnLevelsByLocation,
-  ProtectedCharacteristic,
   PrisonersOnLevelsByProtectedCharacteristic,
+  PrisonersWithEntriesByLocation,
+  Report,
+  Table,
 } from './analyticsServiceTypes'
-import { AnalyticsError, AnalyticsErrorType, TableType, knownGroupsFor } from './analyticsServiceTypes'
+import {
+  AgeYoungPeople,
+  AnalyticsError,
+  AnalyticsErrorType,
+  ProtectedCharacteristic,
+  TableType,
+  knownGroupsFor,
+} from './analyticsServiceTypes'
+import PrisonRegister from '../data/prisonRegister'
 
 export default class AnalyticsService {
   constructor(
@@ -279,7 +286,10 @@ export default class AnalyticsService {
       }
     )
     const missingCharacteristics = new Set(knownGroupsFor(protectedCharacteristic))
-    // TODO: 15-17 age group may be removed if establishment is not a YOI
+    // Don't show empty young people ('15-17') group in non-YCS prisons
+    if (protectedCharacteristic === ProtectedCharacteristic.Age && !PrisonRegister.isYouthCustodyService(prison)) {
+      missingCharacteristics.delete(AgeYoungPeople)
+    }
     rows.forEach(({ characteristic }) => missingCharacteristics.delete(characteristic))
     missingCharacteristics.forEach(characteristic => {
       rows.push({ characteristic, prisonersOnLevels: Array(columns.length).fill(0) })

--- a/server/services/analyticsServiceTypes.ts
+++ b/server/services/analyticsServiceTypes.ts
@@ -106,7 +106,8 @@ export const Ethnicities = ['Asian or Asian British', 'Black or Black British', 
  * Known protected characteristic groups
  * NB: must match source table values
  */
-export const Ages = ['15-17', '18-25', '26-35', '36-45', '46-55', '56-65', '66+'] as const
+export const AgeYoungPeople = '15-17' as const
+export const Ages = [AgeYoungPeople, '18-25', '26-35', '36-45', '46-55', '56-65', '66+'] as const
 
 /**
  * Known protected characteristic groups


### PR DESCRIPTION
Hide 15-17 age group (young people) from protected characteristics graphs
for non-YCS prisons.

NB: YCS = Youth Custody Service