### PR TITLE
INC-567: Consistent indentation in nunjucks templates/macros

### DIFF
--- a/server/views/pages/changeLocation.njk
+++ b/server/views/pages/changeLocation.njk
@@ -7,21 +7,25 @@
 {% set pageTitle = applicationName + ' – Select a location' %}
 
 {% block content %}
-<h1 class="govuk-heading-l">{{title}}</h1>
-<form method="POST" id="changeLocation">
-  <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
-  {{ govukSelect({
-          id: "changeLocationSelect",
-          name: "locationPrefix",
-          label: {
-              text: "Select a location"
-          },
-          classes: 'govuk-!-width-one-third',
-          items: options
-      }) }}
-  {{ govukButton({
+  <h1 class="govuk-heading-l">{{title}}</h1>
+
+  <form method="POST" id="changeLocation">
+    <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
+
+    {{ govukSelect({
+      id: "changeLocationSelect",
+      name: "locationPrefix",
+      label: {
+        text: "Select a location"
+      },
+      classes: 'govuk-!-width-one-third',
+      items: options
+    }) }}
+
+    {{ govukButton({
       text: "Continue",
       preventDoubleClick: true
     }) }}
-</form>
+
+  </form>
 {% endblock %}

--- a/server/views/pages/error.njk
+++ b/server/views/pages/error.njk
@@ -20,6 +20,7 @@
           Error details
         </span>
       </summary>
+
       <div class="govuk-details__text">
         {% if error.message %}
           <p class="govuk-body-l">{{ error.message }}</p>

--- a/server/views/pages/home.njk
+++ b/server/views/pages/home.njk
@@ -25,8 +25,10 @@
         "description": cardDescription,
         "id": "incentive-information"
       }) }}
+
     </li>
     <li class="govuk-grid-column-one-third card-group__item">
+
       {{ card({
         "href": "/analytics/incentive-levels",
         "clickable": "true",
@@ -34,6 +36,7 @@
         "description": "See data visualisations for incentive levels and behaviour entries, including protected characteristics.",
         "id": "incentive-analytics"
       }) }}
+
     </li>
   </ul>
 

--- a/server/views/pages/incentives-table.njk
+++ b/server/views/pages/incentives-table.njk
@@ -6,260 +6,265 @@
 {% set pageTitle = applicationName + " – Incentives information" %}
 
 {% block content %}
-    {% if featureFlags.hideDaysColumnsInIncentivesTable %}
-        {%- from "moj/components/banner/macro.njk" import mojBanner -%}
-        <div class="govuk-grid-row">
-            <div class="govuk-grid-column-two-thirds">
-                {{ mojBanner({
-                    type: 'information',
-                    text: 'Review details have been removed from this table while we investigate the data.'
-                }) }}
-            </div>
-        </div>
-    {% endif %}
+  {% if featureFlags.hideDaysColumnsInIncentivesTable %}
+    {%- from "moj/components/banner/macro.njk" import mojBanner -%}
 
-    <h1 class="govuk-heading-xl govuk-!-margin-bottom-4">
-        Incentive information
-    </h1>
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
 
-    <p>
-        <span class='govuk-!-margin-right-1'>{{ entries.locationDescription }}</span>
-        <a href="/select-location" class="govuk-link">Select another location</a>
-    </p>
+        {{ mojBanner({
+            type: 'information',
+            text: 'Review details have been removed from this table while we investigate the data.'
+        }) }}
 
-    <div class="govuk-grid-row govuk-!-margin-top-8 govuk-grid-row">
-        <div class="govuk-grid-column-full">
-            <h2 class="govuk-heading-l">Incentive levels</h2>
-        </div>
-        {% for level in entries.incentiveLevelSummary %}
-            <div class="govuk-grid-column-one-quarter" data-qa="number-at-level-{{ level.level }}">
-                <p class="govuk-body govuk-!-margin-bottom-2">{{ level.levelDescription }}</p>
-                <span class="govuk-body govuk-!-font-size-36 govuk-!-font-weight-bold">
-                    {{ level.numberAtThisLevel | default(0) }}
-                </span>
-            </div>
-        {% endfor %}
+      </div>
+    </div>
+  {% endif %}
+
+  <h1 class="govuk-heading-xl govuk-!-margin-bottom-4">
+    Incentive information
+  </h1>
+
+  <p>
+    <span class='govuk-!-margin-right-1'>{{ entries.locationDescription }}</span>
+    <a href="/select-location" class="govuk-link">Select another location</a>
+  </p>
+
+  <div class="govuk-grid-row govuk-!-margin-top-8 govuk-grid-row">
+    <div class="govuk-grid-column-full">
+      <h2 class="govuk-heading-l">Incentive levels</h2>
     </div>
 
