### PR TITLE
Anchor protected characteristic selector to top of page

### DIFF
--- a/server/views/pages/analytics/protectedCharacteristicTemplate.njk
+++ b/server/views/pages/analytics/protectedCharacteristicTemplate.njk
@@ -28,7 +28,7 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <form id="form-select-characteristic" method="get" novalidate>
+      <form id="form-select-characteristic" method="get" action="#form-select-characteristic" novalidate>
         <div class="govuk-form-group">
           <label class="govuk-label" for="characteristic">
             Select a protected characteristic


### PR DESCRIPTION
If one of the other 2 selectors on the page are used, they anchor to their associated heading. That anchor is preserved when this selector is used, so it's possible for this form to take you to the wrong part of the page.