### PR TITLE
Prison Register, fix comment about Feltham A

### DIFF
--- a/server/data/prisonRegister.ts
+++ b/server/data/prisonRegister.ts
@@ -2,7 +2,7 @@ export const youthCustodyServicePrisons: ReadonlyArray<string> = [
   // Youth Custody Service, all YOIs
   // 15-17 year olds - young people
   'CKI', // HMYOI Cookham Wood
-  'FYI', // HMYOI Feltham
+  'FYI', // HMYOI Feltham A
   'PYI', // HMP/YOI Parc A
   'WNI', // HMYOI Werrington
   'WYI', // HMYOI Wetherby


### PR DESCRIPTION
The prison with ID `FYI` is called Feltham A in DPS (this is the prison
which may contain young people).

Updated the comment to reduce confusion between this and "Feltham" (without
the A)