-    <p class="govuk-!-margin-top-9"></p>
-    <h2 class="govuk-heading-l govuk-!-margin-top-9">
-        {% if featureFlags.hideDaysColumnsInIncentivesTable %}
-            Behaviour entries in the last 3 months
-        {% else %}
-            Review dates and behaviour entries in the last 3 months
-        {% endif %}
-    </h2>
-
-    {% macro table(level) %}
-        {% set commonHeader = [
-            {
-                text: ""
-            },
-            {
-                text: "Name and prison number",
-                attributes: {
-                    "aria-sort": "ascending",
-                    "data-ga-category": "Incentives information > Sorted table",
-                    "data-ga-action": "by name"
-                }
-            },
-            {
-                text: "Days on level",
-                attributes: {
-                    "aria-sort": "none",
-                    "data-ga-category": "Incentives information > Sorted table",
-                    "data-ga-action": "by days on level"
-                },
-                itemToRemove: featureFlags.hideDaysColumnsInIncentivesTable
-            },
-            {
-                text: "Days since last review",
-                attributes: {
-                    "aria-sort": "none",
-                    "data-ga-category": "Incentives information > Sorted table",
-                    "data-ga-action": "by days since last review"
-                },
-                itemToRemove: featureFlags.hideDaysColumnsInIncentivesTable
-            },
-            {
-                text: "Positive behaviours",
-                attributes: {
-                    "aria-sort": "none",
-                    "data-ga-category": "Incentives information > Sorted table",
-                    "data-ga-action": "by positive behaviours"
-                }
-            },
-            {
-                text: "Incentive encouragements",
-                attributes: {
-                    "aria-sort": "none",
-                    "data-ga-category": "Incentives information > Sorted table",
-                    "data-ga-action": "by incentive encouragements"
-                }
-            },
-            {
-                text: "Negative behaviours",
-                attributes: {
-                    "aria-sort": "none",
-                    "data-ga-category": "Incentives information > Sorted table",
-                    "data-ga-action": "by negative behaviours"
-                }
-            },
-            {
-                text: "Incentive warnings",
-                attributes: {
-                    "aria-sort": "none",
-                    "data-ga-category": "Incentives information > Sorted table",
-                    "data-ga-action": "by incentive warnings"
-                }
-            },
-            {
-                text: "Proven adjudications",
-                attributes: {
-                    "aria-sort": "none",
-                    "data-ga-category": "Incentives information > Sorted table",
-                    "data-ga-action": "by proven adjudications"
-                }
-            }
-        ] | rejectattr('itemToRemove') %}
-
-        {% set rows = [] %}
-        {% for prisoner in level.prisonerBehaviours %}
-            {% if prisoner.imageId > 0 %}
-                {% set imageUrl = '/prisoner-images/' + prisoner.imageId + '.jpeg' %}
-            {% else %}
-                {% set imageUrl = '/assets/images/prisoner.jpeg' %}
-            {% endif %}
-
-            {% set prisonerFullName = (prisoner.lastName + ', ' + prisoner.firstName) | escape %}
-
-            {# First 2 columns always shown #}
-            {% set row = [
-                {
-                    html: '<img src="' + imageUrl + '" alt="' + prisonerFullName + '’s photo" width="90" />'
-                },
-                {
-                    html: '<a href="' + dpsHome + '/prisoner/' + prisoner.prisonerNumber + '/case-notes?fromDate=' + threeMonthsAgo | dateParam + '" class="govuk-link" data-ga-category="Incentives information > Clicked on link" data-ga-action="prisoner name">' + prisonerFullName + '<br>' + prisoner.prisonerNumber + '</a>',
-                    attributes: {
-                        "data-sort-value": prisonerFullName
-                    }
-                },
-                {
-                    html: '<a href="' + dpsHome + '/prisoner/' + prisoner.prisonerNumber + '/incentive-level-details" class="govuk-link" data-ga-category="Incentives information > Clicked on link" data-ga-action="days on level">' + prisoner.daysOnLevel + '</a>',
-                    attributes: {
-                        "data-sort-value": prisoner.daysOnLevel
-                    },
-                    itemToRemove: featureFlags.hideDaysColumnsInIncentivesTable
-                },
-                {
-                    html: '<a href="' + dpsHome + '/prisoner/' + prisoner.prisonerNumber + '/incentive-level-details" class="govuk-link" data-ga-category="Incentives information > Clicked on link" data-ga-action="days since last review">' + prisoner.daysSinceLastReview + '</a>',
-                    attributes: {
-                        "data-sort-value": prisoner.daysSinceLastReview
-                    },
-                    itemToRemove: featureFlags.hideDaysColumnsInIncentivesTable
-                },
-                {
-                    html: '<a href="' + dpsHome + '/prisoner/' + prisoner.prisonerNumber + '/case-notes?type=POS&fromDate=' + threeMonthsAgo | dateParam + '" class="govuk-link" data-ga-category="Incentives information > Clicked on link" data-ga-action="positive behaviours">' + prisoner.positiveBehaviours + '</a>',
-                    attributes: {
-                        "data-sort-value": prisoner.positiveBehaviours
-                    }
-                },
-                {
-                    html: '<a href="' + dpsHome + '/prisoner/' + prisoner.prisonerNumber + '/case-notes?type=POS&subType=IEP_ENC&fromDate=' + threeMonthsAgo | dateParam + '" class="govuk-link" data-ga-category="Incentives information > Clicked on link" data-ga-action="incentive encouragements">' + prisoner.incentiveEncouragements + '</a>',
-                    attributes: {
-                        "data-sort-value": prisoner.incentiveEncouragements
-                    }
-                },
-                {
-                    html: '<a href="' + dpsHome + '/prisoner/' + prisoner.prisonerNumber + '/case-notes?type=NEG&fromDate=' + threeMonthsAgo | dateParam + '" class="govuk-link" data-ga-category="Incentives information > Clicked on link" data-ga-action="negative behaviours">' + prisoner.negativeBehaviours + '</a>',
-                    attributes: {
-                        "data-sort-value": prisoner.negativeBehaviours
-                    }
-                },
-                {
-                    html: '<a href="' + dpsHome + '/prisoner/' + prisoner.prisonerNumber + '/case-notes?type=NEG&subType=IEP_WARN&fromDate=' + threeMonthsAgo | dateParam + '" class="govuk-link" data-ga-category="Incentives information > Clicked on link" data-ga-action="incentive warnings">' + prisoner.incentiveWarnings + '</a>',
-                    attributes: {
-                        "data-sort-value": prisoner.incentiveWarnings
-                    }
-                },
-                {
-                    html: '<a href="' + dpsHome + '/prisoner/' + prisoner.prisonerNumber + '/adjudications?finding=PROVED" class="govuk-link" data-ga-category="Incentives information > Clicked on link" data-ga-action="proven adjudications">' + prisoner.provenAdjudications + '</a>',
-                    attributes: {
-                        "data-sort-value": prisoner.provenAdjudications
-                    }
-                }
-            ] | rejectattr('itemToRemove') %}
-            {% set _ = rows.push(row) %}
-        {% endfor %}
-
-        <h2 class="govuk-heading-l">{{ level.levelDescription }}</h2>
-        {{ govukTable({
-            attributes: {
-                'id': 'incentive-table-' + level.level,
-                'data-module': 'moj-sortable-table'
-            },
-            classes: 'govuk-table--incentive-summary app-table--striped' + '' if featureFlags.hideDaysColumnsInIncentivesTable else ' govuk-table--small-headers',
-            head: commonHeader,
-            rows: rows
-        }) }}
-    {% endmacro %}
-
-    {% set tabsItems = [] %}
     {% for level in entries.incentiveLevelSummary %}
-        {% set _ = tabsItems.push(
-            {
-                label: level.levelDescription + ' (' + level.numberAtThisLevel + ')',
-                id: level.level,
-                attributes: {
-                    "data-ga-category": "Incentives information > Clicked on incentive level tab",
-                    "data-ga-action": level.levelDescription
-                },
-                panel: { html: table(level) }
-            }
-        ) %}
+      <div class="govuk-grid-column-one-quarter" data-qa="number-at-level-{{ level.level }}">
+        <p class="govuk-body govuk-!-margin-bottom-2">{{ level.levelDescription }}</p>
+        <span class="govuk-body govuk-!-font-size-36 govuk-!-font-weight-bold">
+          {{ level.numberAtThisLevel | default(0) }}
+        </span>
+      </div>
     {% endfor %}
+  </div>
 
-    {{ govukTabs({
-        classes: 'govuk-tabs--incentive-summary',
-        items: tabsItems
+  <p class="govuk-!-margin-top-9"></p>
+  <h2 class="govuk-heading-l govuk-!-margin-top-9">
+    {% if featureFlags.hideDaysColumnsInIncentivesTable %}
+      Behaviour entries in the last 3 months
+    {% else %}
+      Review dates and behaviour entries in the last 3 months
+    {% endif %}
+  </h2>
+
+  {% macro table(level) %}
+    {% set commonHeader = [
+      {
+        text: ""
+      },
+      {
+        text: "Name and prison number",
+        attributes: {
+          "aria-sort": "ascending",
+          "data-ga-category": "Incentives information > Sorted table",
+          "data-ga-action": "by name"
+        }
+      },
+      {
+        text: "Days on level",
+        attributes: {
+          "aria-sort": "none",
+          "data-ga-category": "Incentives information > Sorted table",
+          "data-ga-action": "by days on level"
+        },
+        itemToRemove: featureFlags.hideDaysColumnsInIncentivesTable
+      },
+      {
+        text: "Days since last review",
+        attributes: {
+          "aria-sort": "none",
+          "data-ga-category": "Incentives information > Sorted table",
+          "data-ga-action": "by days since last review"
+        },
+        itemToRemove: featureFlags.hideDaysColumnsInIncentivesTable
+      },
+      {
+        text: "Positive behaviours",
+        attributes: {
+          "aria-sort": "none",
+          "data-ga-category": "Incentives information > Sorted table",
+          "data-ga-action": "by positive behaviours"
+        }
+      },
+      {
+        text: "Incentive encouragements",
+        attributes: {
+          "aria-sort": "none",
+          "data-ga-category": "Incentives information > Sorted table",
+          "data-ga-action": "by incentive encouragements"
+        }
+      },
+      {
+        text: "Negative behaviours",
+        attributes: {
+          "aria-sort": "none",
+          "data-ga-category": "Incentives information > Sorted table",
+          "data-ga-action": "by negative behaviours"
+        }
+      },
+      {
+        text: "Incentive warnings",
+        attributes: {
+          "aria-sort": "none",
+          "data-ga-category": "Incentives information > Sorted table",
+          "data-ga-action": "by incentive warnings"
+        }
+      },
+      {
+        text: "Proven adjudications",
+        attributes: {
+          "aria-sort": "none",
+          "data-ga-category": "Incentives information > Sorted table",
+          "data-ga-action": "by proven adjudications"
+        }
+      }
+    ] | rejectattr('itemToRemove') %}
+
+    {% set rows = [] %}
+      {% for prisoner in level.prisonerBehaviours %}
+        {% if prisoner.imageId > 0 %}
+          {% set imageUrl = '/prisoner-images/' + prisoner.imageId + '.jpeg' %}
+        {% else %}
+          {% set imageUrl = '/assets/images/prisoner.jpeg' %}
+        {% endif %}
+
+        {% set prisonerFullName = (prisoner.lastName + ', ' + prisoner.firstName) | escape %}
+
+        {% set row = [
+          {
+            html: '<img src="' + imageUrl + '" alt="' + prisonerFullName + '’s photo" width="90" />'
+          },
+          {
+            html: '<a href="' + dpsHome + '/prisoner/' + prisoner.prisonerNumber + '/case-notes?fromDate=' + threeMonthsAgo | dateParam + '" class="govuk-link" data-ga-category="Incentives information > Clicked on link" data-ga-action="prisoner name">' + prisonerFullName + '<br>' + prisoner.prisonerNumber + '</a>',
+            attributes: {
+              "data-sort-value": prisonerFullName
+            }
+          },
+          {
+            html: '<a href="' + dpsHome + '/prisoner/' + prisoner.prisonerNumber + '/incentive-level-details" class="govuk-link" data-ga-category="Incentives information > Clicked on link" data-ga-action="days on level">' + prisoner.daysOnLevel + '</a>',
+            attributes: {
+              "data-sort-value": prisoner.daysOnLevel
+            },
+            itemToRemove: featureFlags.hideDaysColumnsInIncentivesTable
+          },
+          {
+            html: '<a href="' + dpsHome + '/prisoner/' + prisoner.prisonerNumber + '/incentive-level-details" class="govuk-link" data-ga-category="Incentives information > Clicked on link" data-ga-action="days since last review">' + prisoner.daysSinceLastReview + '</a>',
+            attributes: {
+              "data-sort-value": prisoner.daysSinceLastReview
+            },
+            itemToRemove: featureFlags.hideDaysColumnsInIncentivesTable
+          },
+          {
+            html: '<a href="' + dpsHome + '/prisoner/' + prisoner.prisonerNumber + '/case-notes?type=POS&fromDate=' + threeMonthsAgo | dateParam + '" class="govuk-link" data-ga-category="Incentives information > Clicked on link" data-ga-action="positive behaviours">' + prisoner.positiveBehaviours + '</a>',
+            attributes: {
+              "data-sort-value": prisoner.positiveBehaviours
+            }
+          },
+          {
+              html: '<a href="' + dpsHome + '/prisoner/' + prisoner.prisonerNumber + '/case-notes?type=POS&subType=IEP_ENC&fromDate=' + threeMonthsAgo | dateParam + '" class="govuk-link" data-ga-category="Incentives information > Clicked on link" data-ga-action="incentive encouragements">' + prisoner.incentiveEncouragements + '</a>',
+              attributes: {
+                  "data-sort-value": prisoner.incentiveEncouragements
+              }
+          },
+          {
+            html: '<a href="' + dpsHome + '/prisoner/' + prisoner.prisonerNumber + '/case-notes?type=NEG&fromDate=' + threeMonthsAgo | dateParam + '" class="govuk-link" data-ga-category="Incentives information > Clicked on link" data-ga-action="negative behaviours">' + prisoner.negativeBehaviours + '</a>',
+            attributes: {
+              "data-sort-value": prisoner.negativeBehaviours
+            }
+          },
+          {
+            html: '<a href="' + dpsHome + '/prisoner/' + prisoner.prisonerNumber + '/case-notes?type=NEG&subType=IEP_WARN&fromDate=' + threeMonthsAgo | dateParam + '" class="govuk-link" data-ga-category="Incentives information > Clicked on link" data-ga-action="incentive warnings">' + prisoner.incentiveWarnings + '</a>',
+            attributes: {
+              "data-sort-value": prisoner.incentiveWarnings
+            }
+          },
+          {
+            html: '<a href="' + dpsHome + '/prisoner/' + prisoner.prisonerNumber + '/adjudications?finding=PROVED" class="govuk-link" data-ga-category="Incentives information > Clicked on link" data-ga-action="proven adjudications">' + prisoner.provenAdjudications + '</a>',
+            attributes: {
+              "data-sort-value": prisoner.provenAdjudications
+            }
+          }
+        ] | rejectattr('itemToRemove') %}
+        {% set _ = rows.push(row) %}
+      {% endfor %}
+
+    <h2 class="govuk-heading-l">{{ level.levelDescription }}</h2>
+
+    {{ govukTable({
+      attributes: {
+        'id': 'incentive-table-' + level.level,
+        'data-module': 'moj-sortable-table'
+      },
+      classes: 'govuk-table--incentive-summary app-table--striped' + '' if featureFlags.hideDaysColumnsInIncentivesTable else ' govuk-table--small-headers',
+      head: commonHeader,
+      rows: rows
     }) }}
+
+  {% endmacro %}
+
+  {% set tabsItems = [] %}
+  {% for level in entries.incentiveLevelSummary %}
+    {% set _ = tabsItems.push(
+      {
+        label: level.levelDescription + ' (' + level.numberAtThisLevel + ')',
+        id: level.level,
+        attributes: {
+          "data-ga-category": "Incentives information > Clicked on incentive level tab",
+          "data-ga-action": level.levelDescription
+        },
+        panel: { html: table(level) }
+      }
+    ) %}
+  {% endfor %}
+
+  {{ govukTabs({
+    classes: 'govuk-tabs--incentive-summary',
+    items: tabsItems
+  }) }}
 
 {% endblock %}
 
 {% block bodyEnd %}
-    {{ super() }}
+  {{ super() }}
 
-    <script nonce="{{ cspNonce }}">
-        function gaSendEvent() {
-            const elem = $(this)
+  <script nonce="{{ cspNonce }}">
+    function gaSendEvent() {
+      const elem = $(this)
 
-            const gaCategory = elem.data('ga-category')
-            let gaAction = elem.data('ga-action')
-            const gaLabel = '{{ locationPrefix }}'
+      const gaCategory = elem.data('ga-category')
+      let gaAction = elem.data('ga-action')
+      const gaLabel = '{{ locationPrefix }}'
 
-            // for sorting events, add sort order to GA action
-            const previousSortOrder = elem.attr('aria-sort')
-            if (previousSortOrder) {
-                if (previousSortOrder === 'ascending') {
-                    gaAction += ' (descending)'
-                } else {
-                    gaAction += ' (ascending)'
-                }
-            }
-
-            if (typeof ga === typeof Function) ga('send', 'event', gaCategory, gaAction, gaLabel)
-
-            if (typeof gtag === typeof Function) {
-                gtag('event', 'incentives_event', {
-                    category: gaCategory,
-                    action: gaAction,
-                    label: gaLabel,
-                })
-            }
+      // for sorting events, add sort order to GA action
+      const previousSortOrder = elem.attr('aria-sort')
+      if (previousSortOrder) {
+        if (previousSortOrder === 'ascending') {
+          gaAction += ' (descending)'
+        } else {
+          gaAction += ' (ascending)'
         }
+      }
 
-        $('.govuk-tabs__tab[data-ga-category]').on('focus', gaSendEvent)
-        $('.govuk-table a[data-ga-category]').on('click', gaSendEvent)
-        $('.govuk-table .govuk-table__header[data-ga-category]').on('click', gaSendEvent)
-    </script>
+      if (typeof ga === typeof Function) ga('send', 'event', gaCategory, gaAction, gaLabel)
+
+      if (typeof gtag === typeof Function) {
+        gtag('event', 'incentives_event', {
+          category: gaCategory,
+          action: gaAction,
+          label: gaLabel,
+        })
+      }
+    }
+
+    $('.govuk-tabs__tab[data-ga-category]').on('focus', gaSendEvent)
+    $('.govuk-table a[data-ga-category]').on('click', gaSendEvent)
+    $('.govuk-table .govuk-table__header[data-ga-category]').on('click', gaSendEvent)
+  </script>
 {% endblock bodyEnd %}

--- a/server/views/partials/analytics/chartBase.njk
+++ b/server/views/partials/analytics/chartBase.njk
@@ -12,55 +12,55 @@
   report
 ) %}
 
-<h2 class="govuk-heading-m">
-  {{ title }}
-</h2>
+  <h2 class="govuk-heading-m">
+    {{ title }}
+  </h2>
 
-{% if not report.hasErrors %}
+  {% if not report.hasErrors %}
 
-  <p>
-    Data source: {{ report.dataSource -}}<span class="govuk-visually-hidden">.</span>
-    <br />
-    Date updated: {{ report.lastUpdated | shortDate -}}<span class="govuk-visually-hidden">.</span>
-  </p>
+    <p>
+      Data source: {{ report.dataSource -}}<span class="govuk-visually-hidden">.</span>
+      <br />
+      Date updated: {{ report.lastUpdated | shortDate -}}<span class="govuk-visually-hidden">.</span>
+    </p>
 
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-      {% if guidance %}
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        {% if guidance %}
+          {{ govukDetails({
+            summaryText: "How you can use this chart",
+            text: guidance,
+            id: "guidance-" + chartId,
+            classes: "govuk-!-margin-bottom-2 govuk-!-display-none-print",
+            attributes: {
+              "data-qa": "guidance",
+              "data-ga-category": "How you can use this chart > " + googleAnalyticsCategory,
+              "data-ga-label": activeCaseload | default("")
+            }
+          }) }}
+        {% endif %}
+
         {{ govukDetails({
-          summaryText: "How you can use this chart",
-          text: guidance,
-          id: "guidance-" + chartId,
-          classes: "govuk-!-margin-bottom-2 govuk-!-display-none-print",
+          summaryText: "Is this chart useful?",
+          html: formFeedback(form=form, csrfToken=csrfToken),
+          id: "chart-feedback-" + chartId,
+          classes: "govuk-!-display-none-print",
+          open: form.hasErrors,
           attributes: {
-            "data-qa": "guidance",
-            "data-ga-category": "How you can use this chart > " + googleAnalyticsCategory,
+            "data-qa": "chart-feedback",
+            "data-ga-category": "Is this chart useful > " + googleAnalyticsCategory,
             "data-ga-label": activeCaseload | default("")
           }
         }) }}
-      {% endif %}
-
-      {{ govukDetails({
-        summaryText: "Is this chart useful?",
-        html: formFeedback(form=form, csrfToken=csrfToken),
-        id: "chart-feedback-" + chartId,
-        classes: "govuk-!-display-none-print",
-        open: form.hasErrors,
-        attributes: {
-          "data-qa": "chart-feedback",
-          "data-ga-category": "Is this chart useful > " + googleAnalyticsCategory,
-          "data-ga-label": activeCaseload | default("")
-        }
-      }) }}
+      </div>
     </div>
-  </div>
 
-  {{ caller() }}
+    {{ caller() }}
 
-{% else %}
+  {% else %}
 
-  {% include "./reportError.njk" %}
+    {% include "./reportError.njk" %}
 
-{% endif %}
+  {% endif %}
 
 {% endmacro %}

--- a/server/views/partials/analytics/chartBaseHeatmap.njk
+++ b/server/views/partials/analytics/chartBaseHeatmap.njk
@@ -39,87 +39,87 @@
   rowValue=rowValue
 ) %}
 
-{% call chartBase(
-  title=title,
-  guidance=guidance,
-  chartId=chartId,
-  googleAnalyticsCategory=googleAnalyticsCategory,
-  activeCaseload=activeCaseload,
-  form=form,
-  csrfToken=csrfToken,
-  report=report
-) %}
+  {% call chartBase(
+    title=title,
+    guidance=guidance,
+    chartId=chartId,
+    googleAnalyticsCategory=googleAnalyticsCategory,
+    activeCaseload=activeCaseload,
+    form=form,
+    csrfToken=csrfToken,
+    report=report
+  ) %}
 
-<div class="govuk-!-margin-top-8">
-  <div aria-hidden="true" class="app-chart-legend">
-    <span class="app-chart-legend__label">0%</span>
-    <span class="app-chart-legend__swatch" data-style-background="{{ heatMapColour(0) }}">&nbsp;</span>
-    <span class="app-chart-legend__swatch" data-style-background="{{ heatMapColour(15) }}">&nbsp;</span>
-    <span class="app-chart-legend__swatch" data-style-background="{{ heatMapColour(30) }}">&nbsp;</span>
-    <span class="app-chart-legend__swatch" data-style-background="{{ heatMapColour(45) }}">&nbsp;</span>
-    <span class="app-chart-legend__swatch" data-style-background="{{ heatMapColour(60) }}">&nbsp;</span>
-    <span class="app-chart-legend__swatch" data-style-background="{{ heatMapColour(75) }}">&nbsp;</span>
-    <span class="app-chart-legend__swatch" data-style-background="{{ heatMapColour(100) }}">&nbsp;</span>
-    <span class="app-chart-legend__label">100%</span>
-  </div>
-</div>
+    <div class="govuk-!-margin-top-8">
+      <div aria-hidden="true" class="app-chart-legend">
+        <span class="app-chart-legend__label">0%</span>
+        <span class="app-chart-legend__swatch" data-style-background="{{ heatMapColour(0) }}">&nbsp;</span>
+        <span class="app-chart-legend__swatch" data-style-background="{{ heatMapColour(15) }}">&nbsp;</span>
+        <span class="app-chart-legend__swatch" data-style-background="{{ heatMapColour(30) }}">&nbsp;</span>
+        <span class="app-chart-legend__swatch" data-style-background="{{ heatMapColour(45) }}">&nbsp;</span>
+        <span class="app-chart-legend__swatch" data-style-background="{{ heatMapColour(60) }}">&nbsp;</span>
+        <span class="app-chart-legend__swatch" data-style-background="{{ heatMapColour(75) }}">&nbsp;</span>
+        <span class="app-chart-legend__swatch" data-style-background="{{ heatMapColour(100) }}">&nbsp;</span>
+        <span class="app-chart-legend__label">100%</span>
+      </div>
+    </div>
 
-<table class="app-chart-table app-chart-table--heatmap" id="table-{{ chartId }}">
-  <caption class="govuk-visually-hidden">
-    {{ title }}
-  </caption>
+    <table class="app-chart-table app-chart-table--heatmap" id="table-{{ chartId }}">
+      <caption class="govuk-visually-hidden">
+        {{ title }}
+      </caption>
 
-  <thead>
-    <tr>
-      <th scope="col">{{ labelColumn }}</th>
-      {% for column in report.columns %}
-        <th scope="col">
-          {{ valueColumn(column=column, columnIndex=loop.index0) }}
-        </th>
-      {% endfor %}
-    </tr>
-  </thead>
+      <thead>
+        <tr>
+          <th scope="col">{{ labelColumn }}</th>
+          {% for column in report.columns %}
+            <th scope="col">
+              {{ valueColumn(column=column, columnIndex=loop.index0) }}
+            </th>
+          {% endfor %}
+        </tr>
+      </thead>
 
-  <tbody>
-    {% for row in report.rows %}
-      {% set rowIndex = loop.index0 %}
-      {% set total = row.values | sum %}
+      <tbody>
+        {% for row in report.rows %}
+          {% set rowIndex = loop.index0 %}
+          {% set total = row.values | sum %}
 
-      <tr>
-        <td>
-          <strong>
-            {% if row.href %}
-              <a href="{{ row.href }}">{{ row.label }}</a>
-            {% else %}
-              {{ row.label }}
-            {% endif %}
-          </strong>
-          <br />
-          {{ rowTotalValue(total=total, rowIndex=rowIndex) }}
-        </td>
-
-        {% for column in report.columns %}
-          {% set columnIndex = loop.index0 %}
-          {% set value = row.values[columnIndex] %}
-          {% set percentage = value | percentageOf(total) %}
-
-          <td>
-            <span class="app-chart-table--heatmap__cell" data-style-background="{{ heatMapColour(percentage | float) }}">
-              {{ percentage }}
+          <tr>
+            <td>
+              <strong>
+                {% if row.href %}
+                  <a href="{{ row.href }}">{{ row.label }}</a>
+                {% else %}
+                  {{ row.label }}
+                {% endif %}
+              </strong>
               <br />
-              {{ rowValue(value=value, column=column, columnIndex=columnIndex) }}
-            </span>
-          </td>
+              {{ rowTotalValue(total=total, rowIndex=rowIndex) }}
+            </td>
+
+            {% for column in report.columns %}
+              {% set columnIndex = loop.index0 %}
+              {% set value = row.values[columnIndex] %}
+              {% set percentage = value | percentageOf(total) %}
+
+              <td>
+                <span class="app-chart-table--heatmap__cell" data-style-background="{{ heatMapColour(percentage | float) }}">
+                  {{ percentage }}
+                  <br />
+                  {{ rowValue(value=value, column=column, columnIndex=columnIndex) }}
+                </span>
+              </td>
+            {% endfor %}
+          </tr>
+
+          {% if loop.first %}
+            <tr aria-hidden="true"><td colspan="{{ (report.columns | length) + 1 }}"></td></tr>
+          {% endif %}
         {% endfor %}
-      </tr>
+      </tbody>
+    </table>
 
-      {% if loop.first %}
-        <tr aria-hidden="true"><td colspan="{{ (report.columns | length) + 1 }}"></td></tr>
-      {% endif %}
-    {% endfor %}
-  </tbody>
-</table>
-
-{% endcall %}
+  {% endcall %}
 
 {% endmacro %}

--- a/server/views/partials/analytics/chartBasePercentageBars.njk
+++ b/server/views/partials/analytics/chartBasePercentageBars.njk
@@ -23,90 +23,90 @@
   rowValue=rowValue
 ) %}
 
