### PR TITLE
INC-498: Use consistent colour palette for analytics charts

### DIFF
--- a/assets/sass/components/_chart-colours.scss
+++ b/assets/sass/components/_chart-colours.scss
@@ -2,7 +2,7 @@ $chart-colour-a: govuk-colour("light-blue"); // miro ~ #5695ca
 $chart-colour-b: govuk-colour("dark-blue"); // miro ~ #003078
 $chart-colour-c: govuk-colour("turquoise"); // miro ~ #27a197
 $chart-colour-d: govuk-colour("yellow"); // miro ~ #ffdd04
-$chart-colour-e: govuk-colour("pink");
+$chart-colour-e: govuk-colour("pink"); // not expected to be used: presence in chart indicates unforeseen column set
 
 .app-chart-colour--a {
   background: $chart-colour-a;

--- a/server/utils/analytics.test.ts
+++ b/server/utils/analytics.test.ts
@@ -1,0 +1,56 @@
+import { Colour, makeChartPalette } from './analytics'
+
+describe.each([
+  [
+    'with typical incentive levels',
+    ['Basic', 'Standard', 'Enhanced'],
+    ['app-chart-colour--a', 'app-chart-colour--b', 'app-chart-colour--c'],
+  ],
+  [
+    'with extended incentive levels',
+    ['Basic', 'Standard', 'Enhanced', 'Enhanced 2'],
+    ['app-chart-colour--a', 'app-chart-colour--b', 'app-chart-colour--c', 'app-chart-colour--d'],
+  ],
+  [
+    'with a common incentive level missing',
+    ['Standard', 'Enhanced', 'Enhanced 2'],
+    ['app-chart-colour--b', 'app-chart-colour--c', 'app-chart-colour--d'],
+  ],
+  [
+    'with a different incentive level missing',
+    ['Basic', 'Standard', 'Enhanced 2'],
+    ['app-chart-colour--a', 'app-chart-colour--b', 'app-chart-colour--d'],
+  ],
+  [
+    'with an incorrectly named incentive level',
+    ['Basic', 'Standard', 'Enhanced', 'Super enhanced'],
+    ['app-chart-colour--a', 'app-chart-colour--b', 'app-chart-colour--c', 'app-chart-colour--d'],
+  ],
+  [
+    'with an unexpected incentive level',
+    ['Basic', 'Standard', 'Enhanced', 'Enhanced 2', 'Unexpected'],
+    ['app-chart-colour--a', 'app-chart-colour--b', 'app-chart-colour--c', 'app-chart-colour--d', 'app-chart-colour--e'],
+  ],
+  [
+    'with several unexpected incentive levels',
+    ['Basic', 'Standard', 'Enhanced', 'Enhanced 2', 'Unexpected 1', 'Unexpected 2', 'Unexpected 3'],
+    [
+      'app-chart-colour--a',
+      'app-chart-colour--b',
+      'app-chart-colour--c',
+      'app-chart-colour--d',
+      'app-chart-colour--e',
+      'app-chart-colour--e',
+      'app-chart-colour--e',
+    ],
+  ],
+  [
+    'with behaviour entry types', // NB: types are hard-coded so variations do not require testing
+    ['Positive', 'Negative'],
+    ['app-chart-colour--a', 'app-chart-colour--b'],
+  ],
+])('chartPalette filter', (name: string, columns: string[], expectedPalette: Colour[]) => {
+  it(name, () => {
+    expect(makeChartPalette(columns)).toEqual(expectedPalette)
+  })
+})

--- a/server/utils/analytics.ts
+++ b/server/utils/analytics.ts
@@ -1,0 +1,32 @@
+export const palette = [
+  // match classes in chart-colours SCSS
+  'app-chart-colour--a',
+  'app-chart-colour--b',
+  'app-chart-colour--c',
+  'app-chart-colour--d',
+  'app-chart-colour--e',
+] as const
+export type Colour = typeof palette[number]
+
+export function makeChartPalette(columns: string[]): Colour[] {
+  let availableColours = [...palette]
+  const takeColour = (colour: Colour): Colour => {
+    availableColours = availableColours.filter(aColour => aColour !== colour)
+    return colour
+  }
+  return columns.map(column => {
+    if (column === 'Basic' || column === 'Positive') {
+      return takeColour('app-chart-colour--a')
+    }
+    if (column === 'Standard' || column === 'Negative') {
+      return takeColour('app-chart-colour--b')
+    }
+    if (column === 'Enhanced') {
+      return takeColour('app-chart-colour--c')
+    }
+    if (column === 'Enhanced 2') {
+      return takeColour('app-chart-colour--d')
+    }
+    return availableColours.shift() ?? 'app-chart-colour--e'
+  })
+}

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -4,6 +4,7 @@ import express from 'express'
 import * as pathModule from 'path'
 
 import config from '../config'
+import { makeChartPalette } from './analytics'
 import format from './format'
 
 const production = process.env.NODE_ENV === 'production'
@@ -67,4 +68,6 @@ export default function nunjucksSetup(app: express.Express, path: pathModule.Pla
   njkEnv.addFilter('shortDate', format.shortDate)
   njkEnv.addFilter('thousands', format.thousands)
   njkEnv.addFilter('percentageOf', format.percentage)
+
+  njkEnv.addFilter('chartPalette', makeChartPalette)
 }

--- a/server/views/components/palette.njk
+++ b/server/views/components/palette.njk
@@ -1,3 +1,0 @@
-{% set colourChoices = [
-  'app-chart-colour--a', 'app-chart-colour--b', 'app-chart-colour--c', 'app-chart-colour--d', 'app-chart-colour--e'
-] %}

--- a/server/views/pages/analytics/incentive-levels/prisoners-by-location.njk
+++ b/server/views/pages/analytics/incentive-levels/prisoners-by-location.njk
@@ -1,12 +1,13 @@
 {% from "govuk/components/details/macro.njk" import govukDetails %}
 {% from "../../../components/dataSource.njk" import dataSource %}
-{% from "../../../components/palette.njk" import colourChoices %}
 
 <h2 class="govuk-heading-m">
   Percentage and number of prisoners on each incentive level by wing
 </h2>
 
 {% if not report.hasErrors %}
+
+{% set colourChoices = report.columns | chartPalette %}
 
 {{ dataSource(report.dataSource, report.lastUpdated, {"classes": "govuk-!-margin-bottom-6"}) }}
 

--- a/server/views/pages/analytics/protected-characteristics/prisoners-by-age.njk
+++ b/server/views/pages/analytics/protected-characteristics/prisoners-by-age.njk
@@ -1,12 +1,13 @@
 {% from "govuk/components/details/macro.njk" import govukDetails %}
 {% from "../../../components/dataSource.njk" import dataSource %}
-{% from "../../../components/palette.njk" import colourChoices %}
 
 <h2 class="govuk-heading-m">
   Percentage and number of prisoners on each incentive level by age
 </h2>
 
 {% if not report.hasErrors %}
+
+{% set colourChoices = report.columns | chartPalette %}
 
 {{ dataSource(report.dataSource, report.lastUpdated, {"classes": "govuk-!-margin-bottom-6"}) }}
 

--- a/server/views/pages/analytics/protected-characteristics/prisoners-by-disability.njk
+++ b/server/views/pages/analytics/protected-characteristics/prisoners-by-disability.njk
@@ -1,12 +1,13 @@
 {% from "govuk/components/details/macro.njk" import govukDetails %}
 {% from "../../../components/dataSource.njk" import dataSource %}
-{% from "../../../components/palette.njk" import colourChoices %}
 
 <h2 class="govuk-heading-m">
   Percentage and number of prisoners on each incentive level by recorded disability
 </h2>
 
 {% if not report.hasErrors %}
+
+{% set colourChoices = report.columns | chartPalette %}
 
 {{ dataSource(report.dataSource, report.lastUpdated, {"classes": "govuk-!-margin-bottom-6"}) }}
 

--- a/server/views/pages/analytics/protected-characteristics/prisoners-by-ethnicity.njk
+++ b/server/views/pages/analytics/protected-characteristics/prisoners-by-ethnicity.njk
@@ -1,12 +1,13 @@
 {% from "govuk/components/details/macro.njk" import govukDetails %}
 {% from "../../../components/dataSource.njk" import dataSource %}
-{% from "../../../components/palette.njk" import colourChoices %}
 
 <h2 class="govuk-heading-m">
   Percentage and number of prisoners on each incentive level by ethnicity
 </h2>
 
 {% if not report.hasErrors %}
+
+{% set colourChoices = report.columns | chartPalette %}
 
 {{ dataSource(report.dataSource, report.lastUpdated, {"classes": "govuk-!-margin-bottom-6"}) }}
 

--- a/server/views/pages/analytics/protected-characteristics/prisoners-by-religion.njk
+++ b/server/views/pages/analytics/protected-characteristics/prisoners-by-religion.njk
@@ -1,12 +1,13 @@
 {% from "govuk/components/details/macro.njk" import govukDetails %}
 {% from "../../../components/dataSource.njk" import dataSource %}
-{% from "../../../components/palette.njk" import colourChoices %}
 
 <h2 class="govuk-heading-m">
   Percentage and number of prisoners on each incentive level by religion
 </h2>
 
 {% if not report.hasErrors %}
+
+{% set colourChoices = report.columns | chartPalette %}
 
 {{ dataSource(report.dataSource, report.lastUpdated, {"classes": "govuk-!-margin-bottom-6"}) }}
 

--- a/server/views/pages/analytics/protected-characteristics/prisoners-by-sexual-orientation.njk
+++ b/server/views/pages/analytics/protected-characteristics/prisoners-by-sexual-orientation.njk
@@ -1,12 +1,13 @@
 {% from "govuk/components/details/macro.njk" import govukDetails %}
 {% from "../../../components/dataSource.njk" import dataSource %}
-{% from "../../../components/palette.njk" import colourChoices %}
 
 <h2 class="govuk-heading-m">
   Percentage and number of prisoners on each incentive level by sexual orientation
 </h2>
 
 {% if not report.hasErrors %}
+
+{% set colourChoices = report.columns | chartPalette %}
 
 {{ dataSource(report.dataSource, report.lastUpdated, {"classes": "govuk-!-margin-bottom-6"}) }}
 


### PR DESCRIPTION
Currently, when a prison has nobody on “Basic” the colour palette shifts so that “Standard” uses the first / light blue colour.
It’s been suggested that levels should use the same colours even when some levels are missing.