### PR TITLE
INC-567: Show ESLint issues style issues as warnings

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -48,7 +48,7 @@
         "@typescript-eslint/semi": 0,
         "import/no-unresolved": "error",
         "prettier/prettier": [
-          "error",
+          "warn",
           {
             "trailingComma": "es5",
             "singleQuote": true,
@@ -102,7 +102,7 @@
       { "devDependencies": ["**/*.test.js", "**/*.test.ts", "**/testutils/**"] }
     ],
     "prettier/prettier": [
-      "error",
+      "warn",
       {
         "trailingComma": "es5",
         "singleQuote": true,


### PR DESCRIPTION
It can be distracting while working on something to see all the red
squiggly lines because you may confuse these for syntax errors.

These style issues are now shown as warning/yellow squiggly lines instead.
So that you know they're important but not AS important as syntax errors.

**NOTE**: This doesn't change the fact warnings would cause CI to fail, so
these will need to be fixed at some point.