-{% call chartBase(
-  title=title,
-  guidance=guidance,
-  chartId=chartId,
-  googleAnalyticsCategory=googleAnalyticsCategory,
-  activeCaseload=activeCaseload,
-  form=form,
-  csrfToken=csrfToken,
-  report=report
-) %}
+  {% call chartBase(
+    title=title,
+    guidance=guidance,
+    chartId=chartId,
+    googleAnalyticsCategory=googleAnalyticsCategory,
+    activeCaseload=activeCaseload,
+    form=form,
+    csrfToken=csrfToken,
+    report=report
+  ) %}
 
-<table class="app-chart-table app-chart-table--bars app-chart-table--tight-bars app-chart-table--bars-with-3-columns {% if wideLabel %}app-chart-table--bars-wide-label{% endif %}" id="table-{{ chartId }}">
-  <caption class="govuk-visually-hidden">
-    {{ title }}
-  </caption>
+    <table class="app-chart-table app-chart-table--bars app-chart-table--tight-bars app-chart-table--bars-with-3-columns {% if wideLabel %}app-chart-table--bars-wide-label{% endif %}" id="table-{{ chartId }}">
+      <caption class="govuk-visually-hidden">
+        {{ title }}
+      </caption>
 
-  <thead>
-    <tr>
-      <th scope="col">{{ labelColumn }}</th>
-      <th scope="col">{{ valueColumn(column="Percentage", columnIndex=0) }}</th>
-      <th scope="col">{{ valueColumn(column="Number", columnIndex=1) }}</th>
-      <th aria-hidden="true" scope="col"></th>
-    </tr>
-  </thead>
+      <thead>
+        <tr>
+          <th scope="col">{{ labelColumn }}</th>
+          <th scope="col">{{ valueColumn(column="Percentage", columnIndex=0) }}</th>
+          <th scope="col">{{ valueColumn(column="Number", columnIndex=1) }}</th>
+          <th aria-hidden="true" scope="col"></th>
+        </tr>
+      </thead>
 
