### PR TITLE
INC-590: Use correct size for link to switch region view

### DIFF
--- a/server/views/partials/analytics/layout.njk
+++ b/server/views/partials/analytics/layout.njk
@@ -7,7 +7,9 @@
       <h1 class="govuk-heading-xl">
         {{ pgdRegionName }}
       </h1>
-      <a href="/analytics/select-pgd-region" class="govuk-link">Select another prison group</a>
+      <p>
+        <a href="/analytics/select-pgd-region">Select another prison group</a>
+      </p>
     </div>
 
     {% set incentiveLevelsLink = "/analytics/" + pgdRegionCode + "/incentive-levels" %}


### PR DESCRIPTION
An `a` element only contained within `div`s has a default/arbitrary size