### PR TITLE
INC-567: Exclude folders without server-side code from typescript compilation

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,6 +18,6 @@
     "experimentalDecorators": true,
     "typeRoots": ["./server/@types", "./node_modules/@types"]
   },
-  "exclude": ["node_modules", "assets/**/*.js", "integration_tests", "dist"],
+  "exclude": ["node_modules", "assets", "dist", "helm_deploy", "integration_tests", "test_results"],
   "include": ["**/*.js", "**/*.ts"]
 }


### PR DESCRIPTION
… in order to not try to compile extraneous TS/JS code (for example, jest-coverage output)