-  <tbody>
-    {% set grandTotal = 0 %}
-    {% for row in report.rows %}
-      {% set total = row.values | sum %}
-      {% if loop.first %}
-        {% set grandTotal = total %}
-      {% endif %}
+      <tbody>
+        {% set grandTotal = 0 %}
+        {% for row in report.rows %}
+          {% set total = row.values | sum %}
+          {% if loop.first %}
+            {% set grandTotal = total %}
+          {% endif %}
 
-      <tr>
-        <td>
-          <strong>
-            {% if row.href %}
-              <a href="{{ row.href }}">{{ row.label }}</a>
-            {% else %}
-              {{ row.label }}
-            {% endif %}
-          </strong>
-        </td>
-        <td>
-          {{ rowValue(value=total | percentageOf(grandTotal), column="Percentage", columnIndex=0) }}
-        </td>
-        <td>
-          {{ rowValue(value=total | thousands, column="Number", columnIndex=1) }}
-        </td>
-        <td aria-hidden="true" class="app-chart-table__percentage-cell">
-          <span class="app-chart-table__axis-midpoint"></span>
-          <div class="app-chart-table__percentage-cell-bar app-chart-colour--light-blue" data-style-width="{{ total | percentageOf(grandTotal, false) }}">&nbsp;</div>
-        </td>
-      </tr>
+          <tr>
+            <td>
+              <strong>
+                {% if row.href %}
+                  <a href="{{ row.href }}">{{ row.label }}</a>
+                {% else %}
+                  {{ row.label }}
+                {% endif %}
+              </strong>
+            </td>
+            <td>
+              {{ rowValue(value=total | percentageOf(grandTotal), column="Percentage", columnIndex=0) }}
+            </td>
+            <td>
+              {{ rowValue(value=total | thousands, column="Number", columnIndex=1) }}
+            </td>
+            <td aria-hidden="true" class="app-chart-table__percentage-cell">
+              <span class="app-chart-table__axis-midpoint"></span>
+              <div class="app-chart-table__percentage-cell-bar app-chart-colour--light-blue" data-style-width="{{ total | percentageOf(grandTotal, false) }}">&nbsp;</div>
+            </td>
+          </tr>
 
