### PR TITLE
INC-567: Stop building ARM docker image in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -200,7 +200,7 @@ workflows:
             - build
       - hmpps/helm_lint:
           name: helm_lint
-      - hmpps/build_multiplatform_docker:
+      - hmpps/build_docker:
           name: build_docker
           filters:
             branches:


### PR DESCRIPTION
…because the image _from quay.io_ is never used on such a processor. The extra ~12min of build time in CircleCI is currently a waste of time and money.