### PR TITLE
Upgrade to node 16.17

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ parameters:
 
   node-version:
     type: string
-    default: 16.16-browsers
+    default: 16.17-browsers
 
   python-version:
     type: string
@@ -25,7 +25,7 @@ executors:
   # same as hmpps/node_redis executor with the addition of minio containers
   integration-tests:
     docker:
-      - image: cimg/node:16.16-browsers
+      - image: cimg/node:16.17-browsers
       - image: cimg/redis:5.0
       - image: minio/minio
         command: server --address :9000 /data
@@ -45,7 +45,7 @@ jobs:
       - checkout
       - run:
           name: Update npm
-          command: npm install -g npm@latest
+          command: sudo npm install -g npm@latest
       - restore_cache:
           key: dependency-cache-{{ checksum "package-lock.json" }}
       - run:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Stage: base image
-FROM node:16.16-bullseye-slim as base
+FROM node:16.17-bullseye-slim as base
 
 ARG BUILD_NUMBER=1_0_0
 ARG GIT_REF=not-available

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,7 +53,7 @@
         "@types/http-errors": "^1.8.2",
         "@types/jest": "^28.1.7",
         "@types/jsonwebtoken": "^8.5.8",
-        "@types/node": "^16.11.41",
+        "@types/node": "^16.11.49",
         "@types/nunjucks": "^3.2.1",
         "@types/passport": "^1.0.10",
         "@types/passport-oauth2": "^1.4.11",
@@ -4323,9 +4323,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "16.11.47",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.47.tgz",
-      "integrity": "sha512-fpP+jk2zJ4VW66+wAMFoBJlx1bxmBKx4DUFf68UHgdGCOuyUTDlLWqsaNPJh7xhNDykyJ9eIzAygilP/4WoN8g=="
+      "version": "16.11.49",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.49.tgz",
+      "integrity": "sha512-Abq9fBviLV93OiXMu+f6r0elxCzRwc0RC5f99cU892uBITL44pTvgvEqlRlPRi8EGcO1z7Cp8A4d0s/p3J/+Nw=="
     },
     "node_modules/@types/node-fetch": {
       "version": "2.6.2",
@@ -16910,9 +16910,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "16.11.47",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.47.tgz",
-      "integrity": "sha512-fpP+jk2zJ4VW66+wAMFoBJlx1bxmBKx4DUFf68UHgdGCOuyUTDlLWqsaNPJh7xhNDykyJ9eIzAygilP/4WoN8g=="
+      "version": "16.11.49",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.49.tgz",
+      "integrity": "sha512-Abq9fBviLV93OiXMu+f6r0elxCzRwc0RC5f99cU892uBITL44pTvgvEqlRlPRi8EGcO1z7Cp8A4d0s/p3J/+Nw=="
     },
     "@types/node-fetch": {
       "version": "2.6.2",

--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
     "@types/http-errors": "^1.8.2",
     "@types/jest": "^28.1.7",
     "@types/jsonwebtoken": "^8.5.8",
-    "@types/node": "^16.11.41",
+    "@types/node": "^16.11.49",
     "@types/nunjucks": "^3.2.1",
     "@types/passport": "^1.0.10",
     "@types/passport-oauth2": "^1.4.11",

--- a/renovate.json
+++ b/renovate.json
@@ -20,7 +20,7 @@
     },
     {
       "matchDatasources": ["docker"],
-      "allowedVersions": "16.16-bullseye-slim"
+      "allowedVersions": "16.17-bullseye-slim"
     },
     {
       "matchDatasources": ["docker-compose"],
@@ -30,7 +30,7 @@
     {
       "matchDatasources": ["orb"],
       "matchPackageNames": ["cimg/node"],
-      "allowedVersions": "16.16-browsers"
+      "allowedVersions": "16.17-browsers"
     },
     {
       "matchDatasources": ["orb"],

--- a/server/utils/format.ts
+++ b/server/utils/format.ts
@@ -2,7 +2,7 @@ const notNumber = (n: unknown) => typeof n !== 'number' || Number.isNaN(n)
 
 export default {
   date(date: Date) {
-    return date.toLocaleDateString('en-GB', {
+    const formatted = date.toLocaleDateString('en-GB', {
       hour: '2-digit',
       hour12: false,
       minute: '2-digit',
@@ -11,6 +11,7 @@ export default {
       year: 'numeric',
       timeZone: 'Europe/London',
     })
+    return formatted.replace(' at ', ', ')
   },
 
   shortDate(date: Date) {


### PR DESCRIPTION
…and maintain formatting of dates to match older versions: v16.17 is built against a new ICU library which formats dates differently (`19 August 2022 at 10:12` instead of `19 August 2022, 10:12`).