### PR TITLE
INC-572: Fix Incentive levels PC trends not using correct PC group

### DIFF
--- a/server/routes/analyticsRouter.ts
+++ b/server/routes/analyticsRouter.ts
@@ -195,9 +195,6 @@ export default function routes(router: Router): Router {
     const characteristicName = (req.query.characteristic || 'age') as string
     const activeCaseLoad = res.locals.user.activeCaseload.id
 
-    // TODO: Hardcoded for now. Take value from query param
-    const protectedCharacteristicGroup = '26-35'
-
     if (!(characteristicName in protectedCharacteristicRoutes)) {
       next(new NotFound())
       return
@@ -251,7 +248,7 @@ export default function routes(router: Router): Router {
       analyticsService.getIncentiveLevelTrendsByCharacteristic(
         activeCaseLoad,
         protectedCharacteristic,
-        protectedCharacteristicGroup
+        trendsIncentiveLevelsGroup
       ),
       analyticsService.getBehaviourEntryTrendsByProtectedCharacteristic(
         activeCaseLoad,


### PR DESCRIPTION
For some reason (probably messed up git stash/rebase) code was still
using hardcoded value instead of query param value (meaning non-Age
PC would always have 0 rows matching)