### PR TITLE
INC-572: Dropdown for Incentive levels PC trends

### DIFF
--- a/server/routes/analyticsChartsContent.ts
+++ b/server/routes/analyticsChartsContent.ts
@@ -116,57 +116,57 @@ export const ProtectedCharacteristicsChartsContent: Record<string, AnalyticsChar
     googleAnalyticsCategory: 'Incentive level by sexual orientation',
   },
   'trends-incentive-levels-by-age': {
-    title: 'Incentive levels by age - last 12 months',
+    title: 'Incentive levels by age – last 12 months',
     guidance: guidanceTrendsIncentiveLevelsByPc,
     googleAnalyticsCategory: 'Incentive level by age trends',
   },
   'trends-incentive-levels-by-disability': {
-    title: 'Incentive levels by recorded disability - last 12 months',
+    title: 'Incentive levels by recorded disability – last 12 months',
     guidance: guidanceTrendsIncentiveLevelsByPc,
     googleAnalyticsCategory: 'Incentive level by recorded disability trends',
   },
   'trends-incentive-levels-by-ethnicity': {
-    title: 'Incentive levels by ethnicity - last 12 months',
+    title: 'Incentive levels by ethnicity – last 12 months',
     guidance: guidanceTrendsIncentiveLevelsByPc,
     googleAnalyticsCategory: 'Incentive level by ethnicity trends',
   },
   'trends-incentive-levels-by-religion': {
-    title: 'Incentive levels by religion - last 12 months',
+    title: 'Incentive levels by religion – last 12 months',
     guidance: guidanceTrendsIncentiveLevelsByPc,
     googleAnalyticsCategory: 'Incentive level by religion trends',
   },
   'trends-incentive-levels-by-sexual-orientation': {
-    title: 'Incentive levels by sexual orientation - last 12 months',
+    title: 'Incentive levels by sexual orientation – last 12 months',
     guidance: guidanceTrendsIncentiveLevelsByPc,
     googleAnalyticsCategory: 'Incentive level by sexual orientation trends',
   },
   'trends-entries-by-age': {
-    title: 'Comparison of positive and negative behaviour entries by age - last 12 months',
+    title: 'Comparison of positive and negative behaviour entries by age – last 12 months',
     guidance: guidanceTrendsEntriesByPc,
     googleAnalyticsCategory: 'Behaviour entries by age trends',
   },
   'trends-entries-by-disability': {
-    title: 'Comparison of positive and negative behaviour entries by recorded disability - last 12 months',
+    title: 'Comparison of positive and negative behaviour entries by recorded disability – last 12 months',
     guidance: guidanceTrendsEntriesByPc,
     googleAnalyticsCategory: 'Behaviour entries by recorded disability trends',
   },
   'trends-entries-by-ethnicity': {
-    title: 'Comparison of positive and negative behaviour entries by ethnicity - last 12 months',
+    title: 'Comparison of positive and negative behaviour entries by ethnicity – last 12 months',
     guidance: guidanceTrendsEntriesByPc,
     googleAnalyticsCategory: 'Behaviour entries by ethnicity trends',
   },
   'trends-entries-by-religion': {
-    title: 'Comparison of positive and negative behaviour entries by religion - last 12 months',
+    title: 'Comparison of positive and negative behaviour entries by religion – last 12 months',
     guidance: guidanceTrendsEntriesByPc,
     googleAnalyticsCategory: 'Behaviour entries by religion trends',
   },
   'trends-entries-by-sexual-orientation': {
-    title: 'Comparison of positive and negative behaviour entries by sexual orientation - last 12 months',
+    title: 'Comparison of positive and negative behaviour entries by sexual orientation – last 12 months',
     guidance: guidanceTrendsEntriesByPc,
     googleAnalyticsCategory: 'Behaviour entries by sexual orientation trends',
   },
   'entries-by-age': {
-    title: 'Percentage and number of prisoners receiving each behaviour entry type by age - last 28 days',
+    title: 'Percentage and number of prisoners receiving each behaviour entry type by age – last 28 days',
     guidance:
       'Use this chart to see the number of prisoners with different types of behaviour entries for each age grouping. Are there imbalances that need action to make sure incentives work for everyone? Be cautious about small numbers.',
     labelColumn: 'Age',
@@ -174,7 +174,7 @@ export const ProtectedCharacteristicsChartsContent: Record<string, AnalyticsChar
   },
   'entries-by-disability': {
     title:
-      'Percentage and number of prisoners receiving each behaviour entry type by recorded disability - last 28 days',
+      'Percentage and number of prisoners receiving each behaviour entry type by recorded disability – last 28 days',
     guidance:
       'Use this chart to see the number of prisoners with different types of behaviour entries for each disability grouping. Are there imbalances that need action to make sure incentives work for everyone? Be cautious about small numbers.',
     labelColumn: 'Disability',
@@ -182,7 +182,7 @@ export const ProtectedCharacteristicsChartsContent: Record<string, AnalyticsChar
     wideLabel: true,
   },
   'entries-by-ethnicity': {
-    title: 'Percentage and number of prisoners receiving each behaviour entry type by ethnicity - last 28 days',
+    title: 'Percentage and number of prisoners receiving each behaviour entry type by ethnicity – last 28 days',
     guidance:
       'Use this chart to see the number of prisoners with different types of behaviour entries for each ethnic grouping. Are there imbalances that need action to make sure incentives work for everyone? Be cautious about small numbers.',
     labelColumn: 'Ethnicity',
@@ -190,7 +190,7 @@ export const ProtectedCharacteristicsChartsContent: Record<string, AnalyticsChar
     wideLabel: true,
   },
   'entries-by-religion': {
-    title: 'Percentage and number of prisoners receiving each behaviour entry type by religion - last 28 days',
+    title: 'Percentage and number of prisoners receiving each behaviour entry type by religion – last 28 days',
     guidance:
       'Use this chart to see the number of prisoners with different types of behaviour entries for each religious grouping. Are there imbalances that need action to make sure incentives work for everyone? Be cautious about small numbers.',
     labelColumn: 'Religion',
@@ -198,7 +198,7 @@ export const ProtectedCharacteristicsChartsContent: Record<string, AnalyticsChar
   },
   'entries-by-sexual-orientation': {
     title:
-      'Percentage and number of prisoners receiving each behaviour entry type by sexual orientation - last 28 days',
+      'Percentage and number of prisoners receiving each behaviour entry type by sexual orientation – last 28 days',
     guidance:
       'Use this chart to see the number of prisoners with different types of behaviour entries for each sexual orientation grouping. Are there imbalances that need action to make sure incentives work for everyone? Be cautious about small numbers.',
     labelColumn: 'Sexual orientation',

--- a/server/routes/analyticsRouter.ts
+++ b/server/routes/analyticsRouter.ts
@@ -218,13 +218,23 @@ export default function routes(router: Router): Router {
         ? knownGroupsFor(protectedCharacteristic).filter(ageGroup => ageGroup !== AgeYoungPeople)
         : knownGroupsFor(protectedCharacteristic)
 
+    const trendsIncentiveLevelsGroup = (req.query.trendsIncentiveLevelsGroup || groupsForCharacteristic[0]) as string
     const trendsEntriesGroup = (req.query.trendsEntriesGroup || groupsForCharacteristic[0]) as string
 
-    if (!groupsForCharacteristic.includes(trendsEntriesGroup)) {
+    if (
+      !groupsForCharacteristic.includes(trendsIncentiveLevelsGroup) ||
+      !groupsForCharacteristic.includes(trendsEntriesGroup)
+    ) {
       next(new NotFound())
       return
     }
 
+    const trendsIncentiveLevelsOptions = groupsForCharacteristic.map(name => {
+      return {
+        value: name,
+        selected: name === trendsIncentiveLevelsGroup,
+      }
+    })
     const trendsEntriesOptions = groupsForCharacteristic.map(name => {
       return {
         value: name,
@@ -261,6 +271,7 @@ export default function routes(router: Router): Router {
       ...templateContext(req),
       characteristicName,
       characteristicOptions,
+      trendsIncentiveLevelsOptions,
       trendsEntriesOptions,
       groupSelectLabel,
       incentiveLevelsByCharacteristic,

--- a/server/routes/analyticsRouter.ts
+++ b/server/routes/analyticsRouter.ts
@@ -273,6 +273,8 @@ export default function routes(router: Router): Router {
       characteristicOptions,
       trendsIncentiveLevelsOptions,
       trendsEntriesOptions,
+      trendsIncentiveLevelsGroup,
+      trendsEntriesGroup,
       groupSelectLabel,
       incentiveLevelsByCharacteristic,
       incentiveLevelsTrendsByCharacteristic,

--- a/server/routes/analyticsRouter.ts
+++ b/server/routes/analyticsRouter.ts
@@ -23,25 +23,25 @@ import ChartFeedbackForm from './forms/chartFeedbackForm'
 import PrisonRegister from '../data/prisonRegister'
 
 export const protectedCharacteristicRoutes = {
-  age: { label: 'Age', groupSelectLabel: 'Select an age', characteristic: ProtectedCharacteristic.Age },
+  age: { label: 'Age', groupDropdownLabel: 'Select an age', characteristic: ProtectedCharacteristic.Age },
   ethnicity: {
     label: 'Ethnicity',
-    groupSelectLabel: 'Select an ethnicity',
+    groupDropdownLabel: 'Select an ethnicity',
     characteristic: ProtectedCharacteristic.Ethnicity,
   },
   disability: {
     label: 'Recorded disability',
-    groupSelectLabel: 'Select a recorded disability',
+    groupDropdownLabel: 'Select a recorded disability',
     characteristic: ProtectedCharacteristic.Disability,
   },
   religion: {
     label: 'Religion',
-    groupSelectLabel: 'Select a religion',
+    groupDropdownLabel: 'Select a religion',
     characteristic: ProtectedCharacteristic.Religion,
   },
   'sexual-orientation': {
     label: 'Sexual orientation',
-    groupSelectLabel: 'Select a sexual orientation',
+    groupDropdownLabel: 'Select a sexual orientation',
     characteristic: ProtectedCharacteristic.SexualOrientation,
   },
 } as const
@@ -241,7 +241,7 @@ export default function routes(router: Router): Router {
         selected: name === trendsEntriesGroup,
       }
     })
-    const { groupSelectLabel } = protectedCharacteristicRoutes[characteristicName]
+    const { groupDropdownLabel } = protectedCharacteristicRoutes[characteristicName]
 
     const s3Client = new S3Client(config.s3)
     const analyticsService = new AnalyticsService(s3Client, urlForLocation)
@@ -275,7 +275,7 @@ export default function routes(router: Router): Router {
       trendsEntriesOptions,
       trendsIncentiveLevelsGroup,
       trendsEntriesGroup,
-      groupSelectLabel,
+      groupDropdownLabel,
       incentiveLevelsByCharacteristic,
       incentiveLevelsTrendsByCharacteristic,
       behaviourEntryTrendsByCharacteristic,

--- a/server/views/pages/analytics/protectedCharacteristicTemplate.njk
+++ b/server/views/pages/analytics/protectedCharacteristicTemplate.njk
@@ -87,10 +87,50 @@
   </div>
 
   {% if featureFlags.showAnalyticsPcTrends %}
+
+    {% macro pcGroupDropdown(
+      chartId,
+      characteristicName,
+      groupSelectLabel,
+      fieldName,
+      options
+    ) %}
+
+      <form id="form-select-{{ fieldName }}" method="get" action="#heading-{{ chartId }}" novalidate>
+        <input type="hidden" name="characteristic" value="{{ characteristicName }}">
+        <div class="govuk-form-group">
+          <label class="govuk-label" for="{{ fieldName }}">
+            {{ groupSelectLabel }}
+          </label>
+          <select class="govuk-select" id="{{ fieldName }}" name="{{ fieldName }}">
+            {%- for option in options -%}
+              <option value="{{ option.value }}" {% if option.selected %}selected{% endif %}>{{ option.value }}</option>
+            {%- endfor %}
+          </select>
+
+          <button class="govuk-button govuk-!-margin-left-2" data-module="govuk-button" data-prevent-double-click="true">
+            Show results
+          </button>
+        </div>
+      </form>
+
+    {% endmacro %}
+
     <div class="govuk-grid-row">
       <section class="govuk-grid-column-two-thirds govuk-!-margin-bottom-9">
 
         {% set chartId = "trends-incentive-levels-by-" + characteristicName %}
+
+        {% set afterHeaderHtml %}
+          {{ pcGroupDropdown(
+              chartId,
+              characteristicName,
+              groupSelectLabel,
+              fieldName="trendsIncentiveLevelsGroup",
+              options=trendsIncentiveLevelsOptions
+          ) }}
+        {% endset %}
+
         {{ chartTrends(
           title=ProtectedCharacteristicsChartsContent[chartId].title,
           guidance=ProtectedCharacteristicsChartsContent[chartId].guidance,
@@ -100,7 +140,8 @@
           form=forms[chartId],
           csrfToken=csrfToken,
           report=incentiveLevelsTrendsByCharacteristic,
-          showTotalPopulation=false
+          showTotalPopulation=false,
+          afterHeaderHtml=afterHeaderHtml
         ) }}
 
       </section>
@@ -112,23 +153,13 @@
         {% set chartId = "trends-entries-by-" + characteristicName %}
 
         {% set afterHeaderHtml %}
-          <form id="form-select-trendsEntriesGroup" method="get" action="#heading-{{ chartId }}" novalidate>
-            <input type="hidden" name="characteristic" value="{{ characteristicName }}">
-            <div class="govuk-form-group">
-              <label class="govuk-label" for="trendsEntriesGroup">
-                {{ groupSelectLabel }}
-              </label>
-              <select class="govuk-select" id="trendsEntriesGroup" name="trendsEntriesGroup">
-                {%- for option in trendsEntriesOptions -%}
-                  <option value="{{ option.value }}" {% if option.selected %}selected{% endif %}>{{ option.value }}</option>
-                {%- endfor %}
-              </select>
-
-              <button class="govuk-button govuk-!-margin-left-2" data-module="govuk-button" data-prevent-double-click="true">
-                Show results
-              </button>
-            </div>
-          </form>
+          {{ pcGroupDropdown(
+              chartId,
+              characteristicName,
+              groupSelectLabel,
+              fieldName="trendsEntriesGroup",
+              options=trendsEntriesOptions
+          ) }}
         {% endset %}
 
         {{ chartTrends(

--- a/server/views/pages/analytics/protectedCharacteristicTemplate.njk
+++ b/server/views/pages/analytics/protectedCharacteristicTemplate.njk
@@ -91,7 +91,7 @@
     {% macro pcGroupDropdown(
       chartId,
       hiddenInputs,
-      groupSelectLabel,
+      groupDropdownLabel,
       fieldName,
       options
     ) %}
@@ -103,7 +103,7 @@
 
         <div class="govuk-form-group">
           <label class="govuk-label" for="{{ fieldName }}">
-            {{ groupSelectLabel }}
+            {{ groupDropdownLabel }}
           </label>
           <select class="govuk-select" id="{{ fieldName }}" name="{{ fieldName }}">
             {%- for option in options -%}
@@ -133,7 +133,7 @@
           {{ pcGroupDropdown(
               chartId,
               hiddenInputs,
-              groupSelectLabel,
+              groupDropdownLabel,
               fieldName="trendsIncentiveLevelsGroup",
               options=trendsIncentiveLevelsOptions
           ) }}
@@ -169,7 +169,7 @@
           {{ pcGroupDropdown(
               chartId,
               hiddenInputs,
-              groupSelectLabel,
+              groupDropdownLabel,
               fieldName="trendsEntriesGroup",
               options=trendsEntriesOptions
           ) }}

--- a/server/views/pages/analytics/protectedCharacteristicTemplate.njk
+++ b/server/views/pages/analytics/protectedCharacteristicTemplate.njk
@@ -90,14 +90,17 @@
 
     {% macro pcGroupDropdown(
       chartId,
-      characteristicName,
+      hiddenInputs,
       groupSelectLabel,
       fieldName,
       options
     ) %}
 
       <form id="form-select-{{ fieldName }}" method="get" action="#heading-{{ chartId }}" novalidate>
-        <input type="hidden" name="characteristic" value="{{ characteristicName }}">
+        {%- for name, value in hiddenInputs -%}
+          <input type="hidden" name="{{ name }}" value="{{ value }}">
+        {%- endfor %}
+
         <div class="govuk-form-group">
           <label class="govuk-label" for="{{ fieldName }}">
             {{ groupSelectLabel }}
@@ -122,9 +125,14 @@
         {% set chartId = "trends-incentive-levels-by-" + characteristicName %}
 
         {% set afterHeaderHtml %}
+          {% set hiddenInputs = {
+            characteristic: characteristicName,
+            trendsEntriesGroup: trendsEntriesGroup
+          } %}
+
           {{ pcGroupDropdown(
               chartId,
-              characteristicName,
+              hiddenInputs,
               groupSelectLabel,
               fieldName="trendsIncentiveLevelsGroup",
               options=trendsIncentiveLevelsOptions
@@ -153,9 +161,14 @@
         {% set chartId = "trends-entries-by-" + characteristicName %}
 
         {% set afterHeaderHtml %}
+          {% set hiddenInputs = {
+            characteristic: characteristicName,
+            trendsIncentiveLevelsGroup: trendsIncentiveLevelsGroup
+          } %}
+
           {{ pcGroupDropdown(
               chartId,
-              characteristicName,
+              hiddenInputs,
               groupSelectLabel,
               fieldName="trendsEntriesGroup",
               options=trendsEntriesOptions


### PR DESCRIPTION
- added dropdown
- moved dropdown markup in a little macro used in both PC trends charts
- tweaked dropdowns form to avoid reset of other chart selected PC group on select
- corrected hyphen character in charts content `–`