-      {% if loop.first %}
-        <tr aria-hidden="true">
+          {% if loop.first %}
+            <tr aria-hidden="true">
+              <td colspan="3"></td>
+              <td class="app-chart-table__percentage-cell">
+                <span class="app-chart-table__axis-midpoint"></span>
+              </td>
+            </tr>
+          {% endif %}
+
+        {% endfor %}
+      </tbody>
+
+      <tfoot aria-hidden="true">
+        <tr>
           <td colspan="3"></td>
-          <td class="app-chart-table__percentage-cell">
+          <td class="app-chart-table__axis-values">
             <span class="app-chart-table__axis-midpoint"></span>
+            <span class="app-chart-table__axis-value app-chart-table__axis-value--min">0</span>
+            <span class="app-chart-table__axis-value app-chart-table__axis-value--mid">50</span>
+            <span class="app-chart-table__axis-value app-chart-table__axis-value--max">100</span>
           </td>
         </tr>
-      {% endif %}
+        <tr>
+          <td colspan="3"></td>
+          <td>Percentage</td>
+        </tr>
+      </tfoot>
+    </table>
 
-    {% endfor %}
-  </tbody>
-
-  <tfoot aria-hidden="true">
-    <tr>
-      <td colspan="3"></td>
-      <td class="app-chart-table__axis-values">
-        <span class="app-chart-table__axis-midpoint"></span>
-        <span class="app-chart-table__axis-value app-chart-table__axis-value--min">0</span>
-        <span class="app-chart-table__axis-value app-chart-table__axis-value--mid">50</span>
-        <span class="app-chart-table__axis-value app-chart-table__axis-value--max">100</span>
-      </td>
-    </tr>
-    <tr>
-      <td colspan="3"></td>
-      <td>Percentage</td>
-    </tr>
-  </tfoot>
-</table>
-
-{% endcall %}
+  {% endcall %}
 
 {% endmacro %}

--- a/server/views/partials/analytics/chartBaseStackedPercentageBars.njk
+++ b/server/views/partials/analytics/chartBaseStackedPercentageBars.njk
@@ -28,108 +28,108 @@
   rowValue=rowValue
 ) %}
 
-{% set colourChoices = report.columns | chartPalette %}
+  {% set colourChoices = report.columns | chartPalette %}
 
-{% call chartBase(
-  title=title,
-  guidance=guidance,
-  chartId=chartId,
-  googleAnalyticsCategory=googleAnalyticsCategory,
-  activeCaseload=activeCaseload,
-  form=form,
-  csrfToken=csrfToken,
-  report=report
-) %}
+  {% call chartBase(
+    title=title,
+    guidance=guidance,
+    chartId=chartId,
+    googleAnalyticsCategory=googleAnalyticsCategory,
+    activeCaseload=activeCaseload,
+    form=form,
+    csrfToken=csrfToken,
+    report=report
+  ) %}
 
-<div class="govuk-!-margin-top-8">
-  <div aria-hidden="true" class="app-chart-legend">
-    {% for column in report.columns %}
-      <span class="app-chart-legend__swatch {{ colourChoices[loop.index0] }}">&nbsp;</span>
-      <span class="app-chart-legend__label">{{ column }}</span>
-    {% endfor %}
-  </div>
-</div>
-
-<table class="app-chart-table app-chart-table--bars app-chart-table--bars-with-{{ report.columns.length + 1 }}-columns {% if wideLabel %}app-chart-table--bars-wide-label{% endif %}" id="table-{{ chartId }}">
-  <caption class="govuk-visually-hidden">
-    {{ title }}
-  </caption>
-
-  <thead>
-    <tr>
-      <th scope="col">{{ labelColumn }}</th>
-      {% for column in report.columns %}
-        <th scope="col">
-          {{ valueColumn(column=column, columnIndex=loop.index0) }}
-        </th>
-      {% endfor %}
-      <th aria-hidden="true" scope="col"></th>
-    </tr>
-  </thead>
-
-  <tbody>
-    {% for row in report.rows %}
-      {% set rowIndex = loop.index0 %}
-      {% set total = row.values | sum %}
-
-      <tr>
-        <td>
-          <strong>
-            {% if row.href %}
-              <a href="{{ row.href }}">{{ row.label }}</a>
-            {% else %}
-              {{ row.label }}
-            {% endif %}
-          </strong>
-          <br />
-          {{ rowTotalValue(total=total, rowIndex=rowIndex) }}
-        </td>
+    <div class="govuk-!-margin-top-8">
+      <div aria-hidden="true" class="app-chart-legend">
         {% for column in report.columns %}
-          {% set columnIndex = loop.index0 %}
-          {% set value = row.values[columnIndex] %}
-
-          <td>
-            {{ value | percentageOf(total) }}
-            <br />
-            {{ rowValue(value=value, column=column, columnIndex=columnIndex) }}
-          </td>
+          <span class="app-chart-legend__swatch {{ colourChoices[loop.index0] }}">&nbsp;</span>
+          <span class="app-chart-legend__label">{{ column }}</span>
         {% endfor %}
