### PR TITLE
INC-638: Add further fallback colours to the chart palette

### DIFF
--- a/assets/sass/components/_chart-colours.scss
+++ b/assets/sass/components/_chart-colours.scss
@@ -1,21 +1,21 @@
 .app-chart-colour--light-blue {
-  background: govuk-colour("light-blue"); // miro ~ #5695ca
+  background: govuk-colour("light-blue");
 }
 
 .app-chart-colour--dark-blue {
-  background: govuk-colour("dark-blue"); // miro ~ #003078
+  background: govuk-colour("dark-blue");
 }
 
 .app-chart-colour--turquoise {
-  background: govuk-colour("turquoise"); // miro ~ #27a197
+  background: govuk-colour("turquoise");
 }
 
 .app-chart-colour--yellow {
-  background: govuk-colour("yellow"); // miro ~ #ffdd04
+  background: govuk-colour("yellow");
 }
 
 .app-chart-colour--pink {
-  background: govuk-colour("pink"); // rarely expected to be used
+  background: govuk-colour("pink");
 }
 
 .app-chart-colour--mid-grey {

--- a/assets/sass/components/_chart-colours.scss
+++ b/assets/sass/components/_chart-colours.scss
@@ -15,9 +15,21 @@
 }
 
 .app-chart-colour--pink {
-  background: govuk-colour("pink"); // not expected to be used: presence in chart indicates unforeseen column set
+  background: govuk-colour("pink"); // rarely expected to be used
 }
 
 .app-chart-colour--mid-grey {
   background: govuk-colour("mid-grey");
+}
+
+.app-chart-colour--orange {
+  background: govuk-colour("orange"); // not expected to be used: presence in chart indicates unforeseen column set
+}
+
+.app-chart-colour--light-green {
+  background: govuk-colour("light-green"); // not expected to be used: presence in chart indicates unforeseen column set
+}
+
+.app-chart-colour--red {
+  background: govuk-colour("red"); // not expected to be used: colour palette has ended
 }

--- a/server/utils/analytics.test.ts
+++ b/server/utils/analytics.test.ts
@@ -9,12 +9,13 @@ describe.each([
   ],
   [
     'with extended incentive levels',
-    ['Basic', 'Standard', 'Enhanced', 'Enhanced 2'],
+    ['Basic', 'Standard', 'Enhanced', 'Enhanced 2', 'Enhanced 3'],
     [
       'app-chart-colour--light-blue',
       'app-chart-colour--dark-blue',
       'app-chart-colour--turquoise',
       'app-chart-colour--yellow',
+      'app-chart-colour--pink',
     ],
   ],
   [
@@ -39,13 +40,14 @@ describe.each([
   ],
   [
     'with an unexpected incentive level',
-    ['Basic', 'Standard', 'Enhanced', 'Enhanced 2', 'Unexpected'],
+    ['Basic', 'Standard', 'Enhanced', 'Enhanced 2', 'Enhanced 3', 'Unexpected'],
     [
       'app-chart-colour--light-blue',
       'app-chart-colour--dark-blue',
       'app-chart-colour--turquoise',
       'app-chart-colour--yellow',
       'app-chart-colour--pink',
+      'app-chart-colour--mid-grey', // first colour that is not normally expected
     ],
   ],
   [
@@ -55,6 +57,7 @@ describe.each([
       'Standard',
       'Enhanced',
       'Enhanced 2',
+      'Enhanced 3',
       'Unexpected 1',
       'Unexpected 2',
       'Unexpected 3',
@@ -67,9 +70,10 @@ describe.each([
       'app-chart-colour--turquoise',
       'app-chart-colour--yellow',
       'app-chart-colour--pink',
-      'app-chart-colour--mid-grey',
+      'app-chart-colour--mid-grey', // first colour that is not normally expected
       'app-chart-colour--orange',
       'app-chart-colour--light-green',
+      'app-chart-colour--red', // colour palette has ended
       'app-chart-colour--red', // colour palette has ended
     ],
   ],

--- a/server/utils/analytics.test.ts
+++ b/server/utils/analytics.test.ts
@@ -50,7 +50,17 @@ describe.each([
   ],
   [
     'with several unexpected incentive levels',
-    ['Basic', 'Standard', 'Enhanced', 'Enhanced 2', 'Unexpected 1', 'Unexpected 2', 'Unexpected 3'],
+    [
+      'Basic',
+      'Standard',
+      'Enhanced',
+      'Enhanced 2',
+      'Unexpected 1',
+      'Unexpected 2',
+      'Unexpected 3',
+      'Unexpected 4',
+      'Unexpected 5',
+    ],
     [
       'app-chart-colour--light-blue',
       'app-chart-colour--dark-blue',
@@ -58,7 +68,9 @@ describe.each([
       'app-chart-colour--yellow',
       'app-chart-colour--pink',
       'app-chart-colour--mid-grey',
-      'app-chart-colour--pink',
+      'app-chart-colour--orange',
+      'app-chart-colour--light-green',
+      'app-chart-colour--red', // colour palette has ended
     ],
   ],
   [

--- a/server/utils/analytics.ts
+++ b/server/utils/analytics.ts
@@ -10,6 +10,7 @@ export const palette = [
   'app-chart-colour--yellow',
   'app-chart-colour--pink',
   'app-chart-colour--mid-grey',
+  // colours below are not expected to be used: presence in chart indicates unforeseen values
   'app-chart-colour--orange',
   'app-chart-colour--light-green',
 ] as const
@@ -33,6 +34,9 @@ export function makeChartPalette(columns: string[]): Colour[] {
     }
     if (column === 'Enhanced 2' || column === 'Both') {
       return takeColour('app-chart-colour--yellow')
+    }
+    if (column === 'Enhanced 3') {
+      return takeColour('app-chart-colour--pink')
     }
     if (column === 'None') {
       return takeColour('app-chart-colour--mid-grey')

--- a/server/utils/analytics.ts
+++ b/server/utils/analytics.ts
@@ -10,8 +10,10 @@ export const palette = [
   'app-chart-colour--yellow',
   'app-chart-colour--pink',
   'app-chart-colour--mid-grey',
+  'app-chart-colour--orange',
+  'app-chart-colour--light-green',
 ] as const
-export type Colour = typeof palette[number]
+export type Colour = typeof palette[number] | 'app-chart-colour--red' // red is the final fallback
 
 export function makeChartPalette(columns: string[]): Colour[] {
   let availableColours = [...palette]
@@ -35,7 +37,7 @@ export function makeChartPalette(columns: string[]): Colour[] {
     if (column === 'None') {
       return takeColour('app-chart-colour--mid-grey')
     }
-    return availableColours.shift() ?? 'app-chart-colour--pink'
+    return availableColours.shift() ?? 'app-chart-colour--red'
   })
 }
 


### PR DESCRIPTION
… which should not be needed as the source data is pre-processed before it reaches this app and should have no incentive levels other than:
• Basic
• Standard
• Enhanced
• Enhanced 2
• Enhanced 3
• and a catch-all-others: “New incentive”
I.e. 6 colours should have been sufficient anyway