### PR TITLE
INC-628: Show prison names in regional charts (not prisons IDs)

### DIFF
--- a/server/services/analyticsService.test.ts
+++ b/server/services/analyticsService.test.ts
@@ -313,7 +313,7 @@ describe('AnalyticsService', () => {
 
       expect(rows).toEqual([
         { href: undefined, label: 'All', values: [105, 155] },
-        { href: '', label: 'WRI', values: [105, 155] },
+        { href: '', label: 'Whitemoor (HMP)', values: [105, 155] },
       ])
     })
 
@@ -399,7 +399,7 @@ describe('AnalyticsService', () => {
 
       expect(rows).toEqual([
         { href: undefined, label: 'All', values: [50, 67, 10, 199] },
-        { href: '', label: 'WRI', values: [50, 67, 10, 199] },
+        { href: '', label: 'Whitemoor (HMP)', values: [50, 67, 10, 199] },
       ])
     })
 
@@ -491,7 +491,7 @@ describe('AnalyticsService', () => {
 
       expect(rows).toEqual([
         { href: undefined, label: 'All', values: [12, 90, 217] },
-        { href: '', label: 'WRI', values: [12, 90, 217] },
+        { href: '', label: 'Whitemoor (HMP)', values: [12, 90, 217] },
       ])
     })
 


### PR DESCRIPTION
I've also made the `AnalyticsService` a bit more explicit by introducing a few functions (e.g. `isNational()`, `isRegional()`, `isPrisonLevel()`) so that conditions are more clear.