-        <td aria-hidden="true" class="app-chart-table__percentage-cell">
-          <span class="app-chart-table__axis-midpoint"></span>
-          {% for column in report.columns %}
-            <div class="app-chart-table__percentage-cell-bar {{ colourChoices[loop.index0] }}" data-style-width="{{ row.values[loop.index0] | percentageOf(total, false) }}">&nbsp;<br />&nbsp;</div>
-          {% endfor %}
-        </td>
-      </tr>
+      </div>
+    </div>
 
-      {% if loop.first %}
-        <tr aria-hidden="true">
+    <table class="app-chart-table app-chart-table--bars app-chart-table--bars-with-{{ report.columns.length + 1 }}-columns {% if wideLabel %}app-chart-table--bars-wide-label{% endif %}" id="table-{{ chartId }}">
+      <caption class="govuk-visually-hidden">
+        {{ title }}
+      </caption>
+
+      <thead>
+        <tr>
+          <th scope="col">{{ labelColumn }}</th>
+          {% for column in report.columns %}
+            <th scope="col">
+              {{ valueColumn(column=column, columnIndex=loop.index0) }}
+            </th>
+          {% endfor %}
+          <th aria-hidden="true" scope="col"></th>
+        </tr>
+      </thead>
+
+      <tbody>
+        {% for row in report.rows %}
+          {% set rowIndex = loop.index0 %}
+          {% set total = row.values | sum %}
+
+          <tr>
+            <td>
+              <strong>
+                {% if row.href %}
+                  <a href="{{ row.href }}">{{ row.label }}</a>
+                {% else %}
+                  {{ row.label }}
+                {% endif %}
+              </strong>
+              <br />
+              {{ rowTotalValue(total=total, rowIndex=rowIndex) }}
+            </td>
+            {% for column in report.columns %}
+              {% set columnIndex = loop.index0 %}
+              {% set value = row.values[columnIndex] %}
+
+              <td>
+                {{ value | percentageOf(total) }}
+                <br />
+                {{ rowValue(value=value, column=column, columnIndex=columnIndex) }}
+              </td>
+            {% endfor %}
+            <td aria-hidden="true" class="app-chart-table__percentage-cell">
+              <span class="app-chart-table__axis-midpoint"></span>
+              {% for column in report.columns %}
+                <div class="app-chart-table__percentage-cell-bar {{ colourChoices[loop.index0] }}" data-style-width="{{ row.values[loop.index0] | percentageOf(total, false) }}">&nbsp;<br />&nbsp;</div>
+              {% endfor %}
+            </td>
+          </tr>
+
+          {% if loop.first %}
+            <tr aria-hidden="true">
+              <td colspan="{{ (report.columns | length) + 1 }}"></td>
+              <td class="app-chart-table__percentage-cell">
+                <span class="app-chart-table__axis-midpoint"></span>
+              </td>
+            </tr>
+          {% endif %}
+        {% endfor %}
+      </tbody>
+
+      <tfoot aria-hidden="true">
+        <tr>
           <td colspan="{{ (report.columns | length) + 1 }}"></td>
-          <td class="app-chart-table__percentage-cell">
+          <td class="app-chart-table__axis-values">
             <span class="app-chart-table__axis-midpoint"></span>
+            <span class="app-chart-table__axis-value app-chart-table__axis-value--min">0</span>
+            <span class="app-chart-table__axis-value app-chart-table__axis-value--mid">50</span>
+            <span class="app-chart-table__axis-value app-chart-table__axis-value--max">100</span>
           </td>
         </tr>
-      {% endif %}
-    {% endfor %}
-  </tbody>
+        <tr>
+          <td colspan="{{ (report.columns | length) + 1 }}"></td>
+          <td>Percentage</td>
+        </tr>
+      </tfoot>
+    </table>
 
-  <tfoot aria-hidden="true">
-    <tr>
-      <td colspan="{{ (report.columns | length) + 1 }}"></td>
-      <td class="app-chart-table__axis-values">
-        <span class="app-chart-table__axis-midpoint"></span>
-        <span class="app-chart-table__axis-value app-chart-table__axis-value--min">0</span>
-        <span class="app-chart-table__axis-value app-chart-table__axis-value--mid">50</span>
-        <span class="app-chart-table__axis-value app-chart-table__axis-value--max">100</span>
-      </td>
-    </tr>
-    <tr>
-      <td colspan="{{ (report.columns | length) + 1 }}"></td>
-      <td>Percentage</td>
-    </tr>
-  </tfoot>
-</table>
-
-{% endcall %}
+  {% endcall %}
 
 {% endmacro %}

--- a/server/views/partials/analytics/chartTrends.njk
+++ b/server/views/partials/analytics/chartTrends.njk
@@ -11,164 +11,164 @@
   report
 ) %}
 
-{% call chartBase(
-  title=title,
-  guidance=guidance,
-  chartId=chartId,
-  googleAnalyticsCategory=googleAnalyticsCategory,
-  activeCaseload=activeCaseload,
-  form=form,
-  csrfToken=csrfToken,
-  report=report
-) %}
+  {% call chartBase(
+    title=title,
+    guidance=guidance,
+    chartId=chartId,
+    googleAnalyticsCategory=googleAnalyticsCategory,
+    activeCaseload=activeCaseload,
+    form=form,
+    csrfToken=csrfToken,
+    report=report
+  ) %}
 
