### PR TITLE
INC-556: enable preserveSemverRanges setting

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,8 @@
 {
   "extends": [
     "config:base",
-    ":disableDependencyDashboard"
+    ":disableDependencyDashboard",
+    ":preserveSemverRanges"
   ],
   "assigneesFromCodeOwners": true,
   "timezone": "Europe/London",


### PR DESCRIPTION
https://dsdmoj.atlassian.net/browse/INC-556

Renovate raised https://github.com/ministryofjustice/hmpps-incentives-ui/pull/152 which attempted to pin dependencies, however we want to retain the npm dependencies semvers