### PR TITLE
INC-666: Fix population labels for national/regional trends charts

### DIFF
--- a/integration_tests/e2e/analytics/behaviourEntries.cy.ts
+++ b/integration_tests/e2e/analytics/behaviourEntries.cy.ts
@@ -53,7 +53,6 @@ context('Analytics section > Behaviour entries page', () => {
       // remove header column
       positivesRow.shift()
       negativesRow.shift()
-      populationRow.shift()
 
       expect(positivesRow.map(text => text.split(/\s/)[0])).to.deep.equal(
         // monthly positive entries
@@ -65,7 +64,7 @@ context('Analytics section > Behaviour entries page', () => {
       )
       expect(populationRow).to.deep.equal(
         // monthly average population
-        ['917', '932', '937', '928', '921', '926', '930', '935', '920', '915', '922', '909'],
+        ['Prison population', '917', '932', '937', '928', '921', '926', '930', '935', '920', '915', '922', '909'],
       )
     })
   })
@@ -270,7 +269,6 @@ context('Pgd Region selection > National > Analytics section > Behaviour entries
       // remove header column
       positivesRow.shift()
       negativesRow.shift()
-      populationRow.shift()
 
       expect(positivesRow.map(text => text.split(/\s/)[0])).to.deep.equal(
         // monthly positive entries
@@ -282,7 +280,21 @@ context('Pgd Region selection > National > Analytics section > Behaviour entries
       )
       expect(populationRow).to.deep.equal(
         // monthly average population
-        ['3,077', '3,070', '3,059', '3,047', '3,036', '3,057', '3,060', '3,066', '3,054', '3,059', '3,064', '3,069'],
+        [
+          'National population',
+          '3,077',
+          '3,070',
+          '3,059',
+          '3,047',
+          '3,036',
+          '3,057',
+          '3,060',
+          '3,066',
+          '3,054',
+          '3,059',
+          '3,064',
+          '3,069',
+        ],
       )
     })
   })
@@ -331,7 +343,6 @@ context('Pgd Region selection > LTHS > Analytics section > Behaviour entries pag
       // remove header column
       positivesRow.shift()
       negativesRow.shift()
-      populationRow.shift()
 
       expect(positivesRow.map(text => text.split(/\s/)[0])).to.deep.equal(
         // monthly positive entries
@@ -343,7 +354,7 @@ context('Pgd Region selection > LTHS > Analytics section > Behaviour entries pag
       )
       expect(populationRow).to.deep.equal(
         // monthly average population
-        ['372', '342', '322', '315', '312', '317', '315', '314', '318', '323', '321', '319'],
+        ['Total group population', '372', '342', '322', '315', '312', '317', '315', '314', '318', '323', '321', '319'],
       )
     })
   })

--- a/integration_tests/e2e/analytics/incentiveLevels.cy.ts
+++ b/integration_tests/e2e/analytics/incentiveLevels.cy.ts
@@ -41,7 +41,6 @@ context('Analytics section > Incentive levels page', () => {
       const [_basicRow, standardRow, _enhancedRow, populationRow] = rows
       // remove header column
       standardRow.shift()
-      populationRow.shift()
 
       expect(standardRow.map(text => text.split(/\s/)[0])).to.deep.equal(
         // monthly average population on standard level
@@ -49,7 +48,7 @@ context('Analytics section > Incentive levels page', () => {
       )
       expect(populationRow).to.deep.equal(
         // monthly average population
-        ['917', '932', '937', '928', '921', '926', '930', '935', '920', '915', '922', '909'],
+        ['Prison population', '917', '932', '937', '928', '921', '926', '930', '935', '920', '915', '922', '909'],
       )
     })
   })
@@ -193,7 +192,6 @@ context('Pgd Region selection > National > Analytics section > Incentive levels 
       const [_basicRow, standardRow, _enhancedRow, populationRow] = rows
       // remove header column
       standardRow.shift()
-      populationRow.shift()
 
       expect(standardRow.map(text => text.split(/\s/)[0])).to.deep.equal(
         // monthly average population on standard level
@@ -201,7 +199,21 @@ context('Pgd Region selection > National > Analytics section > Incentive levels 
       )
       expect(populationRow).to.deep.equal(
         // monthly average population
-        ['3,077', '3,070', '3,059', '3,047', '3,036', '3,057', '3,060', '3,066', '3,054', '3,059', '3,064', '3,069'],
+        [
+          'National population',
+          '3,077',
+          '3,070',
+          '3,059',
+          '3,047',
+          '3,036',
+          '3,057',
+          '3,060',
+          '3,066',
+          '3,054',
+          '3,059',
+          '3,064',
+          '3,069',
+        ],
       )
     })
   })
