### PR TITLE
Restructure the prison register to make its purpose clearer

### DIFF
--- a/server/data/prisonRegister.test.ts
+++ b/server/data/prisonRegister.test.ts
@@ -1,0 +1,21 @@
+import PrisonRegister from './prisonRegister'
+
+describe('PrisonRegister', () => {
+  describe.each(
+    // known subset of YCS and Womens estate
+    ['BZI', 'CKI', 'FYI', 'PYI', 'PFI'],
+  )('correctly identifies prisons that house young people', prison => {
+    it(prison, () => {
+      expect(PrisonRegister.housesYoungPeople(prison)).toBeTruthy()
+    })
+  })
+
+  describe.each(
+    // YOIs known to not be YCS and adult prisons
+    ['BWI', 'FMI', 'MDI', 'PBI', 'PRI', 'WRI'],
+  )('correctly identifies prisons that do not house young people', prison => {
+    it(prison, () => {
+      expect(PrisonRegister.housesYoungPeople(prison)).toBeFalsy()
+    })
+  })
+})

--- a/server/data/prisonRegister.ts
+++ b/server/data/prisonRegister.ts
@@ -1,18 +1,26 @@
-export const youthCustodyServicePrisons: ReadonlyArray<string> = [
-  // Youth Custody Service, all YOIs
-  // 15-17 year olds - young people
+/**
+ * Prisons known to be in the Youth Custody Service,
+ * a subset of Young Offender Institutions.
+ * Residents are 15-17 year olds, known as young people at HMPPS.
+ * NB: the HMPPS prison register does not reliably report which prisons are in this set.
+ * Aside: other Young Offender Institutions have residents aged 18-24, known as young adults at HMPPS.
+ */
+const youthCustodyServicePrisons: ReadonlyArray<string> = [
   'CKI', // HMYOI Cookham Wood
+  // 'FMI', // HMYOI Feltham is technically a YCS but only houses young adults
   'FYI', // HMYOI Feltham A
   'PYI', // HMP/YOI Parc A
   'WNI', // HMYOI Werrington
   'WYI', // HMYOI Wetherby
-  // TODO: cannot currently use prison register for this set
+]
 
-  // Other YOIs hold only 18-24 year olds - young adults
-  // apart from Feltham which has 2 parts with YCS in one, YAs in the other.
-  // Female prisons which could have girls (15-17)
-
-  // Women’s Estate
+/**
+ * Prisons known to be part of the Women’s Estate.
+ * Whilst not technically part of the Youth Custody Service,
+ * any could potentially have 15-17 year old residents.
+ * NB: the HMPPS prison register could be used for this set of prisons.
+ */
+const womensEstatePrisons: ReadonlyArray<string> = [
   'AGI', // HMP/YOI Askham Grange
   'BZI', // HMP/YOI Bronzefield
   'DHI', // HMP/YOI Drake Hall
@@ -25,10 +33,14 @@ export const youthCustodyServicePrisons: ReadonlyArray<string> = [
   'PFI', // HMP/YOI Peterborough Female
   'SDI', // HMP/YOI Send
   'STI', // HMP/YOI Styal
-  // TODO: can likely use prison register for this set
 ]
+
 export default class PrisonRegister {
-  static isYouthCustodyService(prison: string): boolean {
-    return youthCustodyServicePrisons.includes(prison)
+  /**
+   * True for prisons where residents may be aged 15 to 17,
+   * those known as young people at HMPPS.
+   */
+  static housesYoungPeople(prison: string): boolean {
+    return youthCustodyServicePrisons.includes(prison) || womensEstatePrisons.includes(prison)
   }
 }

--- a/server/routes/analyticsRouter.test.ts
+++ b/server/routes/analyticsRouter.test.ts
@@ -13,7 +13,7 @@ const s3 = {
   send: jest.fn(),
 }
 
-const isYouthCustodyServiceOriginal = PrisonRegister.isYouthCustodyService
+const housesYoungPeopleOriginal = PrisonRegister.housesYoungPeople
 
 jest.mock('@aws-sdk/client-s3', () => {
   const { GetObjectCommand, ListObjectsV2Command } = jest.requireActual('@aws-sdk/client-s3')
@@ -461,13 +461,13 @@ describe('Protected characteristic pages', () => {
 
       describe('when prison is Youth Custody Service', () => {
         beforeAll(() => {
-          // change isYouthCustodyService() to always return true
-          PrisonRegister.isYouthCustodyService = (_prisonId: string) => true
+          // change housesYoungPeople() to always return true
+          PrisonRegister.housesYoungPeople = (_prisonId: string) => true
         })
 
         afterAll(() => {
-          // restore PrisonRegister.isYouthCustodyService() behaviour
-          PrisonRegister.isYouthCustodyService = isYouthCustodyServiceOriginal
+          // restore PrisonRegister.housesYoungPeople() behaviour
+          PrisonRegister.housesYoungPeople = housesYoungPeopleOriginal
         })
 
         it(`${queryParamName} value can be 15-17`, () => {
@@ -491,13 +491,13 @@ describe('Protected characteristic pages', () => {
 
       describe('when prison is not Youth Custody Service', () => {
         beforeAll(() => {
-          // change isYouthCustodyService() to always return false
-          PrisonRegister.isYouthCustodyService = (_prisonId: string) => false
+          // change housesYoungPeople() to always return false
+          PrisonRegister.housesYoungPeople = (_prisonId: string) => false
         })
 
         afterAll(() => {
-          // restore PrisonRegister.isYouthCustodyService() behaviour
-          PrisonRegister.isYouthCustodyService = isYouthCustodyServiceOriginal
+          // restore PrisonRegister.housesYoungPeople() behaviour
+          PrisonRegister.housesYoungPeople = housesYoungPeopleOriginal
         })
 
         it(`${queryParamName} value cannot be 15-17`, () => {

--- a/server/routes/analyticsRouter.ts
+++ b/server/routes/analyticsRouter.ts
@@ -261,8 +261,7 @@ export default function routes(router: Router): Router {
     const protectedCharacteristic = protectedCharacteristicRoutes[characteristicName]
 
     const groupsForCharacteristic =
-      protectedCharacteristic.id === ProtectedCharacteristic.Age &&
-      !PrisonRegister.isYouthCustodyService(activeCaseLoad)
+      protectedCharacteristic.id === ProtectedCharacteristic.Age && !PrisonRegister.housesYoungPeople(activeCaseLoad)
         ? knownGroupsFor(protectedCharacteristic.id).filter(ageGroup => ageGroup !== AgeYoungPeople)
         : knownGroupsFor(protectedCharacteristic.id)
 

--- a/server/services/analyticsService.test.ts
+++ b/server/services/analyticsService.test.ts
@@ -26,7 +26,7 @@ jest.mock('../data/s3Client')
 
 const cache = new MemoryStitchedTablesCache()
 
-const isYouthCustodyServiceOriginal = PrisonRegister.isYouthCustodyService
+const housesYoungPeopleOriginal = PrisonRegister.housesYoungPeople
 
 const prisonLocations = {
   MDI: [
@@ -596,7 +596,7 @@ describe('AnalyticsService', () => {
       mockAppS3ClientResponse(s3Client)
 
       // pretend that MDI is a YCS
-      PrisonRegister.isYouthCustodyService = (prisonId: string) => prisonId === 'MDI'
+      PrisonRegister.housesYoungPeople = (prisonId: string) => prisonId === 'MDI'
     })
 
     it(`[${characteristic}]: has a totals row`, async () => {
@@ -646,8 +646,8 @@ describe('AnalyticsService', () => {
       })
 
       it(`[${characteristic}]: skips 15-17 group in non-YCS prison`, async () => {
-        // make MDI not a YCS by restoring isYouthCustodyService()
-        PrisonRegister.isYouthCustodyService = isYouthCustodyServiceOriginal
+        // make MDI not a YCS by restoring housesYoungPeople()
+        PrisonRegister.housesYoungPeople = housesYoungPeopleOriginal
 
         const { rows } = await analyticsService.getIncentiveLevelsByProtectedCharacteristic(characteristic)
         const zeroRows = rows.filter(({ label: someCharacteristic }) => someCharacteristic === '15-17')
@@ -857,7 +857,7 @@ describe('AnalyticsService', () => {
       mockAppS3ClientResponse(s3Client)
 
       // pretend that MDI is a YCS
-      PrisonRegister.isYouthCustodyService = (prisonId: string) => prisonId === 'MDI'
+      PrisonRegister.housesYoungPeople = (prisonId: string) => prisonId === 'MDI'
     })
 
     it(`[${characteristic}]: has a totals row`, async () => {
@@ -906,8 +906,8 @@ describe('AnalyticsService', () => {
       })
 
       it(`[${characteristic}]: skips 15-17 group in non-YCS prison`, async () => {
-        // make MDI not a YCS by restoring isYouthCustodyService()
-        PrisonRegister.isYouthCustodyService = isYouthCustodyServiceOriginal
+        // make MDI not a YCS by restoring housesYoungPeople()
+        PrisonRegister.housesYoungPeople = housesYoungPeopleOriginal
 
         const { rows } = await analyticsService.getPrisonersWithEntriesByProtectedCharacteristic(characteristic)
         const zeroRows = rows.filter(({ label: someCharacteristic }) => someCharacteristic === '15-17')
@@ -1055,7 +1055,7 @@ describe('AnalyticsService', () => {
       mockAppS3ClientResponse(s3Client)
 
       // pretend that MDI is a YCS
-      PrisonRegister.isYouthCustodyService = (prisonId: string) => prisonId === 'MDI'
+      PrisonRegister.housesYoungPeople = (prisonId: string) => prisonId === 'MDI'
     })
 
     it(`[${characteristic}]: has a totals row`, async () => {
@@ -1102,8 +1102,8 @@ describe('AnalyticsService', () => {
       })
 
       it(`[${characteristic}]: skips 15-17 group in non-YCS prison`, async () => {
-        // make MDI not a YCS by restoring isYouthCustodyService()
-        PrisonRegister.isYouthCustodyService = isYouthCustodyServiceOriginal
+        // make MDI not a YCS by restoring housesYoungPeople()
+        PrisonRegister.housesYoungPeople = housesYoungPeopleOriginal
 
         const { rows } = await analyticsService.getBehaviourEntriesByProtectedCharacteristic(characteristic)
         const zeroRows = rows.filter(({ label: someCharacteristic }) => someCharacteristic === '15-17')

--- a/server/services/analyticsService.ts
+++ b/server/services/analyticsService.ts
@@ -503,7 +503,7 @@ export default class AnalyticsService {
     if (
       view.isPrisonLevel &&
       protectedCharacteristic === ProtectedCharacteristic.Age &&
-      !PrisonRegister.isYouthCustodyService(filterValue)
+      !PrisonRegister.housesYoungPeople(filterValue)
     ) {
       missingCharacteristics.delete(AgeYoungPeople)
     }
@@ -584,7 +584,7 @@ export default class AnalyticsService {
     if (
       view.isPrisonLevel &&
       protectedCharacteristic === ProtectedCharacteristic.Age &&
-      !PrisonRegister.isYouthCustodyService(filterValue)
+      !PrisonRegister.housesYoungPeople(filterValue)
     ) {
       missingCharacteristics.delete(AgeYoungPeople)
     }
@@ -884,7 +884,7 @@ export default class AnalyticsService {
     if (
       view.isPrisonLevel &&
       protectedCharacteristic === ProtectedCharacteristic.Age &&
-      !PrisonRegister.isYouthCustodyService(filterValue)
+      !PrisonRegister.housesYoungPeople(filterValue)
     ) {
       missingCharacteristics.delete(AgeYoungPeople)
     }


### PR DESCRIPTION
…which is to identify establishments that house 15-17 year olds. That is, the Youth Custody Service (a subset of Young Offender Institutions) and Women's Estate.

This distinction is only used to determine whether a "15-17" age group should appear by default (even when empty) in protected characteristics analytics charts.