### PR TITLE
INC-588: Increase k8s resource limit

### DIFF
--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -19,3 +19,7 @@ generic-service:
     TOKEN_VERIFICATION_API_URL: "https://token-verification-api.prison.service.justice.gov.uk"
     FEATURE_HIDE_DAYS_COLUMNS_IN_INCENTIVES_TABLE: "true"
     FEATURE_SHOW_ANALYTICS_PC_TRENDS: "false"
+
+  resources:
+    limits:
+      memory: 2048Mi


### PR DESCRIPTION
The `LimitRange` k8s resource in the `prod` namespace has been updated
but the limit on the Pods also need to change accordingly.

See: `generic-service` helm chart's values file:
https://github.com/ministryofjustice/hmpps-helm-charts/blob/main/charts/generic-service/values.yaml#L73-L83