### PR TITLE
INC-674: hotjar CSP: unsafe-inline doesn't work with nonce

### DIFF
--- a/server/views/partials/analytics/layout.njk
+++ b/server/views/partials/analytics/layout.njk
@@ -70,7 +70,7 @@
 
   {% if hotjarSiteId %}
     <!-- Hotjar Tracking Code for my site -->
-    <script nonce="{{ cspNonce }}">
+    <script>
         (function(h,o,t,j,a,r){
             h.hj=h.hj||function(){(h.hj.q=h.hj.q||[]).push(arguments)};
             h._hjSettings={hjid:{{ hotjarSiteId }},hjsv:6};


### PR DESCRIPTION
Attempt to fix:

> Refused to apply inline style because it violates the following Content
> Security Policy directive: "style-src 'self' https://*.hotjar.com
> 'unsafe-inline' 'nonce-28d71b7d82e721525528e91165111d8e'".
> Note that 'unsafe-inline' is ignored if either a hash or nonce value is
> present in the source list.