### PR TITLE
INC-668: Use latest shared helm chart to create new ingress controller

### DIFF
--- a/helm_deploy/hmpps-incentives-ui/Chart.yaml
+++ b/helm_deploy/hmpps-incentives-ui/Chart.yaml
@@ -5,7 +5,7 @@ name: hmpps-incentives-ui
 version: 0.2.0
 dependencies:
   - name: generic-service
-    version: 1.3.0
+    version: 1.5.0
     repository: https://ministryofjustice.github.io/hmpps-helm-charts
   - name: generic-prometheus-alerts
     version: 1.1.0

--- a/helm_deploy/hmpps-incentives-ui/values.yaml
+++ b/helm_deploy/hmpps-incentives-ui/values.yaml
@@ -12,6 +12,7 @@ generic-service:
   ingress:
     enabled: true
     v1_2_enabled: true
+    v0_47_enabled: true
     host: app-hostname.local    # override per environment
     tlsSecretName: hmpps-incentives-ui-cert
     annotations:


### PR DESCRIPTION
…retaining the existing one so that traffic slowly migrates to the new one.
C.f. [hmpps-helm-charts#1.5](https://github.com/ministryofjustice/hmpps-helm-charts/releases/tag/generic-service-1.5.0)