@@ -239,7 +251,6 @@ context('Pgd Region selection > LTHS > Analytics section > Incentive levels page
       const [_basicRow, standardRow, _enhancedRow, populationRow] = rows
       // remove header column
       standardRow.shift()
-      populationRow.shift()
 
       expect(standardRow.map(text => text.split(/\s/)[0])).to.deep.equal(
         // monthly average population on standard level
@@ -247,7 +258,7 @@ context('Pgd Region selection > LTHS > Analytics section > Incentive levels page
       )
       expect(populationRow).to.deep.equal(
         // monthly average population
-        ['372', '342', '322', '315', '312', '317', '315', '314', '318', '323', '321', '319'],
+        ['Total group population', '372', '342', '322', '315', '312', '317', '315', '314', '318', '323', '321', '319'],
       )
     })
   })

--- a/server/views/pages/analytics/behaviourEntries.njk
+++ b/server/views/pages/analytics/behaviourEntries.njk
@@ -56,6 +56,16 @@
   <div class="govuk-grid-row">
     <section class="govuk-grid-column-two-thirds govuk-!-margin-bottom-9">
 
+      {% set populationLabel %}
+        {% if analyticsView.isPrisonLevel() %}
+          Prison population
+        {% elif analyticsView.isRegional() %}
+          Total group population
+        {% else %}
+          National population
+        {% endif %}
+      {% endset%}
+
       {% set chartId = "trends-entries" %}
       {{ chartTrends(
         title=analyticsView.behaviourEntriesChartsContent[chartId].title,
@@ -65,7 +75,8 @@
         activeCaseload=user.activeCaseload.id,
         form=forms[chartId],
         csrfToken=csrfToken,
-        report=trends
+        report=trends,
+        populationLabel=populationLabel
       ) }}
 
     </section>

--- a/server/views/pages/analytics/incentiveLevels.njk
+++ b/server/views/pages/analytics/incentiveLevels.njk
@@ -34,6 +34,16 @@
   <div class="govuk-grid-row">
     <section class="govuk-grid-column-two-thirds govuk-!-margin-bottom-9">
 
+      {% set populationLabel %}
+        {% if analyticsView.isPrisonLevel() %}
+          Prison population
+        {% elif analyticsView.isRegional() %}
+          Total group population
+        {% else %}
+          National population
+        {% endif %}
+      {% endset%}
+
       {% set chartId = "trends-incentive-levels" %}
       {{ chartTrends(
         title=analyticsView.incentiveLevelsChartsContent[chartId].title,
@@ -43,7 +53,8 @@
         activeCaseload=user.activeCaseload.id,
         form=forms[chartId],
         csrfToken=csrfToken,
-        report=trends
+        report=trends,
+        populationLabel=populationLabel
       ) }}
 
     </section>

--- a/server/views/partials/analytics/chartTrends.njk
+++ b/server/views/partials/analytics/chartTrends.njk
@@ -10,7 +10,8 @@
   csrfToken,
   report,
   showTotalPopulation=true,
-  afterHeaderHtml=''
+  afterHeaderHtml='',
+  populationLabel
 ) %}
 
   {% call chartBase(
@@ -40,7 +41,7 @@
           <span class="app-chart-legend__swatch app-chart-legend__swatch--trends">&nbsp;</span>
           <span class="app-chart-legend__label">
             {% if report.populationIsTotal %}
-              Prison population
+              {{ populationLabel }}
             {% else %}
               {{ report.monthlyTotalName }}
             {% endif %}
@@ -167,7 +168,7 @@
                 {% if report.populationTotalName %}
                   {{ report.populationTotalName }}
                 {% else %}
-                  Prison population
+                  {{ populationLabel }}
                 {% endif %}
               </th>
               {% for row in report.rows %}


### PR DESCRIPTION
The "total" row incorrectly showed "Prison population" at national and
regional level while it should say "National population" and "Total group
population" respectively.