### PR TITLE
INC-707: Warm up analytics data cache

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -1,4 +1,4 @@
-/* eslint-disable import/first */
+/* eslint-disable import/first,import/order */
 /*
  * Do appinsights first as it does some magic instrumentation work, i.e. it affects other 'require's
  * In particular, applicationinsights automatically collects bunyan logs
@@ -8,7 +8,11 @@ import { initialiseAppInsights, buildAppInsightsClient } from './server/utils/az
 initialiseAppInsights()
 buildAppInsightsClient()
 
+import { setImmediate, setInterval } from 'timers'
+
+import config from './server/config'
 import { app, metricsApp } from './server/index'
+import analyticsPrecacheTables from './server/routes/analyticsPrecacheTables'
 import logger from './logger'
 import { initSentry } from './server/utils/sentry'
 
@@ -16,6 +20,12 @@ initSentry()
 
 app.listen(app.get('port'), () => {
   logger.info(`Server listening on port ${app.get('port')}`)
+
+  if (config.featureFlags.precacheTables) {
+    // warm up analytics table cache asynchronously now and once every hour
+    setImmediate(analyticsPrecacheTables)
+    setInterval(analyticsPrecacheTables, 60 * 60 * 1000)
+  }
 })
 
 metricsApp.listen(metricsApp.get('port'), () => {

--- a/server/config.ts
+++ b/server/config.ts
@@ -138,6 +138,7 @@ export default {
     // Whether to hide the 'Days since last review'/'Days on level' columns
     hideDaysColumnsInIncentivesTable: flag('FEATURE_HIDE_DAYS_COLUMNS_IN_INCENTIVES_TABLE', false),
     useFileSystemCache: flag('FEATURE_FS_CACHE', false),
+    precacheTables: flag('FEATURE_PRECACHE_TABLES', false),
   },
   analyticsDataStaleAferDays: Number(get('ANALYTICS_DATA_STALE_AFTER_DAYS', 0)),
   feedbackUrl: get('FEEDBACK_URL', ''),

--- a/server/routes/analyticsPrecacheTables.ts
+++ b/server/routes/analyticsPrecacheTables.ts
@@ -1,0 +1,57 @@
+import { setImmediate } from 'timers'
+
+import logger from '../../logger'
+import config from '../config'
+import S3Client from '../data/s3Client'
+import AnalyticsView from '../services/analyticsView'
+import AnalyticsService from '../services/analyticsService'
+import { AgeYoungPeople, ProtectedCharacteristic } from '../services/analyticsServiceTypes'
+import PgdRegionService, { National } from '../services/pgdRegionService'
+import { cache } from './analyticsRouter'
+
+async function precacheTablesForRegion(region: string | null) {
+  // NB: viewType and activeCaseLoad have no effect on what data is loaded and stitched
+  const analyticsView = new AnalyticsView(region, 'behaviour-entries', 'MDI')
+  const s3Client = new S3Client(config.s3)
+  const analyticsService = new AnalyticsService(s3Client, cache, analyticsView)
+
+  await analyticsService.getBehaviourEntriesByLocation()
+  await analyticsService.getPrisonersWithEntriesByLocation()
+  await analyticsService.getBehaviourEntryTrends()
+  await analyticsService.getIncentiveLevelsByLocation()
+  await analyticsService.getIncentiveLevelTrends()
+
+  // NB: specific characteristic has no effect on what data is loaded and stitched
+  const age = ProtectedCharacteristic.Age
+  const youngPeople = AgeYoungPeople
+  await analyticsService.getIncentiveLevelsByProtectedCharacteristic(age)
+  await analyticsService.getIncentiveLevelTrendsByCharacteristic(age, youngPeople)
+  await analyticsService.getBehaviourEntriesByProtectedCharacteristic(age)
+  await analyticsService.getBehaviourEntryTrendsByProtectedCharacteristic(age, youngPeople)
+  await analyticsService.getPrisonersWithEntriesByProtectedCharacteristic(age)
+}
+
+async function precachePrisonTables() {
+  logger.info('Pre-caching analytics tables…')
+  await precacheTablesForRegion(null)
+  setImmediate(precacheRegionTables)
+}
+
+async function precacheRegionTables() {
+  // NB: specific region has no effect on what data is loaded and stitched
+  await precacheTablesForRegion(PgdRegionService.getPgdRegionByCode('WLS').code)
+  setImmediate(precacheNationalTables)
+}
+
+async function precacheNationalTables() {
+  await precacheTablesForRegion(National)
+  logger.info('Done pre-caching analytics tables')
+}
+
+/**
+ * Sequentially loads each analytics table to warm up the cache,
+ * repeating for each view level (i.e. prison, region, national)
+ */
+export default async function precacheTables() {
+  return precachePrisonTables()
+}

--- a/server/routes/analyticsRouter.ts
+++ b/server/routes/analyticsRouter.ts
@@ -16,7 +16,7 @@ import {
 import type { ChartId } from './analyticsChartTypes'
 import ChartFeedbackForm from './forms/chartFeedbackForm'
 import PrisonRegister from '../data/prisonRegister'
-import PgdRegionService, { National, PgdRegion } from '../services/pgdRegionService'
+import PgdRegionService, { National, type PgdRegion } from '../services/pgdRegionService'
 import {
   StitchedTablesCache,
   MemoryStitchedTablesCache,


### PR DESCRIPTION
…on startup and hourly so that the first requests do not attempt to load 6+ source tables concurrently.
This hopefully alleviates out-of-memory errors and pod restarts.