-{% set trendsOverlayHeight = 300 %} {# NB: must match $trends-overlay-height in SCSS #}
-{% set colourChoices = report.columns | chartPalette %}
+    {% set trendsOverlayHeight = 300 %} {# NB: must match $trends-overlay-height in SCSS #}
+    {% set colourChoices = report.columns | chartPalette %}
 
-{% set report = report | calculateTrendsRange %}
+    {% set report = report | calculateTrendsRange %}
 
-<div class="govuk-!-margin-top-8">
-  <div aria-hidden="true" class="app-chart-legend">
-    {% for column in report.columns %}
-      <span class="app-chart-legend__swatch {{ colourChoices[loop.index0] }}">&nbsp;</span>
-      <span class="app-chart-legend__label">{{ column }}</span>
-    {% endfor %}
-    {% if not report.plotPercentage %}
-      <span class="app-chart-legend__swatch app-chart-legend__swatch--trends">&nbsp;</span>
-      <span class="app-chart-legend__label">
-        {% if report.populationIsTotal %}
-          Prison population
-        {% else %}
-          {{ report.monthlyTotalName }}
-        {% endif %}
-      </span>
-    {% endif %}
-  </div>
-</div>
-
-<div class="app-chart-container">
-
-  <table class="app-chart-table app-chart-table--trends" id="table-{{ chartId }}">
-    <caption class="govuk-visually-hidden">
-      {{ title }}
-    </caption>
-    <thead>
-      <tr aria-hidden="true" class="app-chart-trends-overlay">
-        <td>
-          <span>
-            {% if not report.plotPercentage %}
-              {{ report.verticalAxisTitle }}
+    <div class="govuk-!-margin-top-8">
+      <div aria-hidden="true" class="app-chart-legend">
+        {% for column in report.columns %}
+          <span class="app-chart-legend__swatch {{ colourChoices[loop.index0] }}">&nbsp;</span>
+          <span class="app-chart-legend__label">{{ column }}</span>
+        {% endfor %}
+        {% if not report.plotPercentage %}
+          <span class="app-chart-legend__swatch app-chart-legend__swatch--trends">&nbsp;</span>
+          <span class="app-chart-legend__label">
+            {% if report.populationIsTotal %}
+              Prison population
             {% else %}
-              Percentage
+              {{ report.monthlyTotalName }}
             {% endif %}
           </span>
-        </td>
-        <td colspan="{{ report.rows | length }}">
-          <svg viewbox="0 0 720 {{ trendsOverlayHeight }}" preserveAspectRatio="none" xmlns="http://www.w3.org/2000/svg">
-            {% for gridlineValue in report.range %}
-              {% set gridlineY = report.range.percentage(gridlineValue) * trendsOverlayHeight / 100 %}
-              {% if gridlineY < 1 %}
-                {% set gridlineY = 0.5 %}
-              {% elseif gridlineY > trendsOverlayHeight - 1 %}
-                {% set gridlineY = trendsOverlayHeight - 0.5 %}
-              {% endif %}
-              <line stroke="#b1b4b6 {#- GDS mid-grey -#}" stroke-width="1" stroke-dasharray="2" x1="0" x2="720" y1="{{ gridlineY }}" y2="{{ gridlineY }}" />
-            {% endfor %}
+        {% endif %}
+      </div>
+    </div>
 
-            {% if not report.plotPercentage %}
-              {% set columnWidth = 720 / report.rows.length %}
-              <path stroke="#b1b4b6 {#- GDS mid-grey -#}" stroke-width="3" fill="none" d="
-                {%- for row in report.rows -%}
-                  {%- if loop.first %} M{% else %} L{% endif -%}
-                  {{- (loop.index0 + 0.5) * columnWidth -}},
-                  {{- trendsOverlayHeight - report.range.percentage(row.total) * trendsOverlayHeight / 100 -}}
-                {%- endfor -%}
-              " />
-            {% endif %}
-          </svg>
-        </td>
-      </tr>
-      <tr aria-hidden="true">
-        <td>
-          <div class="app-chart-trends-vertical-axis">
-            {% for gridlineValue in report.range %}
-              <span>{{ gridlineValue | thousands }}</span>
-            {% endfor %}
-          </div>
-        </td>
-        {% for row in report.rows %}
-          {% set rowIndex = loop.index0 %}
+    <div class="app-chart-container">
 
-          <td>
-            <div class="app-chart-table__group app-chart-table__group-of-{{ report.columns.length }}">
-              {% for column in report.columns %}
-                {% set columnIndex = loop.index0 %}
-                <span class="{{ colourChoices[columnIndex] }}" data-style-height="
-                  {%- if not report.plotPercentage -%}
-                    {{ report.range.percentage(row.values[columnIndex]) }}%
-                  {%- else -%}
-                    {%- if row.total === 0 -%}
-                      0
-                    {%- else -%}
-                      {{ report.range.percentage(row.values[columnIndex] / row.total * 100) }}%
-                    {%- endif -%}
-                  {%- endif -%}
-                "></span>
+      <table class="app-chart-table app-chart-table--trends" id="table-{{ chartId }}">
+        <caption class="govuk-visually-hidden">
+          {{ title }}
+        </caption>
+        <thead>
+          <tr aria-hidden="true" class="app-chart-trends-overlay">
+            <td>
+              <span>
+                {% if not report.plotPercentage %}
+                  {{ report.verticalAxisTitle }}
+                {% else %}
+                  Percentage
+                {% endif %}
+              </span>
+            </td>
+            <td colspan="{{ report.rows | length }}">
+              <svg viewbox="0 0 720 {{ trendsOverlayHeight }}" preserveAspectRatio="none" xmlns="http://www.w3.org/2000/svg">
+                {% for gridlineValue in report.range %}
+                  {% set gridlineY = report.range.percentage(gridlineValue) * trendsOverlayHeight / 100 %}
+                  {% if gridlineY < 1 %}
+                    {% set gridlineY = 0.5 %}
+                  {% elseif gridlineY > trendsOverlayHeight - 1 %}
+                    {% set gridlineY = trendsOverlayHeight - 0.5 %}
+                  {% endif %}
+                  <line stroke="#b1b4b6 {#- GDS mid-grey -#}" stroke-width="1" stroke-dasharray="2" x1="0" x2="720" y1="{{ gridlineY }}" y2="{{ gridlineY }}" />
+                {% endfor %}
+
+                {% if not report.plotPercentage %}
+                  {% set columnWidth = 720 / report.rows.length %}
+                  <path stroke="#b1b4b6 {#- GDS mid-grey -#}" stroke-width="3" fill="none" d="
+                    {%- for row in report.rows -%}
+                      {%- if loop.first %} M{% else %} L{% endif -%}
+                      {{- (loop.index0 + 0.5) * columnWidth -}},
+                      {{- trendsOverlayHeight - report.range.percentage(row.total) * trendsOverlayHeight / 100 -}}
+                    {%- endfor -%}
+                  " />
+                {% endif %}
+              </svg>
+            </td>
+          </tr>
+          <tr aria-hidden="true">
+            <td>
+              <div class="app-chart-trends-vertical-axis">
+                {% for gridlineValue in report.range %}
+                  <span>{{ gridlineValue | thousands }}</span>
+                {% endfor %}
+              </div>
+            </td>
+            {% for row in report.rows %}
+              {% set rowIndex = loop.index0 %}
+
+              <td>
+                <div class="app-chart-table__group app-chart-table__group-of-{{ report.columns.length }}">
+                  {% for column in report.columns %}
+                    {% set columnIndex = loop.index0 %}
+                    <span class="{{ colourChoices[columnIndex] }}" data-style-height="
+                      {%- if not report.plotPercentage -%}
+                        {{ report.range.percentage(row.values[columnIndex]) }}%
+                      {%- else -%}
+                        {%- if row.total === 0 -%}
+                          0
+                        {%- else -%}
+                          {{ report.range.percentage(row.values[columnIndex] / row.total * 100) }}%
+                        {%- endif -%}
+                      {%- endif -%}
+                    "></span>
+                  {% endfor %}
+                </div>
+              </td>
+            {% endfor %}
+          </tr>
+          <tr>
+            <th></th>
+            {% for row in report.rows %}
+              {% set yearAndMonth = row.yearAndMonth | splitYearAndMonth %}
+              <th scope="col">
+                <strong>
+                  {{ yearAndMonth.month }}
+                </strong>
+                <br />
+                {{ yearAndMonth.year }}
+              </th>
+            {% endfor %}
+          </tr>
+        </thead>
+        <tbody class="govuk-table__body">
+          {% for column in report.columns %}
+            {% set columnIndex = loop.index0 %}
+
+            <tr>
+              <th scope="row">{{ column }}</th>
+              {% for row in report.rows %}
+                <td>
+                  {{ row.values[columnIndex] | thousands }}
+                  <br />
+                  {{ row.values[columnIndex] | percentageOf(row.total) }}
+                </td>
               {% endfor %}
-            </div>
-          </td>
-        {% endfor %}
-      </tr>
-      <tr>
-        <th></th>
-        {% for row in report.rows %}
-          {% set yearAndMonth = row.yearAndMonth | splitYearAndMonth %}
-          <th scope="col">
-            <strong>
-              {{ yearAndMonth.month }}
-            </strong>
-            <br />
-            {{ yearAndMonth.year }}
-          </th>
-        {% endfor %}
-      </tr>
-    </thead>
-    <tbody class="govuk-table__body">
-      {% for column in report.columns %}
-        {% set columnIndex = loop.index0 %}
-
-        <tr>
-          <th scope="row">{{ column }}</th>
-          {% for row in report.rows %}
-            <td>
-              {{ row.values[columnIndex] | thousands }}
-              <br />
-              {{ row.values[columnIndex] | percentageOf(row.total) }}
-            </td>
+            </tr>
           {% endfor %}
-        </tr>
-      {% endfor %}
-      {% if not report.populationIsTotal %}
-        <tr>
-          <th scope="row">{{ report.monthlyTotalName }}</th>
-          {% for row in report.rows %}
-            <td>
-              {{ row.total | thousands }}
-            </td>
-          {% endfor %}
-        </tr>
-      {% endif %}
-      <tr>
-        <th scope="row">Prison population</th>
-        {% for row in report.rows %}
-          <td>{{ row.population | thousands }}</td>
-        {% endfor %}
-      </tr>
-    </tbody>
-  </table>
+          {% if not report.populationIsTotal %}
+            <tr>
+              <th scope="row">{{ report.monthlyTotalName }}</th>
+              {% for row in report.rows %}
+                <td>
+                  {{ row.total | thousands }}
+                </td>
+              {% endfor %}
+            </tr>
+          {% endif %}
+          <tr>
+            <th scope="row">Prison population</th>
+            {% for row in report.rows %}
+              <td>{{ row.population | thousands }}</td>
+            {% endfor %}
+          </tr>
+        </tbody>
+      </table>
 
-</div>
+    </div>
 
-{% endcall %}
+  {% endcall %}
 
 {% endmacro %}

--- a/server/views/partials/analytics/formFeedback.njk
+++ b/server/views/partials/analytics/formFeedback.njk
@@ -16,95 +16,96 @@
 
 {% macro formFeedback(form, csrfToken) %}
 
-{% set chartUsefulHtml %}
-  {{ _commentTextarea(form, "yes") }}
-{% endset %}
+  {% set chartUsefulHtml %}
+    {{ _commentTextarea(form, "yes") }}
+  {% endset %}
 
-{% set chartNotUsefulHtml %}
-  {% set mainNoReasonField = form.getField("mainNoReason") %}
-  {{ govukRadios({
-    idPrefix: form.formId + "-mainNoReason",
-    name: "mainNoReason",
-    classes: "govuk-radios--small",
-    fieldset: {
-      legend: {
-        text: "Why wasn’t this chart useful?",
-        classes: "govuk-fieldset__legend--s"
-      }
-    },
-    items: [
-      {
-        value: "not-relevant",
-        text: "It’s not relevant to me",
-        checked: mainNoReasonField.value === "not-relevant"
-      },
-      {
-        value: "do-not-understand",
-        text: "I don’t understand it",
-        checked: mainNoReasonField.value === "do-not-understand"
-      },
-      {
-        value: "does-not-show-enough",
-        text: "It doesn’t show me enough",
-        checked: mainNoReasonField.value === "does-not-show-enough"
-      },
-      {
-        value: "what-to-do-with-info",
-        text: "I don’t know what to do with the information",
-        checked: mainNoReasonField.value === "what-to-do-with-info"
-      },
-      {
-        value: "other",
-        text: "Other",
-        checked: mainNoReasonField.value === "other"
-      }
-    ],
-    errorMessage: { text: mainNoReasonField.error } if mainNoReasonField.error else undefined
-  }) }}
-
-  {{ _commentTextarea(form, "no") }}
-{% endset %}
-
-<form id="form-{{ form.formId }}" method="post" novalidate>
-  {% set chartUsefulField = form.getField("chartUseful") %}
-  {{ govukRadios({
-    idPrefix: form.formId + "-chartUseful",
-    name: "chartUseful",
-    fieldset: {
-      legend: {
-        text: "Is this chart useful?",
-        classes: "govuk-visually-hidden"
-      }
-    },
-    items: [
-      {
-        value: "yes",
-        text: "Yes",
-        checked: chartUsefulField.value === "yes",
-        conditional: {
-          html: chartUsefulHtml
+  {% set chartNotUsefulHtml %}
+    {% set mainNoReasonField = form.getField("mainNoReason") %}
+    {{ govukRadios({
+      idPrefix: form.formId + "-mainNoReason",
+      name: "mainNoReason",
+      classes: "govuk-radios--small",
+      fieldset: {
+        legend: {
+          text: "Why wasn’t this chart useful?",
+          classes: "govuk-fieldset__legend--s"
         }
       },
-      {
-        value: "no",
-        text: "No",
-        checked: chartUsefulField.value === "no",
-        conditional: {
-          html: chartNotUsefulHtml
+      items: [
+        {
+          value: "not-relevant",
+          text: "It’s not relevant to me",
+          checked: mainNoReasonField.value === "not-relevant"
+        },
+        {
+          value: "do-not-understand",
+          text: "I don’t understand it",
+          checked: mainNoReasonField.value === "do-not-understand"
+        },
+        {
+          value: "does-not-show-enough",
+          text: "It doesn’t show me enough",
+          checked: mainNoReasonField.value === "does-not-show-enough"
+        },
+        {
+          value: "what-to-do-with-info",
+          text: "I don’t know what to do with the information",
+          checked: mainNoReasonField.value === "what-to-do-with-info"
+        },
+        {
+          value: "other",
+          text: "Other",
+          checked: mainNoReasonField.value === "other"
         }
-      }
-    ],
-    errorMessage: { text: chartUsefulField.error } if chartUsefulField.error else undefined
-  }) }}
+      ],
+      errorMessage: { text: mainNoReasonField.error } if mainNoReasonField.error else undefined
+    }) }}
 
-  <input type="hidden" name="formId" value="{{ form.formId }}" />
-  <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
+    {{ _commentTextarea(form, "no") }}
+  {% endset %}
 
-  {{ govukButton({
-    text: "Submit",
-    classes: "govuk-!-margin-bottom-0",
-    preventDoubleClick: true
-  }) }}
-</form>
+  <form id="form-{{ form.formId }}" method="post" novalidate>
+    {% set chartUsefulField = form.getField("chartUseful") %}
+    {{ govukRadios({
+      idPrefix: form.formId + "-chartUseful",
+      name: "chartUseful",
+      fieldset: {
+        legend: {
+          text: "Is this chart useful?",
+          classes: "govuk-visually-hidden"
+        }
+      },
+      items: [
+        {
+          value: "yes",
+          text: "Yes",
+          checked: chartUsefulField.value === "yes",
+          conditional: {
+            html: chartUsefulHtml
+          }
+        },
+        {
+          value: "no",
+          text: "No",
+          checked: chartUsefulField.value === "no",
+          conditional: {
+            html: chartNotUsefulHtml
+          }
+        }
+      ],
+      errorMessage: { text: chartUsefulField.error } if chartUsefulField.error else undefined
+    }) }}
+
+    <input type="hidden" name="formId" value="{{ form.formId }}" />
+    <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
+
+    {{ govukButton({
+      text: "Submit",
+      classes: "govuk-!-margin-bottom-0",
+      preventDoubleClick: true
+    }) }}
+
+  </form>
 
 {% endmacro %}

--- a/server/views/partials/analytics/reportError.njk
+++ b/server/views/partials/analytics/reportError.njk
@@ -3,8 +3,8 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-three-quarters">
     {{ mojBanner({
-        type: 'information',
-        text: 'There is a problem with this data – try again later'
+      type: 'information',
+      text: 'There is a problem with this data – try again later'
     }) }}
   </div>
 </div>

--- a/server/views/partials/feedbackBanner.njk
+++ b/server/views/partials/feedbackBanner.njk
@@ -7,16 +7,14 @@
 {% block feedbackBanner %}
   {% if feedbackUrl %}
     <div class="govuk-width-container">
-      {{
-        govukPhaseBanner({
-          classes: 'app-feedback-banner',
-          tag: {
-            classes: 'app-feedback-banner__tag',
-            text: "give feedback"
-          },
-          html: feedbackMessage()
-        })
-      }}
+      {{ govukPhaseBanner({
+        classes: 'app-feedback-banner',
+        tag: {
+          classes: 'app-feedback-banner__tag',
+          text: "give feedback"
+        },
+        html: feedbackMessage()
+      }) }}
     </div>
   {% endif %}
 {% endblock feedbackBanner %}

--- a/server/views/partials/layout.njk
+++ b/server/views/partials/layout.njk
@@ -5,13 +5,13 @@
   {% if googleAnalyticsUaId %}
     <!-- Google Analytics -->
     <script nonce="{{ cspNonce }}">
-    window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
-    ga('create', '{{ googleAnalyticsUaId }}', 'auto');
-    {# GA custom dimension 1 is "Active Case Load" -#}
-    {% if user.activeCaseload.id -%}
-      ga('set', 'dimension1', '{{ user.activeCaseload.id }}');
-    {%- endif %}
-    ga('send', 'pageview');
+      window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+      ga('create', '{{ googleAnalyticsUaId }}', 'auto');
+      {# GA custom dimension 1 is "Active Case Load" -#}
+      {% if user.activeCaseload.id -%}
+        ga('set', 'dimension1', '{{ user.activeCaseload.id }}');
+      {%- endif %}
+      ga('send', 'pageview');
     </script>
     <script async src='https://www.google-analytics.com/analytics.js'></script>
     <!-- End Google Analytics -->


### PR DESCRIPTION
**Use 2 spaces** instead of tabs or 4 spaces

Leave some space around macro calls, e.g.

```nunjucks
    <input type="hidden" name="_csrf" value="{{ csrfToken }}" />

    {{ govukButton({
      text: "Submit",
      classes: "govuk-!-margin-bottom-0",
      preventDoubleClick: true
    }) }}

  </form>
```

If a macro call uses a variable set above it's OK to not leave space between the macro call and the `set`, e.g.

```nunjucks
    {# FINE #}
    {% set chartUsefulField = form.getField("chartUseful") %}
    {{ govukRadios({
      idPrefix: form.formId + "-chartUseful",
      name: "chartUseful",
      fieldset: { 
```

Macro calls arguments are indented from opening `{{`, e.g.

```nunjucks
    {# CORRECT #}
    {{ govukButton({
      text: "Submit",
      classes: "govuk-!-margin-bottom-0",
      preventDoubleClick: true
    }) }}

    {# NOT CONSISTENT (or similar) #}
    {{ 
      govukButton({
        text: "Submit",
        classes: "govuk-!-margin-bottom-0",
        preventDoubleClick: true
      }) 
    }}
```

In general, macros definitions, call blocks, and pretty much anything that is contained has same 2-spaces indentation.