### PR TITLE
INC-579: Made titles and GA events more specific/useful

### DIFF
--- a/assets/js/application.js
+++ b/assets/js/application.js
@@ -2,11 +2,17 @@ window.GOVUKFrontend.initAll()
 window.MOJFrontend.initAll()
 
 $(() => {
-  // track opening/closing of <details> when labelled with GA category
+  // track opening of <details> when labelled with GA category
   $('.govuk-details').on('toggle', e => {
     const $details = $(e.target)
+
+    if (!$details.prop('open')) {
+      // only send GA events when opened
+      return
+    }
+
     const eventCategory = $details.data('ga-category')
-    const eventAction = $details.prop('open') ? 'opened' : 'closed'
+    const eventAction = 'opened'
     const eventLabel = $details.data('ga-label') || ''
     if (eventCategory && typeof ga === 'function') {
       ga('send', 'event', eventCategory, eventAction, eventLabel)

--- a/integration_tests/e2e/analytics/behaviourEntries.cy.ts
+++ b/integration_tests/e2e/analytics/behaviourEntries.cy.ts
@@ -1,10 +1,16 @@
-import { getTextFromTable, testInvalidFeedbackSubmission, testValidFeedbackSubmission } from './utils'
+import {
+  getTextFromTable,
+  testGuidanceBoxes,
+  testInvalidFeedbackSubmission,
+  testValidFeedbackSubmission,
+} from './utils'
 import Page from '../../pages/page'
 import HomePage from '../../pages/home'
 import AnalyticsBehaviourEntries from '../../pages/analytics/behaviourEntries'
 import AnalyticsIncentiveLevels from '../../pages/analytics/incentiveLevels'
 import GoogleAnalyticsSpy from '../../plugins/googleAnalyticsSpy'
 import PgdRegionSelection from '../../pages/analytics/pgdRegionSelection'
+import { ChartId } from '../../../server/routes/analyticsChartTypes'
 
 context('Analytics section > Behaviour entries page', () => {
   beforeEach(() => {
@@ -74,43 +80,13 @@ context('Analytics section > Behaviour entries page', () => {
   })
 
   it('guidance box for analytics is tracked', () => {
-    const page = Page.verifyOnPage(AnalyticsBehaviourEntries)
+    const charts: Partial<Record<ChartId, string>> = {
+      'entries-by-location': 'Behaviour entries by wing (Prison)',
+      'prisoners-with-entries-by-location': 'Prisoners with behaviour entries by wing (Prison)',
+      'trends-entries': 'Behaviour entry trends (Prison)',
+    }
 
-    const gaSpy = new GoogleAnalyticsSpy()
-    gaSpy.install()
-
-    page
-      .getChartGuidance('entries-by-location')
-      .click()
-      .then(() =>
-        gaSpy.shouldHaveSentEvent('incentives_event', {
-          category: 'How you can use this chart > Behaviour entries by wing (Prison)',
-          action: 'opened',
-          label: 'MDI',
-        }),
-      )
-
-    page
-      .getChartGuidance('prisoners-with-entries-by-location')
-      .click()
-      .then(() =>
-        gaSpy.shouldHaveSentEvent('incentives_event', {
-          category: 'How you can use this chart > Prisoners with behaviour entries by wing (Prison)',
-          action: 'opened',
-          label: 'MDI',
-        }),
-      )
-
-    page
-      .getChartGuidance('trends-entries')
-      .click()
-      .then(() =>
-        gaSpy.shouldHaveSentEvent('incentives_event', {
-          category: 'How you can use this chart > Behaviour entry trends (Prison)',
-          action: 'opened',
-          label: 'MDI',
-        }),
-      )
+    testGuidanceBoxes(AnalyticsBehaviourEntries, charts)
   })
 
   it('chart feedback box for analytics is tracked', () => {
@@ -248,43 +224,13 @@ context('Pgd Region selection > National > Analytics section > Behaviour entries
   })
 
   it('guidance box for analytics is tracked', () => {
-    const page = Page.verifyOnPage(AnalyticsBehaviourEntries)
+    const charts: Partial<Record<ChartId, string>> = {
+      'entries-by-location': 'Behaviour entries by prison group (National)',
+      'prisoners-with-entries-by-location': 'Prisoners with behaviour entries by prison group (National)',
+      'trends-entries': 'Behaviour entry trends (National)',
+    }
 
-    const gaSpy = new GoogleAnalyticsSpy()
-    gaSpy.install()
-
-    page
-      .getChartGuidance('entries-by-location')
-      .click()
-      .then(() =>
-        gaSpy.shouldHaveSentEvent('incentives_event', {
-          category: 'How you can use this chart > Behaviour entries by prison group (National)',
-          action: 'opened',
-          label: 'MDI',
-        }),
-      )
-
-    page
-      .getChartGuidance('prisoners-with-entries-by-location')
-      .click()
-      .then(() =>
-        gaSpy.shouldHaveSentEvent('incentives_event', {
-          category: 'How you can use this chart > Prisoners with behaviour entries by prison group (National)',
-          action: 'opened',
-          label: 'MDI',
-        }),
-      )
-
-    page
-      .getChartGuidance('trends-entries')
-      .click()
-      .then(() =>
-        gaSpy.shouldHaveSentEvent('incentives_event', {
-          category: 'How you can use this chart > Behaviour entry trends (National)',
-          action: 'opened',
-          label: 'MDI',
-        }),
-      )
+    testGuidanceBoxes(AnalyticsBehaviourEntries, charts)
   })
 
   it('chart feedback box for analytics is tracked', () => {
@@ -392,43 +338,13 @@ context('Pgd Region selection > LTHS > Analytics section > Behaviour entries pag
   })
 
   it('guidance box for analytics is tracked', () => {
-    const page = Page.verifyOnPage(AnalyticsBehaviourEntries)
+    const charts: Partial<Record<ChartId, string>> = {
+      'entries-by-location': 'Behaviour entries by establishment (Group)',
+      'prisoners-with-entries-by-location': 'Prisoners with behaviour entries by establishment (Group)',
+      'trends-entries': 'Behaviour entry trends (Group)',
+    }
 
-    const gaSpy = new GoogleAnalyticsSpy()
-    gaSpy.install()
-
-    page
-      .getChartGuidance('entries-by-location')
-      .click()
-      .then(() =>
-        gaSpy.shouldHaveSentEvent('incentives_event', {
-          category: 'How you can use this chart > Behaviour entries by establishment (Group)',
-          action: 'opened',
-          label: 'MDI',
-        }),
-      )
-
-    page
-      .getChartGuidance('prisoners-with-entries-by-location')
-      .click()
-      .then(() =>
-        gaSpy.shouldHaveSentEvent('incentives_event', {
-          category: 'How you can use this chart > Prisoners with behaviour entries by establishment (Group)',
-          action: 'opened',
-          label: 'MDI',
-        }),
-      )
-
-    page
-      .getChartGuidance('trends-entries')
-      .click()
-      .then(() =>
-        gaSpy.shouldHaveSentEvent('incentives_event', {
-          category: 'How you can use this chart > Behaviour entry trends (Group)',
-          action: 'opened',
-          label: 'MDI',
-        }),
-      )
+    testGuidanceBoxes(AnalyticsBehaviourEntries, charts)
   })
 
   it('chart feedback box for analytics is tracked', () => {

--- a/integration_tests/e2e/analytics/behaviourEntries.cy.ts
+++ b/integration_tests/e2e/analytics/behaviourEntries.cy.ts
@@ -1,6 +1,6 @@
 import {
   getTextFromTable,
-  testGuidanceBoxes,
+  testDetailsOpenedGaEvents,
   testInvalidFeedbackSubmission,
   testValidFeedbackSubmission,
 } from './utils'
@@ -8,7 +8,6 @@ import Page from '../../pages/page'
 import HomePage from '../../pages/home'
 import AnalyticsBehaviourEntries from '../../pages/analytics/behaviourEntries'
 import AnalyticsIncentiveLevels from '../../pages/analytics/incentiveLevels'
-import GoogleAnalyticsSpy from '../../plugins/googleAnalyticsSpy'
 import PgdRegionSelection from '../../pages/analytics/pgdRegionSelection'
 import { ChartId } from '../../../server/routes/analyticsChartTypes'
 
@@ -81,52 +80,23 @@ context('Analytics section > Behaviour entries page', () => {
 
   it('guidance box for analytics is tracked', () => {
     const charts: Partial<Record<ChartId, string>> = {
-      'entries-by-location': 'Behaviour entries by wing (Prison)',
-      'prisoners-with-entries-by-location': 'Prisoners with behaviour entries by wing (Prison)',
-      'trends-entries': 'Behaviour entry trends (Prison)',
+      'entries-by-location': 'How you can use this chart > Behaviour entries by wing (Prison)',
+      'prisoners-with-entries-by-location':
+        'How you can use this chart > Prisoners with behaviour entries by wing (Prison)',
+      'trends-entries': 'How you can use this chart > Behaviour entry trends (Prison)',
     }
 
-    testGuidanceBoxes(AnalyticsBehaviourEntries, charts)
+    testDetailsOpenedGaEvents(AnalyticsBehaviourEntries, 'getChartGuidance', charts)
   })
 
   it('chart feedback box for analytics is tracked', () => {
-    const page = Page.verifyOnPage(AnalyticsBehaviourEntries)
+    const charts: Partial<Record<ChartId, string>> = {
+      'entries-by-location': 'Is this chart useful > Behaviour entries by wing (Prison)',
+      'prisoners-with-entries-by-location': 'Is this chart useful > Prisoners with behaviour entries by wing (Prison)',
+      'trends-entries': 'Is this chart useful > Behaviour entry trends (Prison)',
+    }
 
-    const gaSpy = new GoogleAnalyticsSpy()
-    gaSpy.install()
-
-    page
-      .getChartFeedback('entries-by-location')
-      .click()
-      .then(() =>
-        gaSpy.shouldHaveSentEvent('incentives_event', {
-          category: 'Is this chart useful > Behaviour entries by wing (Prison)',
-          action: 'opened',
-          label: 'MDI',
-        }),
-      )
-
-    page
-      .getChartFeedback('prisoners-with-entries-by-location')
-      .click()
-      .then(() =>
-        gaSpy.shouldHaveSentEvent('incentives_event', {
-          category: 'Is this chart useful > Prisoners with behaviour entries by wing (Prison)',
-          action: 'opened',
-          label: 'MDI',
-        }),
-      )
-
-    page
-      .getChartFeedback('trends-entries')
-      .click()
-      .then(() =>
-        gaSpy.shouldHaveSentEvent('incentives_event', {
-          category: 'Is this chart useful > Behaviour entry trends (Prison)',
-          action: 'opened',
-          label: 'MDI',
-        }),
-      )
+    testDetailsOpenedGaEvents(AnalyticsBehaviourEntries, 'getChartFeedback', charts)
   })
 
   it('users can submit feedback on charts', () => {
@@ -225,52 +195,24 @@ context('Pgd Region selection > National > Analytics section > Behaviour entries
 
   it('guidance box for analytics is tracked', () => {
     const charts: Partial<Record<ChartId, string>> = {
-      'entries-by-location': 'Behaviour entries by prison group (National)',
-      'prisoners-with-entries-by-location': 'Prisoners with behaviour entries by prison group (National)',
-      'trends-entries': 'Behaviour entry trends (National)',
+      'entries-by-location': 'How you can use this chart > Behaviour entries by prison group (National)',
+      'prisoners-with-entries-by-location':
+        'How you can use this chart > Prisoners with behaviour entries by prison group (National)',
+      'trends-entries': 'How you can use this chart > Behaviour entry trends (National)',
     }
 
-    testGuidanceBoxes(AnalyticsBehaviourEntries, charts)
+    testDetailsOpenedGaEvents(AnalyticsBehaviourEntries, 'getChartGuidance', charts)
   })
 
   it('chart feedback box for analytics is tracked', () => {
-    const page = Page.verifyOnPage(AnalyticsBehaviourEntries)
+    const charts: Partial<Record<ChartId, string>> = {
+      'entries-by-location': 'Is this chart useful > Behaviour entries by prison group (National)',
+      'prisoners-with-entries-by-location':
+        'Is this chart useful > Prisoners with behaviour entries by prison group (National)',
+      'trends-entries': 'Is this chart useful > Behaviour entry trends (National)',
+    }
 
-    const gaSpy = new GoogleAnalyticsSpy()
-    gaSpy.install()
-
-    page
-      .getChartFeedback('entries-by-location')
-      .click()
-      .then(() =>
-        gaSpy.shouldHaveSentEvent('incentives_event', {
-          category: 'Is this chart useful > Behaviour entries by prison group (National)',
-          action: 'opened',
-          label: 'MDI',
-        }),
-      )
-
-    page
-      .getChartFeedback('prisoners-with-entries-by-location')
-      .click()
-      .then(() =>
-        gaSpy.shouldHaveSentEvent('incentives_event', {
-          category: 'Is this chart useful > Prisoners with behaviour entries by prison group (National)',
-          action: 'opened',
-          label: 'MDI',
-        }),
-      )
-
-    page
-      .getChartFeedback('trends-entries')
-      .click()
-      .then(() =>
-        gaSpy.shouldHaveSentEvent('incentives_event', {
-          category: 'Is this chart useful > Behaviour entry trends (National)',
-          action: 'opened',
-          label: 'MDI',
-        }),
-      )
+    testDetailsOpenedGaEvents(AnalyticsBehaviourEntries, 'getChartFeedback', charts)
   })
 })
 
@@ -339,51 +281,23 @@ context('Pgd Region selection > LTHS > Analytics section > Behaviour entries pag
 
   it('guidance box for analytics is tracked', () => {
     const charts: Partial<Record<ChartId, string>> = {
-      'entries-by-location': 'Behaviour entries by establishment (Group)',
-      'prisoners-with-entries-by-location': 'Prisoners with behaviour entries by establishment (Group)',
-      'trends-entries': 'Behaviour entry trends (Group)',
+      'entries-by-location': 'How you can use this chart > Behaviour entries by establishment (Group)',
+      'prisoners-with-entries-by-location':
+        'How you can use this chart > Prisoners with behaviour entries by establishment (Group)',
+      'trends-entries': 'How you can use this chart > Behaviour entry trends (Group)',
     }
 
-    testGuidanceBoxes(AnalyticsBehaviourEntries, charts)
+    testDetailsOpenedGaEvents(AnalyticsBehaviourEntries, 'getChartGuidance', charts)
   })
 
   it('chart feedback box for analytics is tracked', () => {
-    const page = Page.verifyOnPage(AnalyticsBehaviourEntries)
+    const charts: Partial<Record<ChartId, string>> = {
+      'entries-by-location': 'Is this chart useful > Behaviour entries by establishment (Group)',
+      'prisoners-with-entries-by-location':
+        'Is this chart useful > Prisoners with behaviour entries by establishment (Group)',
+      'trends-entries': 'Is this chart useful > Behaviour entry trends (Group)',
+    }
 
-    const gaSpy = new GoogleAnalyticsSpy()
-    gaSpy.install()
-
-    page
-      .getChartFeedback('entries-by-location')
-      .click()
-      .then(() =>
-        gaSpy.shouldHaveSentEvent('incentives_event', {
-          category: 'Is this chart useful > Behaviour entries by establishment (Group)',
-          action: 'opened',
-          label: 'MDI',
-        }),
-      )
-
-    page
-      .getChartFeedback('prisoners-with-entries-by-location')
-      .click()
-      .then(() =>
-        gaSpy.shouldHaveSentEvent('incentives_event', {
-          category: 'Is this chart useful > Prisoners with behaviour entries by establishment (Group)',
-          action: 'opened',
-          label: 'MDI',
-        }),
-      )
-
-    page
-      .getChartFeedback('trends-entries')
-      .click()
-      .then(() =>
-        gaSpy.shouldHaveSentEvent('incentives_event', {
-          category: 'Is this chart useful > Behaviour entry trends (Group)',
-          action: 'opened',
-          label: 'MDI',
-        }),
-      )
+    testDetailsOpenedGaEvents(AnalyticsBehaviourEntries, 'getChartFeedback', charts)
   })
 })

--- a/integration_tests/e2e/analytics/behaviourEntries.cy.ts
+++ b/integration_tests/e2e/analytics/behaviourEntries.cy.ts
@@ -402,7 +402,7 @@ context('Pgd Region selection > LTHS > Analytics section > Behaviour entries pag
       .click()
       .then(() =>
         gaSpy.shouldHaveSentEvent('incentives_event', {
-          category: 'How you can use this chart > Behaviour entries by establishment (PGD Region)',
+          category: 'How you can use this chart > Behaviour entries by establishment (Group)',
           action: 'opened',
           label: 'MDI',
         }),
@@ -413,7 +413,7 @@ context('Pgd Region selection > LTHS > Analytics section > Behaviour entries pag
       .click()
       .then(() =>
         gaSpy.shouldHaveSentEvent('incentives_event', {
-          category: 'How you can use this chart > Prisoners with behaviour entries by establishment (PGD Region)',
+          category: 'How you can use this chart > Prisoners with behaviour entries by establishment (Group)',
           action: 'opened',
           label: 'MDI',
         }),
@@ -424,7 +424,7 @@ context('Pgd Region selection > LTHS > Analytics section > Behaviour entries pag
       .click()
       .then(() =>
         gaSpy.shouldHaveSentEvent('incentives_event', {
-          category: 'How you can use this chart > Behaviour entry trends (PGD Region)',
+          category: 'How you can use this chart > Behaviour entry trends (Group)',
           action: 'opened',
           label: 'MDI',
         }),
@@ -442,7 +442,7 @@ context('Pgd Region selection > LTHS > Analytics section > Behaviour entries pag
       .click()
       .then(() =>
         gaSpy.shouldHaveSentEvent('incentives_event', {
-          category: 'Is this chart useful > Behaviour entries by establishment (PGD Region)',
+          category: 'Is this chart useful > Behaviour entries by establishment (Group)',
           action: 'opened',
           label: 'MDI',
         }),
@@ -453,7 +453,7 @@ context('Pgd Region selection > LTHS > Analytics section > Behaviour entries pag
       .click()
       .then(() =>
         gaSpy.shouldHaveSentEvent('incentives_event', {
-          category: 'Is this chart useful > Prisoners with behaviour entries by establishment (PGD Region)',
+          category: 'Is this chart useful > Prisoners with behaviour entries by establishment (Group)',
           action: 'opened',
           label: 'MDI',
         }),
@@ -464,7 +464,7 @@ context('Pgd Region selection > LTHS > Analytics section > Behaviour entries pag
       .click()
       .then(() =>
         gaSpy.shouldHaveSentEvent('incentives_event', {
-          category: 'Is this chart useful > Behaviour entry trends (PGD Region)',
+          category: 'Is this chart useful > Behaviour entry trends (Group)',
           action: 'opened',
           label: 'MDI',
         }),

--- a/integration_tests/e2e/analytics/behaviourEntries.cy.ts
+++ b/integration_tests/e2e/analytics/behaviourEntries.cy.ts
@@ -85,16 +85,6 @@ context('Analytics section > Behaviour entries page', () => {
           label: 'MDI',
         }),
       )
-    page
-      .getChartGuidance('entries-by-location')
-      .click()
-      .then(() =>
-        gaSpy.shouldHaveSentEvent('incentives_event', {
-          category: 'How you can use this chart > Behaviour entries by wing',
-          action: 'closed',
-          label: 'MDI',
-        }),
-      )
 
     page
       .getChartGuidance('prisoners-with-entries-by-location')
@@ -106,16 +96,6 @@ context('Analytics section > Behaviour entries page', () => {
           label: 'MDI',
         }),
       )
-    page
-      .getChartGuidance('prisoners-with-entries-by-location')
-      .click()
-      .then(() =>
-        gaSpy.shouldHaveSentEvent('incentives_event', {
-          category: 'How you can use this chart > Prisoners with behaviour entries by wing',
-          action: 'closed',
-          label: 'MDI',
-        }),
-      )
 
     page
       .getChartGuidance('trends-entries')
@@ -124,16 +104,6 @@ context('Analytics section > Behaviour entries page', () => {
         gaSpy.shouldHaveSentEvent('incentives_event', {
           category: 'How you can use this chart > Behaviour entry trends',
           action: 'opened',
-          label: 'MDI',
-        }),
-      )
-    page
-      .getChartGuidance('trends-entries')
-      .click()
-      .then(() =>
-        gaSpy.shouldHaveSentEvent('incentives_event', {
-          category: 'How you can use this chart > Behaviour entry trends',
-          action: 'closed',
           label: 'MDI',
         }),
       )
@@ -155,16 +125,6 @@ context('Analytics section > Behaviour entries page', () => {
           label: 'MDI',
         }),
       )
-    page
-      .getChartFeedback('entries-by-location')
-      .click()
-      .then(() =>
-        gaSpy.shouldHaveSentEvent('incentives_event', {
-          category: 'Is this chart useful > Behaviour entries by wing',
-          action: 'closed',
-          label: 'MDI',
-        }),
-      )
 
     page
       .getChartFeedback('prisoners-with-entries-by-location')
@@ -176,16 +136,6 @@ context('Analytics section > Behaviour entries page', () => {
           label: 'MDI',
         }),
       )
-    page
-      .getChartFeedback('prisoners-with-entries-by-location')
-      .click()
-      .then(() =>
-        gaSpy.shouldHaveSentEvent('incentives_event', {
-          category: 'Is this chart useful > Prisoners with behaviour entries by wing',
-          action: 'closed',
-          label: 'MDI',
-        }),
-      )
 
     page
       .getChartFeedback('trends-entries')
@@ -194,16 +144,6 @@ context('Analytics section > Behaviour entries page', () => {
         gaSpy.shouldHaveSentEvent('incentives_event', {
           category: 'Is this chart useful > Behaviour entry trends',
           action: 'opened',
-          label: 'MDI',
-        }),
-      )
-    page
-      .getChartFeedback('trends-entries')
-      .click()
-      .then(() =>
-        gaSpy.shouldHaveSentEvent('incentives_event', {
-          category: 'Is this chart useful > Behaviour entry trends',
-          action: 'closed',
           label: 'MDI',
         }),
       )

--- a/integration_tests/e2e/analytics/behaviourEntries.cy.ts
+++ b/integration_tests/e2e/analytics/behaviourEntries.cy.ts
@@ -21,6 +21,10 @@ context('Analytics section > Behaviour entries page', () => {
     analyticsPage.behaviourEntriesNavItem.click()
   })
 
+  it('has correct title', () => {
+    cy.title().should('eq', 'Manage incentives – Behaviour entries – Prison')
+  })
+
   it('has feedback banner', () => {
     cy.get('.app-feedback-banner').contains('help us to improve it')
     cy.get('.app-feedback-banner a').invoke('attr', 'href').should('equal', 'https://example.com/analytics-feedback')
@@ -182,6 +186,10 @@ context('Pgd Region selection > National > Analytics section > Behaviour entries
     analyticsPage.behaviourEntriesNavItem.click()
   })
 
+  it('has correct title', () => {
+    cy.title().should('eq', 'Manage incentives – Behaviour entries – National')
+  })
+
   it('users see analytics', () => {
     const page = Page.verifyOnPage(AnalyticsBehaviourEntries)
 
@@ -254,6 +262,10 @@ context('Pgd Region selection > LTHS > Analytics section > Behaviour entries pag
     locationSelectionPage.continueButton().click()
     const analyticsPage = Page.verifyOnPage(AnalyticsIncentiveLevels)
     analyticsPage.behaviourEntriesNavItem.click()
+  })
+
+  it('has correct title', () => {
+    cy.title().should('eq', 'Manage incentives – Behaviour entries – Long-term and high security')
   })
 
   it('users see analytics', () => {

--- a/integration_tests/e2e/analytics/behaviourEntries.cy.ts
+++ b/integration_tests/e2e/analytics/behaviourEntries.cy.ts
@@ -84,7 +84,7 @@ context('Analytics section > Behaviour entries page', () => {
       .click()
       .then(() =>
         gaSpy.shouldHaveSentEvent('incentives_event', {
-          category: 'How you can use this chart > Behaviour entries by wing',
+          category: 'How you can use this chart > Behaviour entries by wing (Prison)',
           action: 'opened',
           label: 'MDI',
         }),
@@ -95,7 +95,7 @@ context('Analytics section > Behaviour entries page', () => {
       .click()
       .then(() =>
         gaSpy.shouldHaveSentEvent('incentives_event', {
-          category: 'How you can use this chart > Prisoners with behaviour entries by wing',
+          category: 'How you can use this chart > Prisoners with behaviour entries by wing (Prison)',
           action: 'opened',
           label: 'MDI',
         }),
@@ -106,7 +106,7 @@ context('Analytics section > Behaviour entries page', () => {
       .click()
       .then(() =>
         gaSpy.shouldHaveSentEvent('incentives_event', {
-          category: 'How you can use this chart > Behaviour entry trends',
+          category: 'How you can use this chart > Behaviour entry trends (Prison)',
           action: 'opened',
           label: 'MDI',
         }),
@@ -124,7 +124,7 @@ context('Analytics section > Behaviour entries page', () => {
       .click()
       .then(() =>
         gaSpy.shouldHaveSentEvent('incentives_event', {
-          category: 'Is this chart useful > Behaviour entries by wing',
+          category: 'Is this chart useful > Behaviour entries by wing (Prison)',
           action: 'opened',
           label: 'MDI',
         }),
@@ -135,7 +135,7 @@ context('Analytics section > Behaviour entries page', () => {
       .click()
       .then(() =>
         gaSpy.shouldHaveSentEvent('incentives_event', {
-          category: 'Is this chart useful > Prisoners with behaviour entries by wing',
+          category: 'Is this chart useful > Prisoners with behaviour entries by wing (Prison)',
           action: 'opened',
           label: 'MDI',
         }),
@@ -146,7 +146,7 @@ context('Analytics section > Behaviour entries page', () => {
       .click()
       .then(() =>
         gaSpy.shouldHaveSentEvent('incentives_event', {
-          category: 'Is this chart useful > Behaviour entry trends',
+          category: 'Is this chart useful > Behaviour entry trends (Prison)',
           action: 'opened',
           label: 'MDI',
         }),
@@ -246,6 +246,86 @@ context('Pgd Region selection > National > Analytics section > Behaviour entries
       )
     })
   })
+
+  it('guidance box for analytics is tracked', () => {
+    const page = Page.verifyOnPage(AnalyticsBehaviourEntries)
+
+    const gaSpy = new GoogleAnalyticsSpy()
+    gaSpy.install()
+
+    page
+      .getChartGuidance('entries-by-location')
+      .click()
+      .then(() =>
+        gaSpy.shouldHaveSentEvent('incentives_event', {
+          category: 'How you can use this chart > Behaviour entries by prison group (National)',
+          action: 'opened',
+          label: 'MDI',
+        }),
+      )
+
+    page
+      .getChartGuidance('prisoners-with-entries-by-location')
+      .click()
+      .then(() =>
+        gaSpy.shouldHaveSentEvent('incentives_event', {
+          category: 'How you can use this chart > Prisoners with behaviour entries by prison group (National)',
+          action: 'opened',
+          label: 'MDI',
+        }),
+      )
+
+    page
+      .getChartGuidance('trends-entries')
+      .click()
+      .then(() =>
+        gaSpy.shouldHaveSentEvent('incentives_event', {
+          category: 'How you can use this chart > Behaviour entry trends (National)',
+          action: 'opened',
+          label: 'MDI',
+        }),
+      )
+  })
+
+  it('chart feedback box for analytics is tracked', () => {
+    const page = Page.verifyOnPage(AnalyticsBehaviourEntries)
+
+    const gaSpy = new GoogleAnalyticsSpy()
+    gaSpy.install()
+
+    page
+      .getChartFeedback('entries-by-location')
+      .click()
+      .then(() =>
+        gaSpy.shouldHaveSentEvent('incentives_event', {
+          category: 'Is this chart useful > Behaviour entries by prison group (National)',
+          action: 'opened',
+          label: 'MDI',
+        }),
+      )
+
+    page
+      .getChartFeedback('prisoners-with-entries-by-location')
+      .click()
+      .then(() =>
+        gaSpy.shouldHaveSentEvent('incentives_event', {
+          category: 'Is this chart useful > Prisoners with behaviour entries by prison group (National)',
+          action: 'opened',
+          label: 'MDI',
+        }),
+      )
+
+    page
+      .getChartFeedback('trends-entries')
+      .click()
+      .then(() =>
+        gaSpy.shouldHaveSentEvent('incentives_event', {
+          category: 'Is this chart useful > Behaviour entry trends (National)',
+          action: 'opened',
+          label: 'MDI',
+        }),
+      )
+  })
 })
 
 context('Pgd Region selection > LTHS > Analytics section > Behaviour entries page', () => {
@@ -309,5 +389,85 @@ context('Pgd Region selection > LTHS > Analytics section > Behaviour entries pag
         ['Total group population', '372', '342', '322', '315', '312', '317', '315', '314', '318', '323', '321', '319'],
       )
     })
+  })
+
+  it('guidance box for analytics is tracked', () => {
+    const page = Page.verifyOnPage(AnalyticsBehaviourEntries)
+
+    const gaSpy = new GoogleAnalyticsSpy()
+    gaSpy.install()
+
+    page
+      .getChartGuidance('entries-by-location')
+      .click()
+      .then(() =>
+        gaSpy.shouldHaveSentEvent('incentives_event', {
+          category: 'How you can use this chart > Behaviour entries by establishment (PGD Region)',
+          action: 'opened',
+          label: 'MDI',
+        }),
+      )
+
+    page
+      .getChartGuidance('prisoners-with-entries-by-location')
+      .click()
+      .then(() =>
+        gaSpy.shouldHaveSentEvent('incentives_event', {
+          category: 'How you can use this chart > Prisoners with behaviour entries by establishment (PGD Region)',
+          action: 'opened',
+          label: 'MDI',
+        }),
+      )
+
+    page
+      .getChartGuidance('trends-entries')
+      .click()
+      .then(() =>
+        gaSpy.shouldHaveSentEvent('incentives_event', {
+          category: 'How you can use this chart > Behaviour entry trends (PGD Region)',
+          action: 'opened',
+          label: 'MDI',
+        }),
+      )
+  })
+
+  it('chart feedback box for analytics is tracked', () => {
+    const page = Page.verifyOnPage(AnalyticsBehaviourEntries)
+
+    const gaSpy = new GoogleAnalyticsSpy()
+    gaSpy.install()
+
+    page
+      .getChartFeedback('entries-by-location')
+      .click()
+      .then(() =>
+        gaSpy.shouldHaveSentEvent('incentives_event', {
+          category: 'Is this chart useful > Behaviour entries by establishment (PGD Region)',
+          action: 'opened',
+          label: 'MDI',
+        }),
+      )
+
+    page
+      .getChartFeedback('prisoners-with-entries-by-location')
+      .click()
+      .then(() =>
+        gaSpy.shouldHaveSentEvent('incentives_event', {
+          category: 'Is this chart useful > Prisoners with behaviour entries by establishment (PGD Region)',
+          action: 'opened',
+          label: 'MDI',
+        }),
+      )
+
+    page
+      .getChartFeedback('trends-entries')
+      .click()
+      .then(() =>
+        gaSpy.shouldHaveSentEvent('incentives_event', {
+          category: 'Is this chart useful > Behaviour entry trends (PGD Region)',
+          action: 'opened',
+          label: 'MDI',
+        }),
+      )
   })
 })

--- a/integration_tests/e2e/analytics/incentiveLevels.cy.ts
+++ b/integration_tests/e2e/analytics/incentiveLevels.cy.ts
@@ -69,16 +69,6 @@ context('Analytics section > Incentive levels page', () => {
           label: 'MDI',
         }),
       )
-    page
-      .getChartGuidance('incentive-levels-by-location')
-      .click()
-      .then(() =>
-        gaSpy.shouldHaveSentEvent('incentives_event', {
-          category: 'How you can use this chart > Incentive level by wing',
-          action: 'closed',
-          label: 'MDI',
-        }),
-      )
 
     page
       .getChartGuidance('trends-incentive-levels')
@@ -87,16 +77,6 @@ context('Analytics section > Incentive levels page', () => {
         gaSpy.shouldHaveSentEvent('incentives_event', {
           category: 'How you can use this chart > Incentive level trends',
           action: 'opened',
-          label: 'MDI',
-        }),
-      )
-    page
-      .getChartGuidance('trends-incentive-levels')
-      .click()
-      .then(() =>
-        gaSpy.shouldHaveSentEvent('incentives_event', {
-          category: 'How you can use this chart > Incentive level trends',
-          action: 'closed',
           label: 'MDI',
         }),
       )
@@ -118,16 +98,6 @@ context('Analytics section > Incentive levels page', () => {
           label: 'MDI',
         }),
       )
-    page
-      .getChartFeedback('incentive-levels-by-location')
-      .click()
-      .then(() =>
-        gaSpy.shouldHaveSentEvent('incentives_event', {
-          category: 'Is this chart useful > Incentive level by wing',
-          action: 'closed',
-          label: 'MDI',
-        }),
-      )
 
     page
       .getChartFeedback('trends-incentive-levels')
@@ -136,16 +106,6 @@ context('Analytics section > Incentive levels page', () => {
         gaSpy.shouldHaveSentEvent('incentives_event', {
           category: 'Is this chart useful > Incentive level trends',
           action: 'opened',
-          label: 'MDI',
-        }),
-      )
-    page
-      .getChartFeedback('trends-incentive-levels')
-      .click()
-      .then(() =>
-        gaSpy.shouldHaveSentEvent('incentives_event', {
-          category: 'Is this chart useful > Incentive level trends',
-          action: 'closed',
           label: 'MDI',
         }),
       )

--- a/integration_tests/e2e/analytics/incentiveLevels.cy.ts
+++ b/integration_tests/e2e/analytics/incentiveLevels.cy.ts
@@ -68,7 +68,7 @@ context('Analytics section > Incentive levels page', () => {
       .click()
       .then(() =>
         gaSpy.shouldHaveSentEvent('incentives_event', {
-          category: 'How you can use this chart > Incentive level by wing',
+          category: 'How you can use this chart > Incentive level by wing (Prison)',
           action: 'opened',
           label: 'MDI',
         }),
@@ -79,7 +79,7 @@ context('Analytics section > Incentive levels page', () => {
       .click()
       .then(() =>
         gaSpy.shouldHaveSentEvent('incentives_event', {
-          category: 'How you can use this chart > Incentive level trends',
+          category: 'How you can use this chart > Incentive level trends (Prison)',
           action: 'opened',
           label: 'MDI',
         }),
@@ -97,7 +97,7 @@ context('Analytics section > Incentive levels page', () => {
       .click()
       .then(() =>
         gaSpy.shouldHaveSentEvent('incentives_event', {
-          category: 'Is this chart useful > Incentive level by wing',
+          category: 'Is this chart useful > Incentive level by wing (Prison)',
           action: 'opened',
           label: 'MDI',
         }),
@@ -108,7 +108,7 @@ context('Analytics section > Incentive levels page', () => {
       .click()
       .then(() =>
         gaSpy.shouldHaveSentEvent('incentives_event', {
-          category: 'Is this chart useful > Incentive level trends',
+          category: 'Is this chart useful > Incentive level trends (Prison)',
           action: 'opened',
           label: 'MDI',
         }),
@@ -185,6 +185,64 @@ context('Pgd Region selection > National > Analytics section > Incentive levels 
       )
     })
   })
+
+  it('guidance box for analytics is tracked', () => {
+    const page = Page.verifyOnPage(AnalyticsIncentiveLevels)
+
+    const gaSpy = new GoogleAnalyticsSpy()
+    gaSpy.install()
+
+    page
+      .getChartGuidance('incentive-levels-by-location')
+      .click()
+      .then(() =>
+        gaSpy.shouldHaveSentEvent('incentives_event', {
+          category: 'How you can use this chart > Incentive level by prison group (National)',
+          action: 'opened',
+          label: 'MDI',
+        }),
+      )
+
+    page
+      .getChartGuidance('trends-incentive-levels')
+      .click()
+      .then(() =>
+        gaSpy.shouldHaveSentEvent('incentives_event', {
+          category: 'How you can use this chart > Incentive level trends (National)',
+          action: 'opened',
+          label: 'MDI',
+        }),
+      )
+  })
+
+  it('chart feedback box for analytics is tracked', () => {
+    const page = Page.verifyOnPage(AnalyticsIncentiveLevels)
+
+    const gaSpy = new GoogleAnalyticsSpy()
+    gaSpy.install()
+
+    page
+      .getChartFeedback('incentive-levels-by-location')
+      .click()
+      .then(() =>
+        gaSpy.shouldHaveSentEvent('incentives_event', {
+          category: 'Is this chart useful > Incentive level by prison group (National)',
+          action: 'opened',
+          label: 'MDI',
+        }),
+      )
+
+    page
+      .getChartFeedback('trends-incentive-levels')
+      .click()
+      .then(() =>
+        gaSpy.shouldHaveSentEvent('incentives_event', {
+          category: 'Is this chart useful > Incentive level trends (National)',
+          action: 'opened',
+          label: 'MDI',
+        }),
+      )
+  })
 })
 
 context('Pgd Region selection > LTHS > Analytics section > Incentive levels page', () => {
@@ -233,5 +291,63 @@ context('Pgd Region selection > LTHS > Analytics section > Incentive levels page
         ['Total group population', '372', '342', '322', '315', '312', '317', '315', '314', '318', '323', '321', '319'],
       )
     })
+  })
+
+  it('guidance box for analytics is tracked', () => {
+    const page = Page.verifyOnPage(AnalyticsIncentiveLevels)
+
+    const gaSpy = new GoogleAnalyticsSpy()
+    gaSpy.install()
+
+    page
+      .getChartGuidance('incentive-levels-by-location')
+      .click()
+      .then(() =>
+        gaSpy.shouldHaveSentEvent('incentives_event', {
+          category: 'How you can use this chart > Incentive level by establishment (PGD Region)',
+          action: 'opened',
+          label: 'MDI',
+        }),
+      )
+
+    page
+      .getChartGuidance('trends-incentive-levels')
+      .click()
+      .then(() =>
+        gaSpy.shouldHaveSentEvent('incentives_event', {
+          category: 'How you can use this chart > Incentive level trends (PGD Region)',
+          action: 'opened',
+          label: 'MDI',
+        }),
+      )
+  })
+
+  it('chart feedback box for analytics is tracked', () => {
+    const page = Page.verifyOnPage(AnalyticsIncentiveLevels)
+
+    const gaSpy = new GoogleAnalyticsSpy()
+    gaSpy.install()
+
+    page
+      .getChartFeedback('incentive-levels-by-location')
+      .click()
+      .then(() =>
+        gaSpy.shouldHaveSentEvent('incentives_event', {
+          category: 'Is this chart useful > Incentive level by establishment (PGD Region)',
+          action: 'opened',
+          label: 'MDI',
+        }),
+      )
+
+    page
+      .getChartFeedback('trends-incentive-levels')
+      .click()
+      .then(() =>
+        gaSpy.shouldHaveSentEvent('incentives_event', {
+          category: 'Is this chart useful > Incentive level trends (PGD Region)',
+          action: 'opened',
+          label: 'MDI',
+        }),
+      )
   })
 })

--- a/integration_tests/e2e/analytics/incentiveLevels.cy.ts
+++ b/integration_tests/e2e/analytics/incentiveLevels.cy.ts
@@ -304,7 +304,7 @@ context('Pgd Region selection > LTHS > Analytics section > Incentive levels page
       .click()
       .then(() =>
         gaSpy.shouldHaveSentEvent('incentives_event', {
-          category: 'How you can use this chart > Incentive level by establishment (PGD Region)',
+          category: 'How you can use this chart > Incentive level by establishment (Group)',
           action: 'opened',
           label: 'MDI',
         }),
@@ -315,7 +315,7 @@ context('Pgd Region selection > LTHS > Analytics section > Incentive levels page
       .click()
       .then(() =>
         gaSpy.shouldHaveSentEvent('incentives_event', {
-          category: 'How you can use this chart > Incentive level trends (PGD Region)',
+          category: 'How you can use this chart > Incentive level trends (Group)',
           action: 'opened',
           label: 'MDI',
         }),
@@ -333,7 +333,7 @@ context('Pgd Region selection > LTHS > Analytics section > Incentive levels page
       .click()
       .then(() =>
         gaSpy.shouldHaveSentEvent('incentives_event', {
-          category: 'Is this chart useful > Incentive level by establishment (PGD Region)',
+          category: 'Is this chart useful > Incentive level by establishment (Group)',
           action: 'opened',
           label: 'MDI',
         }),
@@ -344,7 +344,7 @@ context('Pgd Region selection > LTHS > Analytics section > Incentive levels page
       .click()
       .then(() =>
         gaSpy.shouldHaveSentEvent('incentives_event', {
-          category: 'Is this chart useful > Incentive level trends (PGD Region)',
+          category: 'Is this chart useful > Incentive level trends (Group)',
           action: 'opened',
           label: 'MDI',
         }),

--- a/integration_tests/e2e/analytics/incentiveLevels.cy.ts
+++ b/integration_tests/e2e/analytics/incentiveLevels.cy.ts
@@ -19,6 +19,10 @@ context('Analytics section > Incentive levels page', () => {
     Page.verifyOnPage(AnalyticsIncentiveLevels)
   })
 
+  it('has correct title', () => {
+    cy.title().should('eq', 'Manage incentives – Incentive levels – Prison')
+  })
+
   it('has feedback banner', () => {
     cy.get('.app-feedback-banner').contains('help us to improve it')
     cy.get('.app-feedback-banner a').invoke('attr', 'href').should('equal', 'https://example.com/analytics-feedback')
@@ -135,6 +139,10 @@ context('Pgd Region selection > National > Analytics section > Incentive levels 
     Page.verifyOnPage(AnalyticsIncentiveLevels)
   })
 
+  it('has correct title', () => {
+    cy.title().should('eq', 'Manage incentives – Incentive levels – National')
+  })
+
   it('users see analytics', () => {
     const page = Page.verifyOnPage(AnalyticsIncentiveLevels)
 
@@ -192,6 +200,10 @@ context('Pgd Region selection > LTHS > Analytics section > Incentive levels page
     locationSelectionPage.changePgdRegionSelect().select('LTHS')
     locationSelectionPage.continueButton().click()
     Page.verifyOnPage(AnalyticsIncentiveLevels)
+  })
+
+  it('has correct title', () => {
+    cy.title().should('eq', 'Manage incentives – Incentive levels – Long-term and high security')
   })
 
   it('users see analytics', () => {

--- a/integration_tests/e2e/analytics/incentiveLevels.cy.ts
+++ b/integration_tests/e2e/analytics/incentiveLevels.cy.ts
@@ -1,13 +1,12 @@
 import {
   getTextFromTable,
-  testGuidanceBoxes,
+  testDetailsOpenedGaEvents,
   testInvalidFeedbackSubmission,
   testValidFeedbackSubmission,
 } from './utils'
 import Page from '../../pages/page'
 import HomePage from '../../pages/home'
 import AnalyticsIncentiveLevels from '../../pages/analytics/incentiveLevels'
-import GoogleAnalyticsSpy from '../../plugins/googleAnalyticsSpy'
 import PgdRegionSelection from '../../pages/analytics/pgdRegionSelection'
 import { ChartId } from '../../../server/routes/analyticsChartTypes'
 
@@ -65,40 +64,20 @@ context('Analytics section > Incentive levels page', () => {
 
   it('guidance box for analytics is tracked', () => {
     const charts: Partial<Record<ChartId, string>> = {
-      'incentive-levels-by-location': 'Incentive level by wing (Prison)',
-      'trends-incentive-levels': 'Incentive level trends (Prison)',
+      'incentive-levels-by-location': 'How you can use this chart > Incentive level by wing (Prison)',
+      'trends-incentive-levels': 'How you can use this chart > Incentive level trends (Prison)',
     }
 
-    testGuidanceBoxes(AnalyticsIncentiveLevels, charts)
+    testDetailsOpenedGaEvents(AnalyticsIncentiveLevels, 'getChartGuidance', charts)
   })
 
   it('chart feedback box for analytics is tracked', () => {
-    const page = Page.verifyOnPage(AnalyticsIncentiveLevels)
+    const charts: Partial<Record<ChartId, string>> = {
+      'incentive-levels-by-location': 'Is this chart useful > Incentive level by wing (Prison)',
+      'trends-incentive-levels': 'Is this chart useful > Incentive level trends (Prison)',
+    }
 
-    const gaSpy = new GoogleAnalyticsSpy()
-    gaSpy.install()
-
-    page
-      .getChartFeedback('incentive-levels-by-location')
-      .click()
-      .then(() =>
-        gaSpy.shouldHaveSentEvent('incentives_event', {
-          category: 'Is this chart useful > Incentive level by wing (Prison)',
-          action: 'opened',
-          label: 'MDI',
-        }),
-      )
-
-    page
-      .getChartFeedback('trends-incentive-levels')
-      .click()
-      .then(() =>
-        gaSpy.shouldHaveSentEvent('incentives_event', {
-          category: 'Is this chart useful > Incentive level trends (Prison)',
-          action: 'opened',
-          label: 'MDI',
-        }),
-      )
+    testDetailsOpenedGaEvents(AnalyticsIncentiveLevels, 'getChartFeedback', charts)
   })
 
   it('users can submit feedback on chart', () => {
@@ -174,40 +153,20 @@ context('Pgd Region selection > National > Analytics section > Incentive levels 
 
   it('guidance box for analytics is tracked', () => {
     const charts: Partial<Record<ChartId, string>> = {
-      'incentive-levels-by-location': 'Incentive level by prison group (National)',
-      'trends-incentive-levels': 'Incentive level trends (National)',
+      'incentive-levels-by-location': 'How you can use this chart > Incentive level by prison group (National)',
+      'trends-incentive-levels': 'How you can use this chart > Incentive level trends (National)',
     }
 
-    testGuidanceBoxes(AnalyticsIncentiveLevels, charts)
+    testDetailsOpenedGaEvents(AnalyticsIncentiveLevels, 'getChartGuidance', charts)
   })
 
   it('chart feedback box for analytics is tracked', () => {
-    const page = Page.verifyOnPage(AnalyticsIncentiveLevels)
+    const charts: Partial<Record<ChartId, string>> = {
+      'incentive-levels-by-location': 'Is this chart useful > Incentive level by prison group (National)',
+      'trends-incentive-levels': 'Is this chart useful > Incentive level trends (National)',
+    }
 
-    const gaSpy = new GoogleAnalyticsSpy()
-    gaSpy.install()
-
-    page
-      .getChartFeedback('incentive-levels-by-location')
-      .click()
-      .then(() =>
-        gaSpy.shouldHaveSentEvent('incentives_event', {
-          category: 'Is this chart useful > Incentive level by prison group (National)',
-          action: 'opened',
-          label: 'MDI',
-        }),
-      )
-
-    page
-      .getChartFeedback('trends-incentive-levels')
-      .click()
-      .then(() =>
-        gaSpy.shouldHaveSentEvent('incentives_event', {
-          category: 'Is this chart useful > Incentive level trends (National)',
-          action: 'opened',
-          label: 'MDI',
-        }),
-      )
+    testDetailsOpenedGaEvents(AnalyticsIncentiveLevels, 'getChartFeedback', charts)
   })
 })
 
@@ -261,39 +220,19 @@ context('Pgd Region selection > LTHS > Analytics section > Incentive levels page
 
   it('guidance box for analytics is tracked', () => {
     const charts: Partial<Record<ChartId, string>> = {
-      'incentive-levels-by-location': 'Incentive level by establishment (Group)',
-      'trends-incentive-levels': 'Incentive level trends (Group)',
+      'incentive-levels-by-location': 'How you can use this chart > Incentive level by establishment (Group)',
+      'trends-incentive-levels': 'How you can use this chart > Incentive level trends (Group)',
     }
 
-    testGuidanceBoxes(AnalyticsIncentiveLevels, charts)
+    testDetailsOpenedGaEvents(AnalyticsIncentiveLevels, 'getChartGuidance', charts)
   })
 
   it('chart feedback box for analytics is tracked', () => {
-    const page = Page.verifyOnPage(AnalyticsIncentiveLevels)
+    const charts: Partial<Record<ChartId, string>> = {
+      'incentive-levels-by-location': 'Is this chart useful > Incentive level by establishment (Group)',
+      'trends-incentive-levels': 'Is this chart useful > Incentive level trends (Group)',
+    }
 
-    const gaSpy = new GoogleAnalyticsSpy()
-    gaSpy.install()
-
-    page
-      .getChartFeedback('incentive-levels-by-location')
-      .click()
-      .then(() =>
-        gaSpy.shouldHaveSentEvent('incentives_event', {
-          category: 'Is this chart useful > Incentive level by establishment (Group)',
-          action: 'opened',
-          label: 'MDI',
-        }),
-      )
-
-    page
-      .getChartFeedback('trends-incentive-levels')
-      .click()
-      .then(() =>
-        gaSpy.shouldHaveSentEvent('incentives_event', {
-          category: 'Is this chart useful > Incentive level trends (Group)',
-          action: 'opened',
-          label: 'MDI',
-        }),
-      )
+    testDetailsOpenedGaEvents(AnalyticsIncentiveLevels, 'getChartFeedback', charts)
   })
 })

--- a/integration_tests/e2e/analytics/incentiveLevels.cy.ts
+++ b/integration_tests/e2e/analytics/incentiveLevels.cy.ts
@@ -1,9 +1,15 @@
-import { getTextFromTable, testInvalidFeedbackSubmission, testValidFeedbackSubmission } from './utils'
+import {
+  getTextFromTable,
+  testGuidanceBoxes,
+  testInvalidFeedbackSubmission,
+  testValidFeedbackSubmission,
+} from './utils'
 import Page from '../../pages/page'
 import HomePage from '../../pages/home'
 import AnalyticsIncentiveLevels from '../../pages/analytics/incentiveLevels'
 import GoogleAnalyticsSpy from '../../plugins/googleAnalyticsSpy'
 import PgdRegionSelection from '../../pages/analytics/pgdRegionSelection'
+import { ChartId } from '../../../server/routes/analyticsChartTypes'
 
 context('Analytics section > Incentive levels page', () => {
   beforeEach(() => {
@@ -58,32 +64,12 @@ context('Analytics section > Incentive levels page', () => {
   })
 
   it('guidance box for analytics is tracked', () => {
-    const page = Page.verifyOnPage(AnalyticsIncentiveLevels)
+    const charts: Partial<Record<ChartId, string>> = {
+      'incentive-levels-by-location': 'Incentive level by wing (Prison)',
+      'trends-incentive-levels': 'Incentive level trends (Prison)',
+    }
 
-    const gaSpy = new GoogleAnalyticsSpy()
-    gaSpy.install()
-
-    page
-      .getChartGuidance('incentive-levels-by-location')
-      .click()
-      .then(() =>
-        gaSpy.shouldHaveSentEvent('incentives_event', {
-          category: 'How you can use this chart > Incentive level by wing (Prison)',
-          action: 'opened',
-          label: 'MDI',
-        }),
-      )
-
-    page
-      .getChartGuidance('trends-incentive-levels')
-      .click()
-      .then(() =>
-        gaSpy.shouldHaveSentEvent('incentives_event', {
-          category: 'How you can use this chart > Incentive level trends (Prison)',
-          action: 'opened',
-          label: 'MDI',
-        }),
-      )
+    testGuidanceBoxes(AnalyticsIncentiveLevels, charts)
   })
 
   it('chart feedback box for analytics is tracked', () => {
@@ -187,32 +173,12 @@ context('Pgd Region selection > National > Analytics section > Incentive levels 
   })
 
   it('guidance box for analytics is tracked', () => {
-    const page = Page.verifyOnPage(AnalyticsIncentiveLevels)
+    const charts: Partial<Record<ChartId, string>> = {
+      'incentive-levels-by-location': 'Incentive level by prison group (National)',
+      'trends-incentive-levels': 'Incentive level trends (National)',
+    }
 
-    const gaSpy = new GoogleAnalyticsSpy()
-    gaSpy.install()
-
-    page
-      .getChartGuidance('incentive-levels-by-location')
-      .click()
-      .then(() =>
-        gaSpy.shouldHaveSentEvent('incentives_event', {
-          category: 'How you can use this chart > Incentive level by prison group (National)',
-          action: 'opened',
-          label: 'MDI',
-        }),
-      )
-
-    page
-      .getChartGuidance('trends-incentive-levels')
-      .click()
-      .then(() =>
-        gaSpy.shouldHaveSentEvent('incentives_event', {
-          category: 'How you can use this chart > Incentive level trends (National)',
-          action: 'opened',
-          label: 'MDI',
-        }),
-      )
+    testGuidanceBoxes(AnalyticsIncentiveLevels, charts)
   })
 
   it('chart feedback box for analytics is tracked', () => {
@@ -294,32 +260,12 @@ context('Pgd Region selection > LTHS > Analytics section > Incentive levels page
   })
 
   it('guidance box for analytics is tracked', () => {
-    const page = Page.verifyOnPage(AnalyticsIncentiveLevels)
+    const charts: Partial<Record<ChartId, string>> = {
+      'incentive-levels-by-location': 'Incentive level by establishment (Group)',
+      'trends-incentive-levels': 'Incentive level trends (Group)',
+    }
 
-    const gaSpy = new GoogleAnalyticsSpy()
-    gaSpy.install()
-
-    page
-      .getChartGuidance('incentive-levels-by-location')
-      .click()
-      .then(() =>
-        gaSpy.shouldHaveSentEvent('incentives_event', {
-          category: 'How you can use this chart > Incentive level by establishment (Group)',
-          action: 'opened',
-          label: 'MDI',
-        }),
-      )
-
-    page
-      .getChartGuidance('trends-incentive-levels')
-      .click()
-      .then(() =>
-        gaSpy.shouldHaveSentEvent('incentives_event', {
-          category: 'How you can use this chart > Incentive level trends (Group)',
-          action: 'opened',
-          label: 'MDI',
-        }),
-      )
+    testGuidanceBoxes(AnalyticsIncentiveLevels, charts)
   })
 
   it('chart feedback box for analytics is tracked', () => {

--- a/integration_tests/e2e/analytics/protectedCharacteristics.cy.ts
+++ b/integration_tests/e2e/analytics/protectedCharacteristics.cy.ts
@@ -42,7 +42,7 @@ context('Analytics section > Protected characteristics page', () => {
   })
 
   it('has correct title', () => {
-    cy.title().should('eq', 'Manage incentives – Protected characteristics – Prison')
+    cy.title().should('eq', 'Manage incentives – Protected characteristics (Age) – Prison')
   })
 
   it('has feedback banner', () => {
@@ -53,6 +53,8 @@ context('Analytics section > Protected characteristics page', () => {
   it('selector allows user to change protected characteristic', () => {
     cy.get('#characteristic').select('Sexual orientation')
     cy.get('#form-select-characteristic button').click()
+
+    cy.title().should('eq', 'Manage incentives – Protected characteristics (Sexual orientation) – Prison')
 
     cy.get('h2.govuk-heading-m')
       .first()
@@ -263,12 +265,14 @@ context('Pgd Region selection > National > Analytics section > Protected charact
   })
 
   it('has correct title', () => {
-    cy.title().should('eq', 'Manage incentives – Protected characteristics – National')
+    cy.title().should('eq', 'Manage incentives – Protected characteristics (Age) – National')
   })
 
   it('selector allows user to change protected characteristic for that pgdRegion', () => {
     cy.get('#characteristic').select('Sexual orientation')
     cy.get('#form-select-characteristic button').click()
+
+    cy.title().should('eq', 'Manage incentives – Protected characteristics (Sexual orientation) – National')
 
     cy.get('.govuk-heading-xl').contains('National')
     cy.get('h2.govuk-heading-m').first().contains('Percentage and number of prisoners by sexual orientation')
@@ -397,7 +401,7 @@ context('Pgd Region selection > LTHS > Analytics section > Protected characteris
   })
 
   it('has correct title', () => {
-    cy.title().should('eq', 'Manage incentives – Protected characteristics – Long-term and high security')
+    cy.title().should('eq', 'Manage incentives – Protected characteristics (Age) – Long-term and high security')
   })
 
   it('users see analytics', () => {

--- a/integration_tests/e2e/analytics/protectedCharacteristics.cy.ts
+++ b/integration_tests/e2e/analytics/protectedCharacteristics.cy.ts
@@ -41,6 +41,10 @@ context('Analytics section > Protected characteristics page', () => {
     analyticsPage.protectedCharacteristicsNavItem.click()
   })
 
+  it('has correct title', () => {
+    cy.title().should('eq', 'Manage incentives – Protected characteristics – Prison')
+  })
+
   it('has feedback banner', () => {
     cy.get('.app-feedback-banner').contains('help us to improve it')
     cy.get('.app-feedback-banner a').invoke('attr', 'href').should('equal', 'https://example.com/analytics-feedback')
@@ -258,6 +262,10 @@ context('Pgd Region selection > National > Analytics section > Protected charact
     analyticsPage.protectedCharacteristicsNavItem.click()
   })
 
+  it('has correct title', () => {
+    cy.title().should('eq', 'Manage incentives – Protected characteristics – National')
+  })
+
   it('selector allows user to change protected characteristic for that pgdRegion', () => {
     cy.get('#characteristic').select('Sexual orientation')
     cy.get('#form-select-characteristic button').click()
@@ -386,6 +394,10 @@ context('Pgd Region selection > LTHS > Analytics section > Protected characteris
     locationSelectionPage.continueButton().click()
     const analyticsPage = Page.verifyOnPage(AnalyticsIncentiveLevels)
     analyticsPage.protectedCharacteristicsNavItem.click()
+  })
+
+  it('has correct title', () => {
+    cy.title().should('eq', 'Manage incentives – Protected characteristics – Long-term and high security')
   })
 
   it('users see analytics', () => {

--- a/integration_tests/e2e/analytics/protectedCharacteristics.cy.ts
+++ b/integration_tests/e2e/analytics/protectedCharacteristics.cy.ts
@@ -1,6 +1,6 @@
 import {
   getTextFromTable,
-  testGuidanceBoxes,
+  testDetailsOpenedGaEvents,
   testInvalidFeedbackSubmission,
   testValidFeedbackSubmission,
 } from './utils'
@@ -8,7 +8,6 @@ import Page from '../../pages/page'
 import HomePage from '../../pages/home'
 import AnalyticsIncentiveLevels from '../../pages/analytics/incentiveLevels'
 import AnalyticsProtectedCharacteristics from '../../pages/analytics/protectedCharacteristics'
-import GoogleAnalyticsSpy from '../../plugins/googleAnalyticsSpy'
 import { ChartId } from '../../../server/routes/analyticsChartTypes'
 import PgdRegionSelection from '../../pages/analytics/pgdRegionSelection'
 
@@ -173,43 +172,26 @@ context('Analytics section > Protected characteristics page', () => {
 
   it('guidance box for analytics is tracked', () => {
     const charts: Partial<Record<ChartId, string>> = {
-      'incentive-levels-by-age': 'Incentive level by age (Prison)',
-      'trends-incentive-levels-by-age': 'Incentive level by age trends (Prison)',
-      'entries-by-age': 'Comparison of behaviour entries by age (Prison)',
-      'trends-entries-by-age': 'Behaviour entries by age trends (Prison)',
-      'prisoners-with-entries-by-age': 'Behaviour entries by age (Prison)',
+      'incentive-levels-by-age': 'How you can use this chart > Incentive level by age (Prison)',
+      'trends-incentive-levels-by-age': 'How you can use this chart > Incentive level by age trends (Prison)',
+      'entries-by-age': 'How you can use this chart > Comparison of behaviour entries by age (Prison)',
+      'trends-entries-by-age': 'How you can use this chart > Behaviour entries by age trends (Prison)',
+      'prisoners-with-entries-by-age': 'How you can use this chart > Behaviour entries by age (Prison)',
     }
-    testGuidanceBoxes(AnalyticsProtectedCharacteristics, charts)
+    testDetailsOpenedGaEvents(AnalyticsProtectedCharacteristics, 'getChartGuidance', charts)
   })
 
   it('chart feedback box for analytics is tracked', () => {
-    const page = Page.verifyOnPage(AnalyticsProtectedCharacteristics)
-
-    const gaSpy = new GoogleAnalyticsSpy()
-    gaSpy.install()
-
-    const feedbackBoxes: [ChartId, string][] = [
-      ['population-by-age', 'Is this chart useful > Population by age (Prison)'],
-      ['incentive-levels-by-age', 'Is this chart useful > Incentive level by age (Prison)'],
-      ['trends-incentive-levels-by-age', 'Is this chart useful > Incentive level by age trends (Prison)'],
-      ['entries-by-age', 'Is this chart useful > Comparison of behaviour entries by age (Prison)'],
-      ['trends-entries-by-age', 'Is this chart useful > Behaviour entries by age trends (Prison)'],
-      ['prisoners-with-entries-by-age', 'Is this chart useful > Behaviour entries by age (Prison)'],
-    ]
-
-    // eslint-disable-next-line no-restricted-syntax
-    for (const [chartId, expectedCategory] of feedbackBoxes) {
-      page
-        .getChartFeedback(chartId)
-        .click()
-        .then(() =>
-          gaSpy.shouldHaveSentEvent('incentives_event', {
-            category: expectedCategory,
-            action: 'opened',
-            label: 'MDI',
-          }),
-        )
+    const charts: Partial<Record<ChartId, string>> = {
+      'population-by-age': 'Is this chart useful > Population by age (Prison)',
+      'incentive-levels-by-age': 'Is this chart useful > Incentive level by age (Prison)',
+      'trends-incentive-levels-by-age': 'Is this chart useful > Incentive level by age trends (Prison)',
+      'entries-by-age': 'Is this chart useful > Comparison of behaviour entries by age (Prison)',
+      'trends-entries-by-age': 'Is this chart useful > Behaviour entries by age trends (Prison)',
+      'prisoners-with-entries-by-age': 'Is this chart useful > Behaviour entries by age (Prison)',
     }
+
+    testDetailsOpenedGaEvents(AnalyticsProtectedCharacteristics, 'getChartFeedback', charts)
   })
 
   it('users can submit feedback on charts', () => {
@@ -372,43 +354,26 @@ context('Pgd Region selection > National > Analytics section > Protected charact
 
   it('guidance box for analytics is tracked', () => {
     const charts: Partial<Record<ChartId, string>> = {
-      'incentive-levels-by-age': 'Incentive level by age (National)',
-      'trends-incentive-levels-by-age': 'Incentive level by age trends (National)',
-      'entries-by-age': 'Comparison of behaviour entries by age (National)',
-      'trends-entries-by-age': 'Behaviour entries by age trends (National)',
-      'prisoners-with-entries-by-age': 'Behaviour entries by age (National)',
+      'incentive-levels-by-age': 'How you can use this chart > Incentive level by age (National)',
+      'trends-incentive-levels-by-age': 'How you can use this chart > Incentive level by age trends (National)',
+      'entries-by-age': 'How you can use this chart > Comparison of behaviour entries by age (National)',
+      'trends-entries-by-age': 'How you can use this chart > Behaviour entries by age trends (National)',
+      'prisoners-with-entries-by-age': 'How you can use this chart > Behaviour entries by age (National)',
     }
-    testGuidanceBoxes(AnalyticsProtectedCharacteristics, charts)
+    testDetailsOpenedGaEvents(AnalyticsProtectedCharacteristics, 'getChartGuidance', charts)
   })
 
   it('chart feedback box for analytics is tracked', () => {
-    const page = Page.verifyOnPage(AnalyticsProtectedCharacteristics)
-
-    const gaSpy = new GoogleAnalyticsSpy()
-    gaSpy.install()
-
-    const feedbackBoxes: [ChartId, string][] = [
-      ['population-by-age', 'Is this chart useful > Population by age (National)'],
-      ['incentive-levels-by-age', 'Is this chart useful > Incentive level by age (National)'],
-      ['trends-incentive-levels-by-age', 'Is this chart useful > Incentive level by age trends (National)'],
-      ['entries-by-age', 'Is this chart useful > Comparison of behaviour entries by age (National)'],
-      ['trends-entries-by-age', 'Is this chart useful > Behaviour entries by age trends (National)'],
-      ['prisoners-with-entries-by-age', 'Is this chart useful > Behaviour entries by age (National)'],
-    ]
-
-    // eslint-disable-next-line no-restricted-syntax
-    for (const [chartId, expectedCategory] of feedbackBoxes) {
-      page
-        .getChartFeedback(chartId)
-        .click()
-        .then(() =>
-          gaSpy.shouldHaveSentEvent('incentives_event', {
-            category: expectedCategory,
-            action: 'opened',
-            label: 'MDI',
-          }),
-        )
+    const charts: Partial<Record<ChartId, string>> = {
+      'population-by-age': 'Is this chart useful > Population by age (National)',
+      'incentive-levels-by-age': 'Is this chart useful > Incentive level by age (National)',
+      'trends-incentive-levels-by-age': 'Is this chart useful > Incentive level by age trends (National)',
+      'entries-by-age': 'Is this chart useful > Comparison of behaviour entries by age (National)',
+      'trends-entries-by-age': 'Is this chart useful > Behaviour entries by age trends (National)',
+      'prisoners-with-entries-by-age': 'Is this chart useful > Behaviour entries by age (National)',
     }
+
+    testDetailsOpenedGaEvents(AnalyticsProtectedCharacteristics, 'getChartFeedback', charts)
   })
 })
 
@@ -523,42 +488,25 @@ context('Pgd Region selection > LTHS > Analytics section > Protected characteris
 
   it('guidance box for analytics is tracked', () => {
     const charts: Partial<Record<ChartId, string>> = {
-      'incentive-levels-by-age': 'Incentive level by age (Group)',
-      'trends-incentive-levels-by-age': 'Incentive level by age trends (Group)',
-      'entries-by-age': 'Comparison of behaviour entries by age (Group)',
-      'trends-entries-by-age': 'Behaviour entries by age trends (Group)',
-      'prisoners-with-entries-by-age': 'Behaviour entries by age (Group)',
+      'incentive-levels-by-age': 'How you can use this chart > Incentive level by age (Group)',
+      'trends-incentive-levels-by-age': 'How you can use this chart > Incentive level by age trends (Group)',
+      'entries-by-age': 'How you can use this chart > Comparison of behaviour entries by age (Group)',
+      'trends-entries-by-age': 'How you can use this chart > Behaviour entries by age trends (Group)',
+      'prisoners-with-entries-by-age': 'How you can use this chart > Behaviour entries by age (Group)',
     }
-    testGuidanceBoxes(AnalyticsProtectedCharacteristics, charts)
+    testDetailsOpenedGaEvents(AnalyticsProtectedCharacteristics, 'getChartGuidance', charts)
   })
 
   it('chart feedback box for analytics is tracked', () => {
-    const page = Page.verifyOnPage(AnalyticsProtectedCharacteristics)
-
-    const gaSpy = new GoogleAnalyticsSpy()
-    gaSpy.install()
-
-    const feedbackBoxes: [ChartId, string][] = [
-      ['population-by-age', 'Is this chart useful > Population by age (Group)'],
-      ['incentive-levels-by-age', 'Is this chart useful > Incentive level by age (Group)'],
-      ['trends-incentive-levels-by-age', 'Is this chart useful > Incentive level by age trends (Group)'],
-      ['entries-by-age', 'Is this chart useful > Comparison of behaviour entries by age (Group)'],
-      ['trends-entries-by-age', 'Is this chart useful > Behaviour entries by age trends (Group)'],
-      ['prisoners-with-entries-by-age', 'Is this chart useful > Behaviour entries by age (Group)'],
-    ]
-
-    // eslint-disable-next-line no-restricted-syntax
-    for (const [chartId, expectedCategory] of feedbackBoxes) {
-      page
-        .getChartFeedback(chartId)
-        .click()
-        .then(() =>
-          gaSpy.shouldHaveSentEvent('incentives_event', {
-            category: expectedCategory,
-            action: 'opened',
-            label: 'MDI',
-          }),
-        )
+    const charts: Partial<Record<ChartId, string>> = {
+      'population-by-age': 'Is this chart useful > Population by age (Group)',
+      'incentive-levels-by-age': 'Is this chart useful > Incentive level by age (Group)',
+      'trends-incentive-levels-by-age': 'Is this chart useful > Incentive level by age trends (Group)',
+      'entries-by-age': 'Is this chart useful > Comparison of behaviour entries by age (Group)',
+      'trends-entries-by-age': 'Is this chart useful > Behaviour entries by age trends (Group)',
+      'prisoners-with-entries-by-age': 'Is this chart useful > Behaviour entries by age (Group)',
     }
+
+    testDetailsOpenedGaEvents(AnalyticsProtectedCharacteristics, 'getChartFeedback', charts)
   })
 })

--- a/integration_tests/e2e/analytics/protectedCharacteristics.cy.ts
+++ b/integration_tests/e2e/analytics/protectedCharacteristics.cy.ts
@@ -1,4 +1,9 @@
-import { getTextFromTable, testInvalidFeedbackSubmission, testValidFeedbackSubmission } from './utils'
+import {
+  getTextFromTable,
+  testGuidanceBoxes,
+  testInvalidFeedbackSubmission,
+  testValidFeedbackSubmission,
+} from './utils'
 import Page from '../../pages/page'
 import HomePage from '../../pages/home'
 import AnalyticsIncentiveLevels from '../../pages/analytics/incentiveLevels'
@@ -167,32 +172,14 @@ context('Analytics section > Protected characteristics page', () => {
   })
 
   it('guidance box for analytics is tracked', () => {
-    const page = Page.verifyOnPage(AnalyticsProtectedCharacteristics)
-
-    const gaSpy = new GoogleAnalyticsSpy()
-    gaSpy.install()
-
-    const guidanceBoxes: [ChartId, string][] = [
-      ['incentive-levels-by-age', 'How you can use this chart > Incentive level by age (Prison)'],
-      ['trends-incentive-levels-by-age', 'How you can use this chart > Incentive level by age trends (Prison)'],
-      ['entries-by-age', 'How you can use this chart > Comparison of behaviour entries by age (Prison)'],
-      ['trends-entries-by-age', 'How you can use this chart > Behaviour entries by age trends (Prison)'],
-      ['prisoners-with-entries-by-age', 'How you can use this chart > Behaviour entries by age (Prison)'],
-    ]
-
-    // eslint-disable-next-line no-restricted-syntax
-    for (const [chartId, expectedCategory] of guidanceBoxes) {
-      page
-        .getChartGuidance(chartId)
-        .click()
-        .then(() =>
-          gaSpy.shouldHaveSentEvent('incentives_event', {
-            category: expectedCategory,
-            action: 'opened',
-            label: 'MDI',
-          }),
-        )
+    const charts: Partial<Record<ChartId, string>> = {
+      'incentive-levels-by-age': 'Incentive level by age (Prison)',
+      'trends-incentive-levels-by-age': 'Incentive level by age trends (Prison)',
+      'entries-by-age': 'Comparison of behaviour entries by age (Prison)',
+      'trends-entries-by-age': 'Behaviour entries by age trends (Prison)',
+      'prisoners-with-entries-by-age': 'Behaviour entries by age (Prison)',
     }
+    testGuidanceBoxes(AnalyticsProtectedCharacteristics, charts)
   })
 
   it('chart feedback box for analytics is tracked', () => {
@@ -384,32 +371,14 @@ context('Pgd Region selection > National > Analytics section > Protected charact
   })
 
   it('guidance box for analytics is tracked', () => {
-    const page = Page.verifyOnPage(AnalyticsProtectedCharacteristics)
-
-    const gaSpy = new GoogleAnalyticsSpy()
-    gaSpy.install()
-
-    const guidanceBoxes: [ChartId, string][] = [
-      ['incentive-levels-by-age', 'How you can use this chart > Incentive level by age (National)'],
-      ['trends-incentive-levels-by-age', 'How you can use this chart > Incentive level by age trends (National)'],
-      ['entries-by-age', 'How you can use this chart > Comparison of behaviour entries by age (National)'],
-      ['trends-entries-by-age', 'How you can use this chart > Behaviour entries by age trends (National)'],
-      ['prisoners-with-entries-by-age', 'How you can use this chart > Behaviour entries by age (National)'],
-    ]
-
-    // eslint-disable-next-line no-restricted-syntax
-    for (const [chartId, expectedCategory] of guidanceBoxes) {
-      page
-        .getChartGuidance(chartId)
-        .click()
-        .then(() =>
-          gaSpy.shouldHaveSentEvent('incentives_event', {
-            category: expectedCategory,
-            action: 'opened',
-            label: 'MDI',
-          }),
-        )
+    const charts: Partial<Record<ChartId, string>> = {
+      'incentive-levels-by-age': 'Incentive level by age (National)',
+      'trends-incentive-levels-by-age': 'Incentive level by age trends (National)',
+      'entries-by-age': 'Comparison of behaviour entries by age (National)',
+      'trends-entries-by-age': 'Behaviour entries by age trends (National)',
+      'prisoners-with-entries-by-age': 'Behaviour entries by age (National)',
     }
+    testGuidanceBoxes(AnalyticsProtectedCharacteristics, charts)
   })
 
   it('chart feedback box for analytics is tracked', () => {
@@ -551,33 +520,16 @@ context('Pgd Region selection > LTHS > Analytics section > Protected characteris
 
     assertTestData(testData, page)
   })
+
   it('guidance box for analytics is tracked', () => {
-    const page = Page.verifyOnPage(AnalyticsProtectedCharacteristics)
-
-    const gaSpy = new GoogleAnalyticsSpy()
-    gaSpy.install()
-
-    const guidanceBoxes: [ChartId, string][] = [
-      ['incentive-levels-by-age', 'How you can use this chart > Incentive level by age (Group)'],
-      ['trends-incentive-levels-by-age', 'How you can use this chart > Incentive level by age trends (Group)'],
-      ['entries-by-age', 'How you can use this chart > Comparison of behaviour entries by age (Group)'],
-      ['trends-entries-by-age', 'How you can use this chart > Behaviour entries by age trends (Group)'],
-      ['prisoners-with-entries-by-age', 'How you can use this chart > Behaviour entries by age (Group)'],
-    ]
-
-    // eslint-disable-next-line no-restricted-syntax
-    for (const [chartId, expectedCategory] of guidanceBoxes) {
-      page
-        .getChartGuidance(chartId)
-        .click()
-        .then(() =>
-          gaSpy.shouldHaveSentEvent('incentives_event', {
-            category: expectedCategory,
-            action: 'opened',
-            label: 'MDI',
-          }),
-        )
+    const charts: Partial<Record<ChartId, string>> = {
+      'incentive-levels-by-age': 'Incentive level by age (Group)',
+      'trends-incentive-levels-by-age': 'Incentive level by age trends (Group)',
+      'entries-by-age': 'Comparison of behaviour entries by age (Group)',
+      'trends-entries-by-age': 'Behaviour entries by age trends (Group)',
+      'prisoners-with-entries-by-age': 'Behaviour entries by age (Group)',
     }
+    testGuidanceBoxes(AnalyticsProtectedCharacteristics, charts)
   })
 
   it('chart feedback box for analytics is tracked', () => {

--- a/integration_tests/e2e/analytics/protectedCharacteristics.cy.ts
+++ b/integration_tests/e2e/analytics/protectedCharacteristics.cy.ts
@@ -186,16 +186,6 @@ context('Analytics section > Protected characteristics page', () => {
             label: 'MDI',
           }),
         )
-      page
-        .getChartGuidance(chartId)
-        .click()
-        .then(() =>
-          gaSpy.shouldHaveSentEvent('incentives_event', {
-            category: expectedCategory,
-            action: 'closed',
-            label: 'MDI',
-          }),
-        )
     }
   })
 
@@ -223,16 +213,6 @@ context('Analytics section > Protected characteristics page', () => {
           gaSpy.shouldHaveSentEvent('incentives_event', {
             category: expectedCategory,
             action: 'opened',
-            label: 'MDI',
-          }),
-        )
-      page
-        .getChartFeedback(chartId)
-        .click()
-        .then(() =>
-          gaSpy.shouldHaveSentEvent('incentives_event', {
-            category: expectedCategory,
-            action: 'closed',
             label: 'MDI',
           }),
         )

--- a/integration_tests/e2e/analytics/protectedCharacteristics.cy.ts
+++ b/integration_tests/e2e/analytics/protectedCharacteristics.cy.ts
@@ -558,11 +558,11 @@ context('Pgd Region selection > LTHS > Analytics section > Protected characteris
     gaSpy.install()
 
     const guidanceBoxes: [ChartId, string][] = [
-      ['incentive-levels-by-age', 'How you can use this chart > Incentive level by age (PGD Region)'],
-      ['trends-incentive-levels-by-age', 'How you can use this chart > Incentive level by age trends (PGD Region)'],
-      ['entries-by-age', 'How you can use this chart > Comparison of behaviour entries by age (PGD Region)'],
-      ['trends-entries-by-age', 'How you can use this chart > Behaviour entries by age trends (PGD Region)'],
-      ['prisoners-with-entries-by-age', 'How you can use this chart > Behaviour entries by age (PGD Region)'],
+      ['incentive-levels-by-age', 'How you can use this chart > Incentive level by age (Group)'],
+      ['trends-incentive-levels-by-age', 'How you can use this chart > Incentive level by age trends (Group)'],
+      ['entries-by-age', 'How you can use this chart > Comparison of behaviour entries by age (Group)'],
+      ['trends-entries-by-age', 'How you can use this chart > Behaviour entries by age trends (Group)'],
+      ['prisoners-with-entries-by-age', 'How you can use this chart > Behaviour entries by age (Group)'],
     ]
 
     // eslint-disable-next-line no-restricted-syntax
@@ -587,12 +587,12 @@ context('Pgd Region selection > LTHS > Analytics section > Protected characteris
     gaSpy.install()
 
     const feedbackBoxes: [ChartId, string][] = [
-      ['population-by-age', 'Is this chart useful > Population by age (PGD Region)'],
-      ['incentive-levels-by-age', 'Is this chart useful > Incentive level by age (PGD Region)'],
-      ['trends-incentive-levels-by-age', 'Is this chart useful > Incentive level by age trends (PGD Region)'],
-      ['entries-by-age', 'Is this chart useful > Comparison of behaviour entries by age (PGD Region)'],
-      ['trends-entries-by-age', 'Is this chart useful > Behaviour entries by age trends (PGD Region)'],
-      ['prisoners-with-entries-by-age', 'Is this chart useful > Behaviour entries by age (PGD Region)'],
+      ['population-by-age', 'Is this chart useful > Population by age (Group)'],
+      ['incentive-levels-by-age', 'Is this chart useful > Incentive level by age (Group)'],
+      ['trends-incentive-levels-by-age', 'Is this chart useful > Incentive level by age trends (Group)'],
+      ['entries-by-age', 'Is this chart useful > Comparison of behaviour entries by age (Group)'],
+      ['trends-entries-by-age', 'Is this chart useful > Behaviour entries by age trends (Group)'],
+      ['prisoners-with-entries-by-age', 'Is this chart useful > Behaviour entries by age (Group)'],
     ]
 
     // eslint-disable-next-line no-restricted-syntax

--- a/integration_tests/e2e/analytics/protectedCharacteristics.cy.ts
+++ b/integration_tests/e2e/analytics/protectedCharacteristics.cy.ts
@@ -173,11 +173,11 @@ context('Analytics section > Protected characteristics page', () => {
     gaSpy.install()
 
     const guidanceBoxes: [ChartId, string][] = [
-      ['incentive-levels-by-age', 'How you can use this chart > Incentive level by age'],
-      ['trends-incentive-levels-by-age', 'How you can use this chart > Incentive level by age trends'],
-      ['entries-by-age', 'How you can use this chart > Comparison of behaviour entries by age'],
-      ['trends-entries-by-age', 'How you can use this chart > Behaviour entries by age trends'],
-      ['prisoners-with-entries-by-age', 'How you can use this chart > Behaviour entries by age'],
+      ['incentive-levels-by-age', 'How you can use this chart > Incentive level by age (Prison)'],
+      ['trends-incentive-levels-by-age', 'How you can use this chart > Incentive level by age trends (Prison)'],
+      ['entries-by-age', 'How you can use this chart > Comparison of behaviour entries by age (Prison)'],
+      ['trends-entries-by-age', 'How you can use this chart > Behaviour entries by age trends (Prison)'],
+      ['prisoners-with-entries-by-age', 'How you can use this chart > Behaviour entries by age (Prison)'],
     ]
 
     // eslint-disable-next-line no-restricted-syntax
@@ -202,12 +202,12 @@ context('Analytics section > Protected characteristics page', () => {
     gaSpy.install()
 
     const feedbackBoxes: [ChartId, string][] = [
-      ['population-by-age', 'Is this chart useful > Population by age'],
-      ['incentive-levels-by-age', 'Is this chart useful > Incentive level by age'],
-      ['trends-incentive-levels-by-age', 'Is this chart useful > Incentive level by age trends'],
-      ['entries-by-age', 'Is this chart useful > Comparison of behaviour entries by age'],
-      ['trends-entries-by-age', 'Is this chart useful > Behaviour entries by age trends'],
-      ['prisoners-with-entries-by-age', 'Is this chart useful > Behaviour entries by age'],
+      ['population-by-age', 'Is this chart useful > Population by age (Prison)'],
+      ['incentive-levels-by-age', 'Is this chart useful > Incentive level by age (Prison)'],
+      ['trends-incentive-levels-by-age', 'Is this chart useful > Incentive level by age trends (Prison)'],
+      ['entries-by-age', 'Is this chart useful > Comparison of behaviour entries by age (Prison)'],
+      ['trends-entries-by-age', 'Is this chart useful > Behaviour entries by age trends (Prison)'],
+      ['prisoners-with-entries-by-age', 'Is this chart useful > Behaviour entries by age (Prison)'],
     ]
 
     // eslint-disable-next-line no-restricted-syntax
@@ -382,6 +382,65 @@ context('Pgd Region selection > National > Analytics section > Protected charact
 
     assertTestData(testData, page)
   })
+
+  it('guidance box for analytics is tracked', () => {
+    const page = Page.verifyOnPage(AnalyticsProtectedCharacteristics)
+
+    const gaSpy = new GoogleAnalyticsSpy()
+    gaSpy.install()
+
+    const guidanceBoxes: [ChartId, string][] = [
+      ['incentive-levels-by-age', 'How you can use this chart > Incentive level by age (National)'],
+      ['trends-incentive-levels-by-age', 'How you can use this chart > Incentive level by age trends (National)'],
+      ['entries-by-age', 'How you can use this chart > Comparison of behaviour entries by age (National)'],
+      ['trends-entries-by-age', 'How you can use this chart > Behaviour entries by age trends (National)'],
+      ['prisoners-with-entries-by-age', 'How you can use this chart > Behaviour entries by age (National)'],
+    ]
+
+    // eslint-disable-next-line no-restricted-syntax
+    for (const [chartId, expectedCategory] of guidanceBoxes) {
+      page
+        .getChartGuidance(chartId)
+        .click()
+        .then(() =>
+          gaSpy.shouldHaveSentEvent('incentives_event', {
+            category: expectedCategory,
+            action: 'opened',
+            label: 'MDI',
+          }),
+        )
+    }
+  })
+
+  it('chart feedback box for analytics is tracked', () => {
+    const page = Page.verifyOnPage(AnalyticsProtectedCharacteristics)
+
+    const gaSpy = new GoogleAnalyticsSpy()
+    gaSpy.install()
+
+    const feedbackBoxes: [ChartId, string][] = [
+      ['population-by-age', 'Is this chart useful > Population by age (National)'],
+      ['incentive-levels-by-age', 'Is this chart useful > Incentive level by age (National)'],
+      ['trends-incentive-levels-by-age', 'Is this chart useful > Incentive level by age trends (National)'],
+      ['entries-by-age', 'Is this chart useful > Comparison of behaviour entries by age (National)'],
+      ['trends-entries-by-age', 'Is this chart useful > Behaviour entries by age trends (National)'],
+      ['prisoners-with-entries-by-age', 'Is this chart useful > Behaviour entries by age (National)'],
+    ]
+
+    // eslint-disable-next-line no-restricted-syntax
+    for (const [chartId, expectedCategory] of feedbackBoxes) {
+      page
+        .getChartFeedback(chartId)
+        .click()
+        .then(() =>
+          gaSpy.shouldHaveSentEvent('incentives_event', {
+            category: expectedCategory,
+            action: 'opened',
+            label: 'MDI',
+          }),
+        )
+    }
+  })
 })
 
 context('Pgd Region selection > LTHS > Analytics section > Protected characteristics page', () => {
@@ -491,5 +550,63 @@ context('Pgd Region selection > LTHS > Analytics section > Protected characteris
     ]
 
     assertTestData(testData, page)
+  })
+  it('guidance box for analytics is tracked', () => {
+    const page = Page.verifyOnPage(AnalyticsProtectedCharacteristics)
+
+    const gaSpy = new GoogleAnalyticsSpy()
+    gaSpy.install()
+
+    const guidanceBoxes: [ChartId, string][] = [
+      ['incentive-levels-by-age', 'How you can use this chart > Incentive level by age (PGD Region)'],
+      ['trends-incentive-levels-by-age', 'How you can use this chart > Incentive level by age trends (PGD Region)'],
+      ['entries-by-age', 'How you can use this chart > Comparison of behaviour entries by age (PGD Region)'],
+      ['trends-entries-by-age', 'How you can use this chart > Behaviour entries by age trends (PGD Region)'],
+      ['prisoners-with-entries-by-age', 'How you can use this chart > Behaviour entries by age (PGD Region)'],
+    ]
+
+    // eslint-disable-next-line no-restricted-syntax
+    for (const [chartId, expectedCategory] of guidanceBoxes) {
+      page
+        .getChartGuidance(chartId)
+        .click()
+        .then(() =>
+          gaSpy.shouldHaveSentEvent('incentives_event', {
+            category: expectedCategory,
+            action: 'opened',
+            label: 'MDI',
+          }),
+        )
+    }
+  })
+
+  it('chart feedback box for analytics is tracked', () => {
+    const page = Page.verifyOnPage(AnalyticsProtectedCharacteristics)
+
+    const gaSpy = new GoogleAnalyticsSpy()
+    gaSpy.install()
+
+    const feedbackBoxes: [ChartId, string][] = [
+      ['population-by-age', 'Is this chart useful > Population by age (PGD Region)'],
+      ['incentive-levels-by-age', 'Is this chart useful > Incentive level by age (PGD Region)'],
+      ['trends-incentive-levels-by-age', 'Is this chart useful > Incentive level by age trends (PGD Region)'],
+      ['entries-by-age', 'Is this chart useful > Comparison of behaviour entries by age (PGD Region)'],
+      ['trends-entries-by-age', 'Is this chart useful > Behaviour entries by age trends (PGD Region)'],
+      ['prisoners-with-entries-by-age', 'Is this chart useful > Behaviour entries by age (PGD Region)'],
+    ]
+
+    // eslint-disable-next-line no-restricted-syntax
+    for (const [chartId, expectedCategory] of feedbackBoxes) {
+      page
+        .getChartFeedback(chartId)
+        .click()
+        .then(() =>
+          gaSpy.shouldHaveSentEvent('incentives_event', {
+            category: expectedCategory,
+            action: 'opened',
+            label: 'MDI',
+          }),
+        )
+    }
   })
 })

--- a/integration_tests/e2e/analytics/utils.ts
+++ b/integration_tests/e2e/analytics/utils.ts
@@ -74,8 +74,9 @@ export function getTextFromTable(chainable: PageElement<HTMLTableRowElement>): C
   })
 }
 
-export function testGuidanceBoxes<PageClass extends AnalyticsPage>(
+export function testDetailsOpenedGaEvents<PageClass extends AnalyticsPage>(
   pageClass: new () => PageClass,
+  detailsGetterMethod: 'getChartGuidance' | 'getChartFeedback',
   charts: Partial<Record<ChartId, string>>,
 ) {
   const page = Page.verifyOnPage(pageClass)
@@ -85,12 +86,12 @@ export function testGuidanceBoxes<PageClass extends AnalyticsPage>(
 
   // eslint-disable-next-line no-restricted-syntax
   for (const [chartId, gaCategory] of Object.entries(charts)) {
-    page
-      .getChartGuidance(chartId as ChartId)
+    page[detailsGetterMethod]
+      .call(page, chartId)
       .click()
       .then(() =>
         gaSpy.shouldHaveSentEvent('incentives_event', {
-          category: `How you can use this chart > ${gaCategory}`,
+          category: gaCategory,
           action: 'opened',
           label: 'MDI',
         }),

--- a/server/routes/analyticsChartsContent.ts
+++ b/server/routes/analyticsChartsContent.ts
@@ -240,13 +240,13 @@ export const RegionalIncentiveLevelsChartsContent: Record<string, AnalyticsChart
     guidance:
       'Use this chart to see incentive level splits for individual establishments. What does it tell you about how the incentives policy is applied? Are there any opportunities to share practice?',
     labelColumn: 'Location',
-    googleAnalyticsCategory: 'Incentive level by establishment (PGD Region)',
+    googleAnalyticsCategory: 'Incentive level by establishment (Group)',
   },
   'trends-incentive-levels': {
     title: 'Incentive levels in the prison group – last 12 months',
     guidance:
       'This chart tells you the split of incentive levels across the whole prison group - it can be used as a guide to start asking questions. Be aware that patterns for individual establishments could be masked - these can be viewed separately.',
-    googleAnalyticsCategory: 'Incentive level trends (PGD Region)',
+    googleAnalyticsCategory: 'Incentive level trends (Group)',
   },
 }
 
@@ -256,20 +256,20 @@ export const RegionalBehaviourEntriesChartsContent: Record<string, AnalyticsChar
     guidance:
       'This chart lets you see the balance of positive to negative entries in each establishment. Do these proportions meet your expectations for the incentives policies?',
     labelColumn: 'Location',
-    googleAnalyticsCategory: 'Behaviour entries by establishment (PGD Region)',
+    googleAnalyticsCategory: 'Behaviour entries by establishment (Group)',
   },
   'prisoners-with-entries-by-location': {
     title: 'Percentage and number of prisoners receiving each behaviour entry type by establishment – last 28 days',
     guidance:
       'Individual prisoner behaviours can give a fuller picture of the establishment. Are you happy with how many prisoners have no behaviour entries, and what all these numbers suggest about the incentives policy application?',
     labelColumn: 'Location',
-    googleAnalyticsCategory: 'Prisoners with behaviour entries by establishment (PGD Region)',
+    googleAnalyticsCategory: 'Prisoners with behaviour entries by establishment (Group)',
   },
   'trends-entries': {
     title: 'Comparison of positive and negative behaviour entries in the prison group – last 12 months',
     guidance:
       'This chart tells you the split of behaviour entries across the whole prison group for general information. Be aware that ratios for individual establishments could be masked - these can be viewed separately.',
-    googleAnalyticsCategory: 'Behaviour entry trends (PGD Region)',
+    googleAnalyticsCategory: 'Behaviour entry trends (Group)',
   },
 }
 
@@ -287,177 +287,177 @@ export const RegionalProtectedCharacteristicsChartsContent: Record<string, Analy
   'population-by-age': {
     title: 'Percentage and number of prisoners by age',
     labelColumn: 'Age',
-    googleAnalyticsCategory: 'Population by age (PGD Region)',
+    googleAnalyticsCategory: 'Population by age (Group)',
   },
   'population-by-disability': {
     title: 'Percentage and number of prisoners by recorded disability',
     labelColumn: 'Disability',
-    googleAnalyticsCategory: 'Population by disability (PGD Region)',
+    googleAnalyticsCategory: 'Population by disability (Group)',
     labelColumnWidth: 'wide',
   },
   'population-by-ethnicity': {
     title: 'Percentage and number of prisoners by ethnicity',
     labelColumn: 'Ethnicity',
-    googleAnalyticsCategory: 'Population by ethnicity (PGD Region)',
+    googleAnalyticsCategory: 'Population by ethnicity (Group)',
     labelColumnWidth: 'wide',
   },
   'population-by-religion': {
     title: 'Percentage and number of prisoners by religion',
     labelColumn: 'Religion',
-    googleAnalyticsCategory: 'Population by religion (PGD Region)',
+    googleAnalyticsCategory: 'Population by religion (Group)',
   },
   'population-by-sexual-orientation': {
     title: 'Percentage and number of prisoners by sexual orientation',
     labelColumn: 'Sexual orientation',
-    googleAnalyticsCategory: 'Population by sexual orientation (PGD Region)',
+    googleAnalyticsCategory: 'Population by sexual orientation (Group)',
   },
   'incentive-levels-by-age': {
     title: 'Percentage and number of prisoners on each incentive level by age',
     guidance: regionalGuidanceIncentiveLevelsByPc,
     labelColumn: 'Age',
-    googleAnalyticsCategory: 'Incentive level by age (PGD Region)',
+    googleAnalyticsCategory: 'Incentive level by age (Group)',
   },
   'incentive-levels-by-disability': {
     title: 'Percentage and number of prisoners on each incentive level by recorded disability',
     guidance: regionalGuidanceIncentiveLevelsByPc,
     labelColumn: 'Disability',
-    googleAnalyticsCategory: 'Incentive level by disability (PGD Region)',
+    googleAnalyticsCategory: 'Incentive level by disability (Group)',
     labelColumnWidth: 'wide',
   },
   'incentive-levels-by-ethnicity': {
     title: 'Percentage and number of prisoners on each incentive level by ethnicity',
     guidance: regionalGuidanceIncentiveLevelsByPc,
     labelColumn: 'Ethnicity',
-    googleAnalyticsCategory: 'Incentive level by ethnicity (PGD Region)',
+    googleAnalyticsCategory: 'Incentive level by ethnicity (Group)',
     labelColumnWidth: 'wide',
   },
   'incentive-levels-by-religion': {
     title: 'Percentage and number of prisoners on each incentive level by religion',
     guidance: regionalGuidanceIncentiveLevelsByPc,
     labelColumn: 'Religion',
-    googleAnalyticsCategory: 'Incentive level by religion (PGD Region)',
+    googleAnalyticsCategory: 'Incentive level by religion (Group)',
   },
   'incentive-levels-by-sexual-orientation': {
     title: 'Percentage and number of prisoners on each incentive level by sexual orientation',
     guidance: regionalGuidanceIncentiveLevelsByPc,
     labelColumn: 'Sexual orientation',
-    googleAnalyticsCategory: 'Incentive level by sexual orientation (PGD Region)',
+    googleAnalyticsCategory: 'Incentive level by sexual orientation (Group)',
   },
   'trends-incentive-levels-by-age': {
     title: 'Incentive levels by age – last 12 months',
     guidance: regionalGuidanceTrendsIncentiveLevelsByPc,
-    googleAnalyticsCategory: 'Incentive level by age trends (PGD Region)',
+    googleAnalyticsCategory: 'Incentive level by age trends (Group)',
   },
   'trends-incentive-levels-by-disability': {
     title: 'Incentive levels by recorded disability – last 12 months',
     guidance: regionalGuidanceTrendsIncentiveLevelsByPc,
-    googleAnalyticsCategory: 'Incentive level by recorded disability trends (PGD Region)',
+    googleAnalyticsCategory: 'Incentive level by recorded disability trends (Group)',
   },
   'trends-incentive-levels-by-ethnicity': {
     title: 'Incentive levels by ethnicity – last 12 months',
     guidance: regionalGuidanceTrendsIncentiveLevelsByPc,
-    googleAnalyticsCategory: 'Incentive level by ethnicity trends (PGD Region)',
+    googleAnalyticsCategory: 'Incentive level by ethnicity trends (Group)',
   },
   'trends-incentive-levels-by-religion': {
     title: 'Incentive levels by religion – last 12 months',
     guidance: regionalGuidanceTrendsIncentiveLevelsByPc,
-    googleAnalyticsCategory: 'Incentive level by religion trends (PGD Region)',
+    googleAnalyticsCategory: 'Incentive level by religion trends (Group)',
   },
   'trends-incentive-levels-by-sexual-orientation': {
     title: 'Incentive levels by sexual orientation – last 12 months',
     guidance: regionalGuidanceTrendsIncentiveLevelsByPc,
-    googleAnalyticsCategory: 'Incentive level by sexual orientation trends (PGD Region)',
+    googleAnalyticsCategory: 'Incentive level by sexual orientation trends (Group)',
   },
   'entries-by-age': {
     title: 'Comparison of positive and negative behaviour entries by age – last 28 days',
     guidance: regionalGuidanceEntriesByPc,
     labelColumn: 'Age',
-    googleAnalyticsCategory: 'Comparison of behaviour entries by age (PGD Region)',
+    googleAnalyticsCategory: 'Comparison of behaviour entries by age (Group)',
   },
   'entries-by-disability': {
     title: 'Comparison of positive and negative behaviour entries by recorded disability – last 28 days',
     guidance: regionalGuidanceEntriesByPc,
     labelColumn: 'Disability',
-    googleAnalyticsCategory: 'Comparison of behaviour entries by disability (PGD Region)',
+    googleAnalyticsCategory: 'Comparison of behaviour entries by disability (Group)',
     labelColumnWidth: 'wide',
   },
   'entries-by-ethnicity': {
     title: 'Comparison of positive and negative behaviour entries by ethnicity – last 28 days',
     guidance: regionalGuidanceEntriesByPc,
     labelColumn: 'Ethnicity',
-    googleAnalyticsCategory: 'Comparison of behaviour entries by ethnicity (PGD Region)',
+    googleAnalyticsCategory: 'Comparison of behaviour entries by ethnicity (Group)',
     labelColumnWidth: 'wide',
   },
   'entries-by-religion': {
     title: 'Comparison of positive and negative behaviour entries by religion – last 28 days',
     guidance: regionalGuidanceEntriesByPc,
     labelColumn: 'Religion',
-    googleAnalyticsCategory: 'Comparison of behaviour entries by religion (PGD Region)',
+    googleAnalyticsCategory: 'Comparison of behaviour entries by religion (Group)',
   },
   'entries-by-sexual-orientation': {
     title: 'Comparison of positive and negative behaviour entries by sexual orientation – last 28 days',
     guidance: regionalGuidanceEntriesByPc,
     labelColumn: 'Sexual orientation',
-    googleAnalyticsCategory: 'Comparison of behaviour entries by sexual orientation (PGD Region)',
+    googleAnalyticsCategory: 'Comparison of behaviour entries by sexual orientation (Group)',
   },
   'trends-entries-by-age': {
     title: 'Comparison of positive and negative behaviour entries by age – last 12 months',
     guidance: regionalGuidanceTrendsEntriesByPc,
-    googleAnalyticsCategory: 'Behaviour entries by age trends (PGD Region)',
+    googleAnalyticsCategory: 'Behaviour entries by age trends (Group)',
   },
   'trends-entries-by-disability': {
     title: 'Comparison of positive and negative behaviour entries by recorded disability – last 12 months',
     guidance: regionalGuidanceTrendsEntriesByPc,
-    googleAnalyticsCategory: 'Behaviour entries by recorded disability trends (PGD Region)',
+    googleAnalyticsCategory: 'Behaviour entries by recorded disability trends (Group)',
   },
   'trends-entries-by-ethnicity': {
     title: 'Comparison of positive and negative behaviour entries by ethnicity – last 12 months',
     guidance: regionalGuidanceTrendsEntriesByPc,
-    googleAnalyticsCategory: 'Behaviour entries by ethnicity trends (PGD Region)',
+    googleAnalyticsCategory: 'Behaviour entries by ethnicity trends (Group)',
   },
   'trends-entries-by-religion': {
     title: 'Comparison of positive and negative behaviour entries by religion – last 12 months',
     guidance: regionalGuidanceTrendsEntriesByPc,
-    googleAnalyticsCategory: 'Behaviour entries by religion trends (PGD Region)',
+    googleAnalyticsCategory: 'Behaviour entries by religion trends (Group)',
   },
   'trends-entries-by-sexual-orientation': {
     title: 'Comparison of positive and negative behaviour entries by sexual orientation – last 12 months',
     guidance: regionalGuidanceTrendsEntriesByPc,
-    googleAnalyticsCategory: 'Behaviour entries by sexual orientation trends (PGD Region)',
+    googleAnalyticsCategory: 'Behaviour entries by sexual orientation trends (Group)',
   },
   'prisoners-with-entries-by-age': {
     title: 'Percentage and number of prisoners receiving each behaviour entry type by age – last 28 days',
     guidance: regionalGuidancePrisonersWithEntriesByPc,
     labelColumn: 'Age',
-    googleAnalyticsCategory: 'Behaviour entries by age (PGD Region)',
+    googleAnalyticsCategory: 'Behaviour entries by age (Group)',
   },
   'prisoners-with-entries-by-disability': {
     title:
       'Percentage and number of prisoners receiving each behaviour entry type by recorded disability – last 28 days',
     guidance: regionalGuidancePrisonersWithEntriesByPc,
     labelColumn: 'Disability',
-    googleAnalyticsCategory: 'Behaviour entries by disability (PGD Region)',
+    googleAnalyticsCategory: 'Behaviour entries by disability (Group)',
     labelColumnWidth: 'wide',
   },
   'prisoners-with-entries-by-ethnicity': {
     title: 'Percentage and number of prisoners receiving each behaviour entry type by ethnicity – last 28 days',
     guidance: regionalGuidancePrisonersWithEntriesByPc,
     labelColumn: 'Ethnicity',
-    googleAnalyticsCategory: 'Behaviour entries by ethnicity (PGD Region)',
+    googleAnalyticsCategory: 'Behaviour entries by ethnicity (Group)',
     labelColumnWidth: 'wide',
   },
   'prisoners-with-entries-by-religion': {
     title: 'Percentage and number of prisoners receiving each behaviour entry type by religion – last 28 days',
     guidance: regionalGuidancePrisonersWithEntriesByPc,
     labelColumn: 'Religion',
-    googleAnalyticsCategory: 'Behaviour entries by religion (PGD Region)',
+    googleAnalyticsCategory: 'Behaviour entries by religion (Group)',
   },
   'prisoners-with-entries-by-sexual-orientation': {
     title:
       'Percentage and number of prisoners receiving each behaviour entry type by sexual orientation – last 28 days',
     guidance: regionalGuidancePrisonersWithEntriesByPc,
     labelColumn: 'Sexual orientation',
-    googleAnalyticsCategory: 'Behaviour entries by sexual orientation (PGD Region)',
+    googleAnalyticsCategory: 'Behaviour entries by sexual orientation (Group)',
   },
 }
 

--- a/server/routes/analyticsChartsContent.ts
+++ b/server/routes/analyticsChartsContent.ts
@@ -12,7 +12,7 @@ export const BehaviourEntriesChartsContent: Record<string, AnalyticsChartContent
     guidance:
       'This chart lets you see the balance of positive to negative entries across the prison and at residential location level. Do these splits suggest a fair and consistent application of incentives?',
     labelColumn: 'Location',
-    googleAnalyticsCategory: 'Behaviour entries by wing',
+    googleAnalyticsCategory: 'Behaviour entries by wing (Prison)',
   },
   'prisoners-with-entries-by-location': {
     title:
@@ -20,13 +20,13 @@ export const BehaviourEntriesChartsContent: Record<string, AnalyticsChartContent
     guidance:
       'Individual prisoner behaviours can give you a fuller picture. Are you happy with how many prisoners have no entries and how many have both? Positive entries can help lead to behaviour improvements.',
     labelColumn: 'Location',
-    googleAnalyticsCategory: 'Prisoners with behaviour entries by wing',
+    googleAnalyticsCategory: 'Prisoners with behaviour entries by wing (Prison)',
   },
   'trends-entries': {
     title: 'Comparison of positive and negative behaviour entries in the establishment – last 12 months',
     guidance:
       'Use this chart to compare the numbers of positive, negative and total entries with previous months. What do the number of entries and the positive-negative ratios tell you about the incentives policy and the behaviour of prisoners? Be aware of any significant population changes.',
-    googleAnalyticsCategory: 'Behaviour entry trends',
+    googleAnalyticsCategory: 'Behaviour entry trends (Prison)',
   },
 }
 
@@ -36,13 +36,13 @@ export const IncentiveLevelsChartsContent: Record<string, AnalyticsChartContent>
     guidance:
       'Use this chart to see incentive level splits for the prison and residential location. What does it tell you about how the incentives policy is applied, the population and possible actions for your prison?',
     labelColumn: 'Location',
-    googleAnalyticsCategory: 'Incentive level by wing',
+    googleAnalyticsCategory: 'Incentive level by wing (Prison)',
   },
   'trends-incentive-levels': {
     title: 'Incentive levels in the establishment – last 12 months',
     guidance:
       'Use this chart to compare incentive levels with previous months. Information is taken from monthly averages. Is there anything that needs more exploration? Is the incentives scheme producing the levels you would like it to?',
-    googleAnalyticsCategory: 'Incentive level trends',
+    googleAnalyticsCategory: 'Incentive level trends (Prison)',
   },
 }
 
@@ -60,177 +60,177 @@ export const ProtectedCharacteristicsChartsContent: Record<string, AnalyticsChar
   'population-by-age': {
     title: 'Percentage and number of prisoners in the establishment by age',
     labelColumn: 'Age',
-    googleAnalyticsCategory: 'Population by age',
+    googleAnalyticsCategory: 'Population by age (Prison)',
   },
   'population-by-disability': {
     title: 'Percentage and number of prisoners in the establishment by recorded disability',
     labelColumn: 'Disability',
-    googleAnalyticsCategory: 'Population by disability',
+    googleAnalyticsCategory: 'Population by disability (Prison)',
     labelColumnWidth: 'wide',
   },
   'population-by-ethnicity': {
     title: 'Percentage and number of prisoners in the establishment by ethnicity',
     labelColumn: 'Ethnicity',
-    googleAnalyticsCategory: 'Population by ethnicity',
+    googleAnalyticsCategory: 'Population by ethnicity (Prison)',
     labelColumnWidth: 'wide',
   },
   'population-by-religion': {
     title: 'Percentage and number of prisoners in the establishment by religion',
     labelColumn: 'Religion',
-    googleAnalyticsCategory: 'Population by religion',
+    googleAnalyticsCategory: 'Population by religion (Prison)',
   },
   'population-by-sexual-orientation': {
     title: 'Percentage and number of prisoners in the establishment by sexual orientation',
     labelColumn: 'Sexual orientation',
-    googleAnalyticsCategory: 'Population by sexual orientation',
+    googleAnalyticsCategory: 'Population by sexual orientation (Prison)',
   },
   'incentive-levels-by-age': {
     title: 'Percentage and number of prisoners on each incentive level by age',
     guidance: guidanceIncentiveLevelsByPc,
     labelColumn: 'Age',
-    googleAnalyticsCategory: 'Incentive level by age',
+    googleAnalyticsCategory: 'Incentive level by age (Prison)',
   },
   'incentive-levels-by-disability': {
     title: 'Percentage and number of prisoners on each incentive level by recorded disability',
     guidance: guidanceIncentiveLevelsByPc,
     labelColumn: 'Disability',
-    googleAnalyticsCategory: 'Incentive level by disability',
+    googleAnalyticsCategory: 'Incentive level by disability (Prison)',
     labelColumnWidth: 'wide',
   },
   'incentive-levels-by-ethnicity': {
     title: 'Percentage and number of prisoners on each incentive level by ethnicity',
     guidance: guidanceIncentiveLevelsByPc,
     labelColumn: 'Ethnicity',
-    googleAnalyticsCategory: 'Incentive level by ethnicity',
+    googleAnalyticsCategory: 'Incentive level by ethnicity (Prison)',
     labelColumnWidth: 'wide',
   },
   'incentive-levels-by-religion': {
     title: 'Percentage and number of prisoners on each incentive level by religion',
     guidance: guidanceIncentiveLevelsByPc,
     labelColumn: 'Religion',
-    googleAnalyticsCategory: 'Incentive level by religion',
+    googleAnalyticsCategory: 'Incentive level by religion (Prison)',
   },
   'incentive-levels-by-sexual-orientation': {
     title: 'Percentage and number of prisoners on each incentive level by sexual orientation',
     guidance: guidanceIncentiveLevelsByPc,
     labelColumn: 'Sexual orientation',
-    googleAnalyticsCategory: 'Incentive level by sexual orientation',
+    googleAnalyticsCategory: 'Incentive level by sexual orientation (Prison)',
   },
   'trends-incentive-levels-by-age': {
     title: 'Incentive levels by age – last 12 months',
     guidance: guidanceTrendsIncentiveLevelsByPc,
-    googleAnalyticsCategory: 'Incentive level by age trends',
+    googleAnalyticsCategory: 'Incentive level by age trends (Prison)',
   },
   'trends-incentive-levels-by-disability': {
     title: 'Incentive levels by recorded disability – last 12 months',
     guidance: guidanceTrendsIncentiveLevelsByPc,
-    googleAnalyticsCategory: 'Incentive level by recorded disability trends',
+    googleAnalyticsCategory: 'Incentive level by recorded disability trends (Prison)',
   },
   'trends-incentive-levels-by-ethnicity': {
     title: 'Incentive levels by ethnicity – last 12 months',
     guidance: guidanceTrendsIncentiveLevelsByPc,
-    googleAnalyticsCategory: 'Incentive level by ethnicity trends',
+    googleAnalyticsCategory: 'Incentive level by ethnicity trends (Prison)',
   },
   'trends-incentive-levels-by-religion': {
     title: 'Incentive levels by religion – last 12 months',
     guidance: guidanceTrendsIncentiveLevelsByPc,
-    googleAnalyticsCategory: 'Incentive level by religion trends',
+    googleAnalyticsCategory: 'Incentive level by religion trends (Prison)',
   },
   'trends-incentive-levels-by-sexual-orientation': {
     title: 'Incentive levels by sexual orientation – last 12 months',
     guidance: guidanceTrendsIncentiveLevelsByPc,
-    googleAnalyticsCategory: 'Incentive level by sexual orientation trends',
+    googleAnalyticsCategory: 'Incentive level by sexual orientation trends (Prison)',
   },
   'entries-by-age': {
     title: 'Comparison of positive and negative behaviour entries by age – last 28 days',
     guidance: guidanceEntriesByPc,
     labelColumn: 'Age',
-    googleAnalyticsCategory: 'Comparison of behaviour entries by age',
+    googleAnalyticsCategory: 'Comparison of behaviour entries by age (Prison)',
   },
   'entries-by-disability': {
     title: 'Comparison of positive and negative behaviour entries by recorded disability – last 28 days',
     guidance: guidanceEntriesByPc,
     labelColumn: 'Disability',
-    googleAnalyticsCategory: 'Comparison of behaviour entries by disability',
+    googleAnalyticsCategory: 'Comparison of behaviour entries by disability (Prison)',
     labelColumnWidth: 'wide',
   },
   'entries-by-ethnicity': {
     title: 'Comparison of positive and negative behaviour entries by ethnicity – last 28 days',
     guidance: guidanceEntriesByPc,
     labelColumn: 'Ethnicity',
-    googleAnalyticsCategory: 'Comparison of behaviour entries by ethnicity',
+    googleAnalyticsCategory: 'Comparison of behaviour entries by ethnicity (Prison)',
     labelColumnWidth: 'wide',
   },
   'entries-by-religion': {
     title: 'Comparison of positive and negative behaviour entries by religion – last 28 days',
     guidance: guidanceEntriesByPc,
     labelColumn: 'Religion',
-    googleAnalyticsCategory: 'Comparison of behaviour entries by religion',
+    googleAnalyticsCategory: 'Comparison of behaviour entries by religion (Prison)',
   },
   'entries-by-sexual-orientation': {
     title: 'Comparison of positive and negative behaviour entries by sexual orientation – last 28 days',
     guidance: guidanceEntriesByPc,
     labelColumn: 'Sexual orientation',
-    googleAnalyticsCategory: 'Comparison of behaviour entries by sexual orientation',
+    googleAnalyticsCategory: 'Comparison of behaviour entries by sexual orientation (Prison)',
   },
   'trends-entries-by-age': {
     title: 'Comparison of positive and negative behaviour entries by age – last 12 months',
     guidance: guidanceTrendsEntriesByPc,
-    googleAnalyticsCategory: 'Behaviour entries by age trends',
+    googleAnalyticsCategory: 'Behaviour entries by age trends (Prison)',
   },
   'trends-entries-by-disability': {
     title: 'Comparison of positive and negative behaviour entries by recorded disability – last 12 months',
     guidance: guidanceTrendsEntriesByPc,
-    googleAnalyticsCategory: 'Behaviour entries by recorded disability trends',
+    googleAnalyticsCategory: 'Behaviour entries by recorded disability trends (Prison)',
   },
   'trends-entries-by-ethnicity': {
     title: 'Comparison of positive and negative behaviour entries by ethnicity – last 12 months',
     guidance: guidanceTrendsEntriesByPc,
-    googleAnalyticsCategory: 'Behaviour entries by ethnicity trends',
+    googleAnalyticsCategory: 'Behaviour entries by ethnicity trends (Prison)',
   },
   'trends-entries-by-religion': {
     title: 'Comparison of positive and negative behaviour entries by religion – last 12 months',
     guidance: guidanceTrendsEntriesByPc,
-    googleAnalyticsCategory: 'Behaviour entries by religion trends',
+    googleAnalyticsCategory: 'Behaviour entries by religion trends (Prison)',
   },
   'trends-entries-by-sexual-orientation': {
     title: 'Comparison of positive and negative behaviour entries by sexual orientation – last 12 months',
     guidance: guidanceTrendsEntriesByPc,
-    googleAnalyticsCategory: 'Behaviour entries by sexual orientation trends',
+    googleAnalyticsCategory: 'Behaviour entries by sexual orientation trends (Prison)',
   },
   'prisoners-with-entries-by-age': {
     title: 'Percentage and number of prisoners receiving each behaviour entry type by age – last 28 days',
     guidance: guidancePrisonersWithEntriesByPc,
     labelColumn: 'Age',
-    googleAnalyticsCategory: 'Behaviour entries by age',
+    googleAnalyticsCategory: 'Behaviour entries by age (Prison)',
   },
   'prisoners-with-entries-by-disability': {
     title:
       'Percentage and number of prisoners receiving each behaviour entry type by recorded disability – last 28 days',
     guidance: guidancePrisonersWithEntriesByPc,
     labelColumn: 'Disability',
-    googleAnalyticsCategory: 'Behaviour entries by disability',
+    googleAnalyticsCategory: 'Behaviour entries by disability (Prison)',
     labelColumnWidth: 'wide',
   },
   'prisoners-with-entries-by-ethnicity': {
     title: 'Percentage and number of prisoners receiving each behaviour entry type by ethnicity – last 28 days',
     guidance: guidancePrisonersWithEntriesByPc,
     labelColumn: 'Ethnicity',
-    googleAnalyticsCategory: 'Behaviour entries by ethnicity',
+    googleAnalyticsCategory: 'Behaviour entries by ethnicity (Prison)',
     labelColumnWidth: 'wide',
   },
   'prisoners-with-entries-by-religion': {
     title: 'Percentage and number of prisoners receiving each behaviour entry type by religion – last 28 days',
     guidance: guidancePrisonersWithEntriesByPc,
     labelColumn: 'Religion',
-    googleAnalyticsCategory: 'Behaviour entries by religion',
+    googleAnalyticsCategory: 'Behaviour entries by religion (Prison)',
   },
   'prisoners-with-entries-by-sexual-orientation': {
     title:
       'Percentage and number of prisoners receiving each behaviour entry type by sexual orientation – last 28 days',
     guidance: guidancePrisonersWithEntriesByPc,
     labelColumn: 'Sexual orientation',
-    googleAnalyticsCategory: 'Behaviour entries by sexual orientation',
+    googleAnalyticsCategory: 'Behaviour entries by sexual orientation (Prison)',
   },
 }
 
@@ -240,13 +240,13 @@ export const RegionalIncentiveLevelsChartsContent: Record<string, AnalyticsChart
     guidance:
       'Use this chart to see incentive level splits for individual establishments. What does it tell you about how the incentives policy is applied? Are there any opportunities to share practice?',
     labelColumn: 'Location',
-    googleAnalyticsCategory: 'Incentive level by establishment',
+    googleAnalyticsCategory: 'Incentive level by establishment (PGD Region)',
   },
   'trends-incentive-levels': {
     title: 'Incentive levels in the prison group – last 12 months',
     guidance:
       'This chart tells you the split of incentive levels across the whole prison group - it can be used as a guide to start asking questions. Be aware that patterns for individual establishments could be masked - these can be viewed separately.',
-    googleAnalyticsCategory: 'Incentive level trends',
+    googleAnalyticsCategory: 'Incentive level trends (PGD Region)',
   },
 }
 
@@ -256,20 +256,20 @@ export const RegionalBehaviourEntriesChartsContent: Record<string, AnalyticsChar
     guidance:
       'This chart lets you see the balance of positive to negative entries in each establishment. Do these proportions meet your expectations for the incentives policies?',
     labelColumn: 'Location',
-    googleAnalyticsCategory: 'Behaviour entries by establishment',
+    googleAnalyticsCategory: 'Behaviour entries by establishment (PGD Region)',
   },
   'prisoners-with-entries-by-location': {
     title: 'Percentage and number of prisoners receiving each behaviour entry type by establishment – last 28 days',
     guidance:
       'Individual prisoner behaviours can give a fuller picture of the establishment. Are you happy with how many prisoners have no behaviour entries, and what all these numbers suggest about the incentives policy application?',
     labelColumn: 'Location',
-    googleAnalyticsCategory: 'Prisoners with behaviour entries by establishment',
+    googleAnalyticsCategory: 'Prisoners with behaviour entries by establishment (PGD Region)',
   },
   'trends-entries': {
     title: 'Comparison of positive and negative behaviour entries in the prison group – last 12 months',
     guidance:
       'This chart tells you the split of behaviour entries across the whole prison group for general information. Be aware that ratios for individual establishments could be masked - these can be viewed separately.',
-    googleAnalyticsCategory: 'Behaviour entry trends',
+    googleAnalyticsCategory: 'Behaviour entry trends (PGD Region)',
   },
 }
 
@@ -287,177 +287,177 @@ export const RegionalProtectedCharacteristicsChartsContent: Record<string, Analy
   'population-by-age': {
     title: 'Percentage and number of prisoners by age',
     labelColumn: 'Age',
-    googleAnalyticsCategory: 'Population by age',
+    googleAnalyticsCategory: 'Population by age (PGD Region)',
   },
   'population-by-disability': {
     title: 'Percentage and number of prisoners by recorded disability',
     labelColumn: 'Disability',
-    googleAnalyticsCategory: 'Population by disability',
+    googleAnalyticsCategory: 'Population by disability (PGD Region)',
     labelColumnWidth: 'wide',
   },
   'population-by-ethnicity': {
     title: 'Percentage and number of prisoners by ethnicity',
     labelColumn: 'Ethnicity',
-    googleAnalyticsCategory: 'Population by ethnicity',
+    googleAnalyticsCategory: 'Population by ethnicity (PGD Region)',
     labelColumnWidth: 'wide',
   },
   'population-by-religion': {
     title: 'Percentage and number of prisoners by religion',
     labelColumn: 'Religion',
-    googleAnalyticsCategory: 'Population by religion',
+    googleAnalyticsCategory: 'Population by religion (PGD Region)',
   },
   'population-by-sexual-orientation': {
     title: 'Percentage and number of prisoners by sexual orientation',
     labelColumn: 'Sexual orientation',
-    googleAnalyticsCategory: 'Population by sexual orientation',
+    googleAnalyticsCategory: 'Population by sexual orientation (PGD Region)',
   },
   'incentive-levels-by-age': {
     title: 'Percentage and number of prisoners on each incentive level by age',
     guidance: regionalGuidanceIncentiveLevelsByPc,
     labelColumn: 'Age',
-    googleAnalyticsCategory: 'Incentive level by age',
+    googleAnalyticsCategory: 'Incentive level by age (PGD Region)',
   },
   'incentive-levels-by-disability': {
     title: 'Percentage and number of prisoners on each incentive level by recorded disability',
     guidance: regionalGuidanceIncentiveLevelsByPc,
     labelColumn: 'Disability',
-    googleAnalyticsCategory: 'Incentive level by disability',
+    googleAnalyticsCategory: 'Incentive level by disability (PGD Region)',
     labelColumnWidth: 'wide',
   },
   'incentive-levels-by-ethnicity': {
     title: 'Percentage and number of prisoners on each incentive level by ethnicity',
     guidance: regionalGuidanceIncentiveLevelsByPc,
     labelColumn: 'Ethnicity',
-    googleAnalyticsCategory: 'Incentive level by ethnicity',
+    googleAnalyticsCategory: 'Incentive level by ethnicity (PGD Region)',
     labelColumnWidth: 'wide',
   },
   'incentive-levels-by-religion': {
     title: 'Percentage and number of prisoners on each incentive level by religion',
     guidance: regionalGuidanceIncentiveLevelsByPc,
     labelColumn: 'Religion',
-    googleAnalyticsCategory: 'Incentive level by religion',
+    googleAnalyticsCategory: 'Incentive level by religion (PGD Region)',
   },
   'incentive-levels-by-sexual-orientation': {
     title: 'Percentage and number of prisoners on each incentive level by sexual orientation',
     guidance: regionalGuidanceIncentiveLevelsByPc,
     labelColumn: 'Sexual orientation',
-    googleAnalyticsCategory: 'Incentive level by sexual orientation',
+    googleAnalyticsCategory: 'Incentive level by sexual orientation (PGD Region)',
   },
   'trends-incentive-levels-by-age': {
     title: 'Incentive levels by age – last 12 months',
     guidance: regionalGuidanceTrendsIncentiveLevelsByPc,
-    googleAnalyticsCategory: 'Incentive level by age trends',
+    googleAnalyticsCategory: 'Incentive level by age trends (PGD Region)',
   },
   'trends-incentive-levels-by-disability': {
     title: 'Incentive levels by recorded disability – last 12 months',
     guidance: regionalGuidanceTrendsIncentiveLevelsByPc,
-    googleAnalyticsCategory: 'Incentive level by recorded disability trends',
+    googleAnalyticsCategory: 'Incentive level by recorded disability trends (PGD Region)',
   },
   'trends-incentive-levels-by-ethnicity': {
     title: 'Incentive levels by ethnicity – last 12 months',
     guidance: regionalGuidanceTrendsIncentiveLevelsByPc,
-    googleAnalyticsCategory: 'Incentive level by ethnicity trends',
+    googleAnalyticsCategory: 'Incentive level by ethnicity trends (PGD Region)',
   },
   'trends-incentive-levels-by-religion': {
     title: 'Incentive levels by religion – last 12 months',
     guidance: regionalGuidanceTrendsIncentiveLevelsByPc,
-    googleAnalyticsCategory: 'Incentive level by religion trends',
+    googleAnalyticsCategory: 'Incentive level by religion trends (PGD Region)',
   },
   'trends-incentive-levels-by-sexual-orientation': {
     title: 'Incentive levels by sexual orientation – last 12 months',
     guidance: regionalGuidanceTrendsIncentiveLevelsByPc,
-    googleAnalyticsCategory: 'Incentive level by sexual orientation trends',
+    googleAnalyticsCategory: 'Incentive level by sexual orientation trends (PGD Region)',
   },
   'entries-by-age': {
     title: 'Comparison of positive and negative behaviour entries by age – last 28 days',
     guidance: regionalGuidanceEntriesByPc,
     labelColumn: 'Age',
-    googleAnalyticsCategory: 'Comparison of behaviour entries by age',
+    googleAnalyticsCategory: 'Comparison of behaviour entries by age (PGD Region)',
   },
   'entries-by-disability': {
     title: 'Comparison of positive and negative behaviour entries by recorded disability – last 28 days',
     guidance: regionalGuidanceEntriesByPc,
     labelColumn: 'Disability',
-    googleAnalyticsCategory: 'Comparison of behaviour entries by disability',
+    googleAnalyticsCategory: 'Comparison of behaviour entries by disability (PGD Region)',
     labelColumnWidth: 'wide',
   },
   'entries-by-ethnicity': {
     title: 'Comparison of positive and negative behaviour entries by ethnicity – last 28 days',
     guidance: regionalGuidanceEntriesByPc,
     labelColumn: 'Ethnicity',
-    googleAnalyticsCategory: 'Comparison of behaviour entries by ethnicity',
+    googleAnalyticsCategory: 'Comparison of behaviour entries by ethnicity (PGD Region)',
     labelColumnWidth: 'wide',
   },
   'entries-by-religion': {
     title: 'Comparison of positive and negative behaviour entries by religion – last 28 days',
     guidance: regionalGuidanceEntriesByPc,
     labelColumn: 'Religion',
-    googleAnalyticsCategory: 'Comparison of behaviour entries by religion',
+    googleAnalyticsCategory: 'Comparison of behaviour entries by religion (PGD Region)',
   },
   'entries-by-sexual-orientation': {
     title: 'Comparison of positive and negative behaviour entries by sexual orientation – last 28 days',
     guidance: regionalGuidanceEntriesByPc,
     labelColumn: 'Sexual orientation',
-    googleAnalyticsCategory: 'Comparison of behaviour entries by sexual orientation',
+    googleAnalyticsCategory: 'Comparison of behaviour entries by sexual orientation (PGD Region)',
   },
   'trends-entries-by-age': {
     title: 'Comparison of positive and negative behaviour entries by age – last 12 months',
     guidance: regionalGuidanceTrendsEntriesByPc,
-    googleAnalyticsCategory: 'Behaviour entries by age trends',
+    googleAnalyticsCategory: 'Behaviour entries by age trends (PGD Region)',
   },
   'trends-entries-by-disability': {
     title: 'Comparison of positive and negative behaviour entries by recorded disability – last 12 months',
     guidance: regionalGuidanceTrendsEntriesByPc,
-    googleAnalyticsCategory: 'Behaviour entries by recorded disability trends',
+    googleAnalyticsCategory: 'Behaviour entries by recorded disability trends (PGD Region)',
   },
   'trends-entries-by-ethnicity': {
     title: 'Comparison of positive and negative behaviour entries by ethnicity – last 12 months',
     guidance: regionalGuidanceTrendsEntriesByPc,
-    googleAnalyticsCategory: 'Behaviour entries by ethnicity trends',
+    googleAnalyticsCategory: 'Behaviour entries by ethnicity trends (PGD Region)',
   },
   'trends-entries-by-religion': {
     title: 'Comparison of positive and negative behaviour entries by religion – last 12 months',
     guidance: regionalGuidanceTrendsEntriesByPc,
-    googleAnalyticsCategory: 'Behaviour entries by religion trends',
+    googleAnalyticsCategory: 'Behaviour entries by religion trends (PGD Region)',
   },
   'trends-entries-by-sexual-orientation': {
     title: 'Comparison of positive and negative behaviour entries by sexual orientation – last 12 months',
     guidance: regionalGuidanceTrendsEntriesByPc,
-    googleAnalyticsCategory: 'Behaviour entries by sexual orientation trends',
+    googleAnalyticsCategory: 'Behaviour entries by sexual orientation trends (PGD Region)',
   },
   'prisoners-with-entries-by-age': {
     title: 'Percentage and number of prisoners receiving each behaviour entry type by age – last 28 days',
     guidance: regionalGuidancePrisonersWithEntriesByPc,
     labelColumn: 'Age',
-    googleAnalyticsCategory: 'Behaviour entries by age',
+    googleAnalyticsCategory: 'Behaviour entries by age (PGD Region)',
   },
   'prisoners-with-entries-by-disability': {
     title:
       'Percentage and number of prisoners receiving each behaviour entry type by recorded disability – last 28 days',
     guidance: regionalGuidancePrisonersWithEntriesByPc,
     labelColumn: 'Disability',
-    googleAnalyticsCategory: 'Behaviour entries by disability',
+    googleAnalyticsCategory: 'Behaviour entries by disability (PGD Region)',
     labelColumnWidth: 'wide',
   },
   'prisoners-with-entries-by-ethnicity': {
     title: 'Percentage and number of prisoners receiving each behaviour entry type by ethnicity – last 28 days',
     guidance: regionalGuidancePrisonersWithEntriesByPc,
     labelColumn: 'Ethnicity',
-    googleAnalyticsCategory: 'Behaviour entries by ethnicity',
+    googleAnalyticsCategory: 'Behaviour entries by ethnicity (PGD Region)',
     labelColumnWidth: 'wide',
   },
   'prisoners-with-entries-by-religion': {
     title: 'Percentage and number of prisoners receiving each behaviour entry type by religion – last 28 days',
     guidance: regionalGuidancePrisonersWithEntriesByPc,
     labelColumn: 'Religion',
-    googleAnalyticsCategory: 'Behaviour entries by religion',
+    googleAnalyticsCategory: 'Behaviour entries by religion (PGD Region)',
   },
   'prisoners-with-entries-by-sexual-orientation': {
     title:
       'Percentage and number of prisoners receiving each behaviour entry type by sexual orientation – last 28 days',
     guidance: regionalGuidancePrisonersWithEntriesByPc,
     labelColumn: 'Sexual orientation',
-    googleAnalyticsCategory: 'Behaviour entries by sexual orientation',
+    googleAnalyticsCategory: 'Behaviour entries by sexual orientation (PGD Region)',
   },
 }
 
@@ -467,13 +467,13 @@ export const NationalIncentiveLevelsChartsContent: Record<string, AnalyticsChart
     guidance:
       'Use this chart to see incentive level splits nationally and for each prison group. This will give you information for general patterns across the prison service, but it could highlight where you might want to explore further.',
     labelColumn: 'Location',
-    googleAnalyticsCategory: 'Incentive level by prison group',
+    googleAnalyticsCategory: 'Incentive level by prison group (National)',
   },
   'trends-incentive-levels': {
     title: 'National incentive levels – last 12 months',
     guidance:
       'This chart tells you the split of incentive levels nationally across the whole prison service in the last 12 months. It can be used as a guide to start asking questions, and to inform where you might want to look deeper.',
-    googleAnalyticsCategory: 'Incentive level trends',
+    googleAnalyticsCategory: 'Incentive level trends (National)',
   },
 }
 
@@ -483,20 +483,20 @@ export const NationalBehaviourEntriesChartsContent: Record<string, AnalyticsChar
     guidance:
       'This chart lets you see the balance of positive to negative entries nationally and at prison group level, for general information.',
     labelColumn: 'Location',
-    googleAnalyticsCategory: 'Behaviour entries by prison group',
+    googleAnalyticsCategory: 'Behaviour entries by prison group (National)',
   },
   'prisoners-with-entries-by-location': {
     title: 'Percentage and number of prisoners receiving each behaviour entry type by prison group – last 28 days',
     guidance:
       'This chart shows you the breakdown of prisoners receiving each behaviour entry type, nationally and at prison group level. Do these numbers suggest anything about how incentive policies are generally being applied?',
     labelColumn: 'Location',
-    googleAnalyticsCategory: 'Prisoners with behaviour entries by prison group',
+    googleAnalyticsCategory: 'Prisoners with behaviour entries by prison group (National)',
   },
   'trends-entries': {
     title: 'Comparison of positive and negative behaviour entries at national level – last 12 months',
     guidance:
       'This chart shows you the split of behaviour entries nationally, for general information. Be aware that ratios for individual establishments and prison groups could be quite different.',
-    googleAnalyticsCategory: 'Behaviour entry trends',
+    googleAnalyticsCategory: 'Behaviour entry trends (National)',
   },
 }
 
@@ -514,176 +514,176 @@ export const NationalProtectedCharacteristicsChartsContent: Record<string, Analy
   'population-by-age': {
     title: 'Percentage and number of prisoners by age',
     labelColumn: 'Age',
-    googleAnalyticsCategory: 'Population by age',
+    googleAnalyticsCategory: 'Population by age (National)',
   },
   'population-by-disability': {
     title: 'Percentage and number of prisoners by recorded disability',
     labelColumn: 'Disability',
-    googleAnalyticsCategory: 'Population by disability',
+    googleAnalyticsCategory: 'Population by disability (National)',
     labelColumnWidth: 'wide',
   },
   'population-by-ethnicity': {
     title: 'Percentage and number of prisoners by ethnicity',
     labelColumn: 'Ethnicity',
-    googleAnalyticsCategory: 'Population by ethnicity',
+    googleAnalyticsCategory: 'Population by ethnicity (National)',
     labelColumnWidth: 'wide',
   },
   'population-by-religion': {
     title: 'Percentage and number of prisoners by religion',
     labelColumn: 'Religion',
-    googleAnalyticsCategory: 'Population by religion',
+    googleAnalyticsCategory: 'Population by religion (National)',
   },
   'population-by-sexual-orientation': {
     title: 'Percentage and number of prisoners by sexual orientation',
     labelColumn: 'Sexual orientation',
-    googleAnalyticsCategory: 'Population by sexual orientation',
+    googleAnalyticsCategory: 'Population by sexual orientation (National)',
   },
   'incentive-levels-by-age': {
     title: 'Percentage and number of prisoners on each incentive level by age',
     guidance: nationalGuidanceIncentiveLevelsByPc,
     labelColumn: 'Age',
-    googleAnalyticsCategory: 'Incentive level by age',
+    googleAnalyticsCategory: 'Incentive level by age (National)',
   },
   'incentive-levels-by-disability': {
     title: 'Percentage and number of prisoners on each incentive level by recorded disability',
     guidance: nationalGuidanceIncentiveLevelsByPc,
     labelColumn: 'Disability',
-    googleAnalyticsCategory: 'Incentive level by disability',
+    googleAnalyticsCategory: 'Incentive level by disability (National)',
     labelColumnWidth: 'wide',
   },
   'incentive-levels-by-ethnicity': {
     title: 'Percentage and number of prisoners on each incentive level by ethnicity',
     guidance: nationalGuidanceIncentiveLevelsByPc,
     labelColumn: 'Ethnicity',
-    googleAnalyticsCategory: 'Incentive level by ethnicity',
+    googleAnalyticsCategory: 'Incentive level by ethnicity (National)',
     labelColumnWidth: 'wide',
   },
   'incentive-levels-by-religion': {
     title: 'Percentage and number of prisoners on each incentive level by religion',
     guidance: nationalGuidanceIncentiveLevelsByPc,
     labelColumn: 'Religion',
-    googleAnalyticsCategory: 'Incentive level by religion',
+    googleAnalyticsCategory: 'Incentive level by religion (National)',
   },
   'incentive-levels-by-sexual-orientation': {
     title: 'Percentage and number of prisoners on each incentive level by sexual orientation',
     guidance: nationalGuidanceIncentiveLevelsByPc,
     labelColumn: 'Sexual orientation',
-    googleAnalyticsCategory: 'Incentive level by sexual orientation',
+    googleAnalyticsCategory: 'Incentive level by sexual orientation (National)',
   },
   'trends-incentive-levels-by-age': {
     title: 'Incentive levels by age – last 12 months',
     guidance: nationalGuidanceTrendsIncentiveLevelsByPc,
-    googleAnalyticsCategory: 'Incentive level by age trends',
+    googleAnalyticsCategory: 'Incentive level by age trends (National)',
   },
   'trends-incentive-levels-by-disability': {
     title: 'Incentive levels by recorded disability – last 12 months',
     guidance: nationalGuidanceTrendsIncentiveLevelsByPc,
-    googleAnalyticsCategory: 'Incentive level by recorded disability trends',
+    googleAnalyticsCategory: 'Incentive level by recorded disability trends (National)',
   },
   'trends-incentive-levels-by-ethnicity': {
     title: 'Incentive levels by ethnicity – last 12 months',
     guidance: nationalGuidanceTrendsIncentiveLevelsByPc,
-    googleAnalyticsCategory: 'Incentive level by ethnicity trends',
+    googleAnalyticsCategory: 'Incentive level by ethnicity trends (National)',
   },
   'trends-incentive-levels-by-religion': {
     title: 'Incentive levels by religion – last 12 months',
     guidance: nationalGuidanceTrendsIncentiveLevelsByPc,
-    googleAnalyticsCategory: 'Incentive level by religion trends',
+    googleAnalyticsCategory: 'Incentive level by religion trends (National)',
   },
   'trends-incentive-levels-by-sexual-orientation': {
     title: 'Incentive levels by sexual orientation – last 12 months',
     guidance: nationalGuidanceTrendsIncentiveLevelsByPc,
-    googleAnalyticsCategory: 'Incentive level by sexual orientation trends',
+    googleAnalyticsCategory: 'Incentive level by sexual orientation trends (National)',
   },
   'entries-by-age': {
     title: 'Comparison of positive and negative behaviour entries by age – last 28 days',
     guidance: nationalGuidanceEntriesByPc,
     labelColumn: 'Age',
-    googleAnalyticsCategory: 'Comparison of behaviour entries by age',
+    googleAnalyticsCategory: 'Comparison of behaviour entries by age (National)',
   },
   'entries-by-disability': {
     title: 'Comparison of positive and negative behaviour entries by recorded disability – last 28 days',
     guidance: nationalGuidanceEntriesByPc,
     labelColumn: 'Disability',
-    googleAnalyticsCategory: 'Comparison of behaviour entries by disability',
+    googleAnalyticsCategory: 'Comparison of behaviour entries by disability (National)',
     labelColumnWidth: 'wide',
   },
   'entries-by-ethnicity': {
     title: 'Comparison of positive and negative behaviour entries by ethnicity – last 28 days',
     guidance: nationalGuidanceEntriesByPc,
     labelColumn: 'Ethnicity',
-    googleAnalyticsCategory: 'Comparison of behaviour entries by ethnicity',
+    googleAnalyticsCategory: 'Comparison of behaviour entries by ethnicity (National)',
     labelColumnWidth: 'wide',
   },
   'entries-by-religion': {
     title: 'Comparison of positive and negative behaviour entries by religion – last 28 days',
     guidance: nationalGuidanceEntriesByPc,
     labelColumn: 'Religion',
-    googleAnalyticsCategory: 'Comparison of behaviour entries by religion',
+    googleAnalyticsCategory: 'Comparison of behaviour entries by religion (National)',
   },
   'entries-by-sexual-orientation': {
     title: 'Comparison of positive and negative behaviour entries by sexual orientation – last 28 days',
     guidance: nationalGuidanceEntriesByPc,
     labelColumn: 'Sexual orientation',
-    googleAnalyticsCategory: 'Comparison of behaviour entries by sexual orientation',
+    googleAnalyticsCategory: 'Comparison of behaviour entries by sexual orientation (National)',
   },
   'trends-entries-by-age': {
     title: 'Comparison of positive and negative behaviour entries by age – last 12 months',
     guidance: nationalGuidanceTrendsEntriesByPc,
-    googleAnalyticsCategory: 'Behaviour entries by age trends',
+    googleAnalyticsCategory: 'Behaviour entries by age trends (National)',
   },
   'trends-entries-by-disability': {
     title: 'Comparison of positive and negative behaviour entries by recorded disability – last 12 months',
     guidance: nationalGuidanceTrendsEntriesByPc,
-    googleAnalyticsCategory: 'Behaviour entries by recorded disability trends',
+    googleAnalyticsCategory: 'Behaviour entries by recorded disability trends (National)',
   },
   'trends-entries-by-ethnicity': {
     title: 'Comparison of positive and negative behaviour entries by ethnicity – last 12 months',
     guidance: nationalGuidanceTrendsEntriesByPc,
-    googleAnalyticsCategory: 'Behaviour entries by ethnicity trends',
+    googleAnalyticsCategory: 'Behaviour entries by ethnicity trends (National)',
   },
   'trends-entries-by-religion': {
     title: 'Comparison of positive and negative behaviour entries by religion – last 12 months',
     guidance: nationalGuidanceTrendsEntriesByPc,
-    googleAnalyticsCategory: 'Behaviour entries by religion trends',
+    googleAnalyticsCategory: 'Behaviour entries by religion trends (National)',
   },
   'trends-entries-by-sexual-orientation': {
     title: 'Comparison of positive and negative behaviour entries by sexual orientation – last 12 months',
     guidance: nationalGuidanceTrendsEntriesByPc,
-    googleAnalyticsCategory: 'Behaviour entries by sexual orientation trends',
+    googleAnalyticsCategory: 'Behaviour entries by sexual orientation trends (National)',
   },
   'prisoners-with-entries-by-age': {
     title: 'Percentage and number of prisoners receiving each behaviour entry type by age – last 28 days',
     guidance: nationalGuidancePrisonersWithEntriesByPc,
     labelColumn: 'Age',
-    googleAnalyticsCategory: 'Behaviour entries by age',
+    googleAnalyticsCategory: 'Behaviour entries by age (National)',
   },
   'prisoners-with-entries-by-disability': {
     title:
       'Percentage and number of prisoners receiving each behaviour entry type by recorded disability – last 28 days',
     guidance: nationalGuidancePrisonersWithEntriesByPc,
     labelColumn: 'Disability',
-    googleAnalyticsCategory: 'Behaviour entries by disability',
+    googleAnalyticsCategory: 'Behaviour entries by disability (National)',
     labelColumnWidth: 'wide',
   },
   'prisoners-with-entries-by-ethnicity': {
     title: 'Percentage and number of prisoners receiving each behaviour entry type by ethnicity – last 28 days',
     guidance: nationalGuidancePrisonersWithEntriesByPc,
     labelColumn: 'Ethnicity',
-    googleAnalyticsCategory: 'Behaviour entries by ethnicity',
+    googleAnalyticsCategory: 'Behaviour entries by ethnicity (National)',
     labelColumnWidth: 'wide',
   },
   'prisoners-with-entries-by-religion': {
     title: 'Percentage and number of prisoners receiving each behaviour entry type by religion – last 28 days',
     guidance: nationalGuidancePrisonersWithEntriesByPc,
     labelColumn: 'Religion',
-    googleAnalyticsCategory: 'Behaviour entries by religion',
+    googleAnalyticsCategory: 'Behaviour entries by religion (National)',
   },
   'prisoners-with-entries-by-sexual-orientation': {
     title:
       'Percentage and number of prisoners receiving each behaviour entry type by sexual orientation – last 28 days',
     guidance: nationalGuidancePrisonersWithEntriesByPc,
     labelColumn: 'Sexual orientation',
-    googleAnalyticsCategory: 'Behaviour entries by sexual orientation',
+    googleAnalyticsCategory: 'Behaviour entries by sexual orientation (National)',
   },
 }

--- a/server/routes/analyticsRouter.ts
+++ b/server/routes/analyticsRouter.ts
@@ -261,7 +261,8 @@ export default function routes(router: Router): Router {
     const protectedCharacteristic = protectedCharacteristicRoutes[characteristicName]
 
     const groupsForCharacteristic =
-      protectedCharacteristic.id === ProtectedCharacteristic.Age && !PrisonRegister.isYouthCustodyService(activeCaseLoad)
+      protectedCharacteristic.id === ProtectedCharacteristic.Age &&
+      !PrisonRegister.isYouthCustodyService(activeCaseLoad)
         ? knownGroupsFor(protectedCharacteristic.id).filter(ageGroup => ageGroup !== AgeYoungPeople)
         : knownGroupsFor(protectedCharacteristic.id)
 

--- a/server/routes/analyticsRouter.ts
+++ b/server/routes/analyticsRouter.ts
@@ -25,26 +25,26 @@ import {
 import AnalyticsView from '../services/analyticsView'
 
 export const protectedCharacteristicRoutes = {
-  age: { label: 'Age', groupDropdownLabel: 'Select an age', characteristic: ProtectedCharacteristic.Age },
+  age: { label: 'Age', groupDropdownLabel: 'Select an age', id: ProtectedCharacteristic.Age },
   ethnicity: {
     label: 'Ethnicity',
     groupDropdownLabel: 'Select an ethnicity',
-    characteristic: ProtectedCharacteristic.Ethnicity,
+    id: ProtectedCharacteristic.Ethnicity,
   },
   disability: {
     label: 'Recorded disability',
     groupDropdownLabel: 'Select a recorded disability',
-    characteristic: ProtectedCharacteristic.Disability,
+    id: ProtectedCharacteristic.Disability,
   },
   religion: {
     label: 'Religion',
     groupDropdownLabel: 'Select a religion',
-    characteristic: ProtectedCharacteristic.Religion,
+    id: ProtectedCharacteristic.Religion,
   },
   'sexual-orientation': {
     label: 'Sexual orientation',
     groupDropdownLabel: 'Select a sexual orientation',
-    characteristic: ProtectedCharacteristic.SexualOrientation,
+    id: ProtectedCharacteristic.SexualOrientation,
   },
 } as const
 
@@ -258,12 +258,12 @@ export default function routes(router: Router): Router {
       }
     })
 
-    const protectedCharacteristic = protectedCharacteristicRoutes[characteristicName].characteristic
+    const protectedCharacteristic = protectedCharacteristicRoutes[characteristicName]
 
     const groupsForCharacteristic =
-      protectedCharacteristic === ProtectedCharacteristic.Age && !PrisonRegister.isYouthCustodyService(activeCaseLoad)
-        ? knownGroupsFor(protectedCharacteristic).filter(ageGroup => ageGroup !== AgeYoungPeople)
-        : knownGroupsFor(protectedCharacteristic)
+      protectedCharacteristic.id === ProtectedCharacteristic.Age && !PrisonRegister.isYouthCustodyService(activeCaseLoad)
+        ? knownGroupsFor(protectedCharacteristic.id).filter(ageGroup => ageGroup !== AgeYoungPeople)
+        : knownGroupsFor(protectedCharacteristic.id)
 
     const trendsIncentiveLevelsGroup = (req.query.trendsIncentiveLevelsGroup || groupsForCharacteristic[0]) as string
     const trendsEntriesGroup = (req.query.trendsEntriesGroup || groupsForCharacteristic[0]) as string
@@ -288,17 +288,16 @@ export default function routes(router: Router): Router {
         selected: name === trendsEntriesGroup,
       }
     })
-    const { groupDropdownLabel } = protectedCharacteristicRoutes[characteristicName]
 
     const s3Client = new S3Client(config.s3)
     const analyticsService = new AnalyticsService(s3Client, cache, analyticsView)
 
     const charts = [
-      analyticsService.getIncentiveLevelsByProtectedCharacteristic(protectedCharacteristic),
-      analyticsService.getIncentiveLevelTrendsByCharacteristic(protectedCharacteristic, trendsIncentiveLevelsGroup),
-      analyticsService.getBehaviourEntriesByProtectedCharacteristic(protectedCharacteristic),
-      analyticsService.getBehaviourEntryTrendsByProtectedCharacteristic(protectedCharacteristic, trendsEntriesGroup),
-      analyticsService.getPrisonersWithEntriesByProtectedCharacteristic(protectedCharacteristic),
+      analyticsService.getIncentiveLevelsByProtectedCharacteristic(protectedCharacteristic.id),
+      analyticsService.getIncentiveLevelTrendsByCharacteristic(protectedCharacteristic.id, trendsIncentiveLevelsGroup),
+      analyticsService.getBehaviourEntriesByProtectedCharacteristic(protectedCharacteristic.id),
+      analyticsService.getBehaviourEntryTrendsByProtectedCharacteristic(protectedCharacteristic.id, trendsEntriesGroup),
+      analyticsService.getPrisonersWithEntriesByProtectedCharacteristic(protectedCharacteristic.id),
     ].map(transformAnalyticsError)
     const [
       incentiveLevelsByCharacteristic,
@@ -311,13 +310,13 @@ export default function routes(router: Router): Router {
     res.render('pages/analytics/protectedCharacteristicTemplate', {
       ...templateContext(req),
       analyticsView,
+      protectedCharacteristic,
       characteristicName,
       characteristicOptions,
       trendsIncentiveLevelsOptions,
       trendsEntriesOptions,
       trendsIncentiveLevelsGroup,
       trendsEntriesGroup,
-      groupDropdownLabel,
       incentiveLevelsByCharacteristic,
       incentiveLevelsTrendsByCharacteristic,
       behaviourEntriesByCharacteristic,

--- a/server/services/analyticsView.test.ts
+++ b/server/services/analyticsView.test.ts
@@ -114,6 +114,23 @@ describe('AnalyticsView', () => {
     })
   })
 
+  describe('getLevelForTitle()', () => {
+    it(`for National, it return 'National'`, () => {
+      const analyticsView = new AnalyticsView('National', 'behaviour-entries', 'MDI')
+      expect(analyticsView.getLevelForTitle()).toEqual('National')
+    })
+
+    it('for Regional, it returns the PGD region name', () => {
+      const analyticsView = new AnalyticsView('LTHS', 'behaviour-entries', 'MDI')
+      expect(analyticsView.getLevelForTitle()).toEqual('Long-term and high security')
+    })
+
+    it(`for a prison, it returns 'Prison'`, () => {
+      const analyticsView = new AnalyticsView(null, 'behaviour-entries', 'MDI')
+      expect(analyticsView.getLevelForTitle()).toEqual('Prison')
+    })
+  })
+
   describe('linkTo()', () => {
     it('for National', () => {
       // eslint-disable-next-line no-restricted-syntax

--- a/server/services/analyticsView.ts
+++ b/server/services/analyticsView.ts
@@ -158,6 +158,18 @@ export default class AnalyticsView {
   isPrisonLevel(): boolean {
     return this.viewLevel === 'prison'
   }
+
+  getLevelForTitle(): string {
+    if (this.isPrisonLevel()) {
+      return 'Prison'
+    }
+
+    if (this.isRegional()) {
+      return this.getPgdRegionName()
+    }
+
+    return 'National'
+  }
 }
 
 /**

--- a/server/views/pages/analytics/behaviourEntries.njk
+++ b/server/views/pages/analytics/behaviourEntries.njk
@@ -6,7 +6,7 @@
 
 {% set chartPageId = "behaviour-entries" %}
 {% set chartPageTitle = "Behaviour entries" %}
-{% set pageTitle = applicationName + " – " + chartPageTitle %}
+{% set pageTitle = applicationName + " – " + chartPageTitle + " – " + analyticsView.getLevelForTitle() %}
 
 {% set extraWideLabel = analyticsView.isNational() %}
 

--- a/server/views/pages/analytics/incentiveLevels.njk
+++ b/server/views/pages/analytics/incentiveLevels.njk
@@ -5,7 +5,7 @@
 
 {% set chartPageId = "incentive-levels" %}
 {% set chartPageTitle = "Incentive levels" %}
-{% set pageTitle = applicationName + " – " + chartPageTitle %}
+{% set pageTitle = applicationName + " – " + chartPageTitle + " – " + analyticsView.getLevelForTitle() %}
 
 {% set extraWideLabel = analyticsView.isNational() %}
 

--- a/server/views/pages/analytics/protectedCharacteristicTemplate.njk
+++ b/server/views/pages/analytics/protectedCharacteristicTemplate.njk
@@ -7,7 +7,7 @@
 
 {% set chartPageId = "protected-characteristics" %}
 {% set chartPageTitle = "Protected characteristics" %}
-{% set pageTitle = applicationName + " – " + chartPageTitle + " – " + analyticsView.getLevelForTitle() %}
+{% set pageTitle = applicationName + " – " + chartPageTitle + " (" + protectedCharacteristic.label + ") " + " – " + analyticsView.getLevelForTitle() %}
 
 {% block chartContent %}
 
@@ -117,7 +117,7 @@
         {{ pcGroupDropdown(
             chartId,
             hiddenInputs,
-            groupDropdownLabel,
+            protectedCharacteristic.groupDropdownLabel,
             fieldName="trendsIncentiveLevelsGroup",
             options=trendsIncentiveLevelsOptions
         ) }}
@@ -173,7 +173,7 @@
         {{ pcGroupDropdown(
             chartId,
             hiddenInputs,
-            groupDropdownLabel,
+            protectedCharacteristic.groupDropdownLabel,
             fieldName="trendsEntriesGroup",
             options=trendsEntriesOptions
         ) }}

--- a/server/views/pages/analytics/protectedCharacteristicTemplate.njk
+++ b/server/views/pages/analytics/protectedCharacteristicTemplate.njk
@@ -7,7 +7,7 @@
 
 {% set chartPageId = "protected-characteristics" %}
 {% set chartPageTitle = "Protected characteristics" %}
-{% set pageTitle = applicationName + " – " + chartPageTitle %}
+{% set pageTitle = applicationName + " – " + chartPageTitle + " – " + analyticsView.getLevelForTitle() %}
 
 {% block chartContent %}
 


### PR DESCRIPTION
- Analytics pages' titles include the level (Prison/Regional/National)
  - titles for regional level include the PGD region name
  - titles for prison level do **not** include the prison level as this would make events too granular and we're mainly interested in discriminate view level (active case load can be used if that level of granularity is necessary)
- Similarly, charts' GA events now include the level being viewed (Prison/Regional/National)
  - GA events for regional level do **not** include the PGD region name, there are limitations in terms of GA events character counts. Furthermore we're mainly interested in discriminate view level (e.g. was this an event for national? regional? prison level?)
  - For regional level the word 'Group' has been chosen during three amigos.
- Protected Characteristic page's title now includes the Protected Characteristic being viewed (e.g. `Age`)
- don't send details' `closed` GA events. Consensus reached in three amigos was that this is noisy and doesn't add much value.