### PR TITLE
INC-594: Remove info banner from Incentives table pages

### DIFF
--- a/server/routes/incentivesTable.test.ts
+++ b/server/routes/incentivesTable.test.ts
@@ -50,17 +50,6 @@ describe('GET /incentive-summary/:locationPrefix', () => {
         app.locals.featureFlags.hideDaysColumnsInIncentivesTable = true
       })
 
-      it('information banner is shown', () => {
-        return request(app)
-          .get('/incentive-summary/MDI-2')
-          .expect('Content-Type', /html/)
-          .expect(res => {
-            expect(res.text).toContain(
-              'Review details have been removed from this table while we investigate the data.',
-            )
-          })
-      })
-
       it('table heading does not mention review dates', () => {
         return request(app)
           .get('/incentive-summary/MDI-2')
@@ -74,17 +63,6 @@ describe('GET /incentive-summary/:locationPrefix', () => {
     describe(`when off`, () => {
       beforeAll(() => {
         app.locals.featureFlags.hideDaysColumnsInIncentivesTable = false
-      })
-
-      it('information banner is not shown', () => {
-        return request(app)
-          .get('/incentive-summary/MDI-2')
-          .expect('Content-Type', /html/)
-          .expect(res => {
-            expect(res.text).not.toContain(
-              'Review details have been removed from this table while we work on improving the data.',
-            )
-          })
       })
 
       it('table heading mentions review dates', () => {

--- a/server/views/pages/incentives-table.njk
+++ b/server/views/pages/incentives-table.njk
@@ -6,21 +6,6 @@
 {% set pageTitle = applicationName + " – Incentives information" %}
 
 {% block content %}
-  {% if featureFlags.hideDaysColumnsInIncentivesTable %}
-    {%- from "moj/components/banner/macro.njk" import mojBanner -%}
-
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-two-thirds">
-
-        {{ mojBanner({
-          type: "information",
-          text: "Review details have been removed from this table while we investigate the data."
-        }) }}
-
-      </div>
-    </div>
-  {% endif %}
-
   <h1 class="govuk-heading-xl govuk-!-margin-bottom-4">
     Incentive information
   </h1>


### PR DESCRIPTION
When the 'Days since last review'/'Days on level' columns were removed a info banner highlighting this was
removed while data was being "investigated".

We want to remove this info banner now.