### PR TITLE
INC-612: Add HMPPS Auth domain to those allowed in form actions security policy

### DIFF
--- a/server/middleware/setUpWebSecurity.ts
+++ b/server/middleware/setUpWebSecurity.ts
@@ -2,6 +2,8 @@ import crypto from 'crypto'
 import express, { Router, Request, Response } from 'express'
 import helmet from 'helmet'
 
+import config from '../config'
+
 export default function setUpWebSecurity(): Router {
   const router = express.Router()
 
@@ -17,6 +19,7 @@ export default function setUpWebSecurity(): Router {
       contentSecurityPolicy: {
         directives: {
           defaultSrc: ["'self'"],
+          formAction: ["'self'", new URL(config.apis.hmppsAuth.url).hostname],
           scriptSrc: [
             "'self'",
             '*.google-analytics.com',


### PR DESCRIPTION
… so that when a user token expires, a redirect is permitted via HMPPS Auth in Chromium
c.f https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/form-action