### PR TITLE
INC-674: Add hotjar servers to IP allowlist

### DIFF
--- a/helm_deploy/hmpps-incentives-ui/values.yaml
+++ b/helm_deploy/hmpps-incentives-ui/values.yaml
@@ -133,6 +133,10 @@ generic-service:
     fivewells-7: "194.33.249.0/29"
     fivewells-8: "51.149.249.32/29"
     fivewells-9: "194.33.248.0/29"
+    # hotjar servers: https://help.hotjar.com/hc/en-us/articles/115011789288
+    hotjar-1: 18.203.61.76
+    hotjar-2: 18.203.176.135
+    hotjar-3: 52.17.197.221
 
 generic-prometheus-alerts:
   targetApplication: hmpps-incentives-ui


### PR DESCRIPTION
We got a recording in hotjar but page has not style (so charts are not
showing correctly for example).

This is because hotjar is unable to retrieve the CSS files as mentioned
in their docs:

https://help.hotjar.com/hc/en-us/articles/115011822728-Troubleshooting-FAQs-for-Recordings#why-do-the-pages-look-brokenno-css-loading

This adds hotjar IP addresses to allowlist:

https://help.hotjar.com/hc/en-us/articles/115011789288