### PR TITLE
INC-843: Update sorting parameters to match incentive-api's contract

### DIFF
--- a/server/data/incentivesApi.test.ts
+++ b/server/data/incentivesApi.test.ts
@@ -47,9 +47,9 @@ describe('IncentiveApi', () => {
 
     const scenarios: { name: string; params: IncentivesReviewsPaginationAndSorting }[] = [
       { name: 'no', params: {} },
-      { name: 'sorting', params: { sort: 'nextReviewDate', order: 'ascending' } },
+      { name: 'sorting', params: { sort: 'nextReviewDate', order: 'asc' } },
       { name: 'pagination', params: { page: 2, pageSize: 10 } },
-      { name: 'all', params: { sort: 'negativeBehaviours', order: 'descending', page: 3, pageSize: 20 } },
+      { name: 'all', params: { sort: 'negativeBehaviours', order: 'desc', page: 3, pageSize: 20 } },
     ]
     it.each(scenarios)('passes $name query params to Incentives API', async ({ params }) => {
       incentivesApi

--- a/server/data/incentivesApi.test.ts
+++ b/server/data/incentivesApi.test.ts
@@ -47,9 +47,9 @@ describe('IncentiveApi', () => {
 
     const scenarios: { name: string; params: IncentivesReviewsPaginationAndSorting }[] = [
       { name: 'no', params: {} },
-      { name: 'sorting', params: { sort: 'nextReviewDate', order: 'asc' } },
+      { name: 'sorting', params: { sort: 'NEXT_REVIEW_DATE', order: 'asc' } },
       { name: 'pagination', params: { page: 2, pageSize: 10 } },
-      { name: 'all', params: { sort: 'negativeBehaviours', order: 'desc', page: 3, pageSize: 20 } },
+      { name: 'all', params: { sort: 'NEGATIVE_BEHAVIOURS', order: 'desc', page: 3, pageSize: 20 } },
     ]
     it.each(scenarios)('passes $name query params to Incentives API', async ({ params }) => {
       incentivesApi

--- a/server/data/incentivesApi.test.ts
+++ b/server/data/incentivesApi.test.ts
@@ -47,9 +47,9 @@ describe('IncentiveApi', () => {
 
     const scenarios: { name: string; params: IncentivesReviewsPaginationAndSorting }[] = [
       { name: 'no', params: {} },
-      { name: 'sorting', params: { sort: 'NEXT_REVIEW_DATE', order: 'asc' } },
+      { name: 'sorting', params: { sort: 'NEXT_REVIEW_DATE', order: 'ASC' } },
       { name: 'pagination', params: { page: 2, pageSize: 10 } },
-      { name: 'all', params: { sort: 'NEGATIVE_BEHAVIOURS', order: 'desc', page: 3, pageSize: 20 } },
+      { name: 'all', params: { sort: 'NEGATIVE_BEHAVIOURS', order: 'DESC', page: 3, pageSize: 20 } },
     ]
     it.each(scenarios)('passes $name query params to Incentives API', async ({ params }) => {
       incentivesApi

--- a/server/data/incentivesApi.test.ts
+++ b/server/data/incentivesApi.test.ts
@@ -95,7 +95,7 @@ describe('IncentiveApi', () => {
               nextReviewDate: '2023-09-10',
               positiveBehaviours: 2,
               negativeBehaviours: 0,
-              acctStatus: false,
+              hasAcctOpen: false,
             },
           ],
         })
@@ -115,7 +115,7 @@ describe('IncentiveApi', () => {
             nextReviewDate: new Date(2023, 8, 10, 12),
             positiveBehaviours: 2,
             negativeBehaviours: 0,
-            acctStatus: false,
+            hasAcctOpen: false,
           },
         ],
       })

--- a/server/data/incentivesApi.ts
+++ b/server/data/incentivesApi.ts
@@ -42,7 +42,7 @@ export interface Level {
 
 // NB: Reviews request field names are TBC
 export const sortOptions = ['name', 'nextReviewDate', 'positiveBehaviours', 'negativeBehaviours', 'acctStatus'] as const
-export const orderOptions = ['ascending', 'descending'] as const
+export const orderOptions = ['asc', 'desc'] as const
 
 // NB: Reviews request field names are TBC
 export type IncentivesReviewsPaginationAndSorting = {

--- a/server/data/incentivesApi.ts
+++ b/server/data/incentivesApi.ts
@@ -49,7 +49,7 @@ export const sortOptions = [
   'NEGATIVE_BEHAVIOURS',
   'ACCT_STATUS',
 ] as const
-export const orderOptions = ['asc', 'desc'] as const
+export const orderOptions = ['ASC', 'DESC'] as const
 
 // NB: Reviews request field names are TBC
 export type IncentivesReviewsPaginationAndSorting = {

--- a/server/data/incentivesApi.ts
+++ b/server/data/incentivesApi.ts
@@ -40,8 +40,15 @@ export interface Level {
   default: boolean
 }
 
-// NB: Reviews request field names are TBC
-export const sortOptions = ['name', 'nextReviewDate', 'positiveBehaviours', 'negativeBehaviours', 'acctStatus'] as const
+export const sortOptions = [
+  'PRISONER_NUMBER',
+  'FIRST_NAME',
+  'LAST_NAME',
+  'NEXT_REVIEW_DATE',
+  'POSITIVE_BEHAVIOURS',
+  'NEGATIVE_BEHAVIOURS',
+  'ACCT_STATUS',
+] as const
 export const orderOptions = ['asc', 'desc'] as const
 
 // NB: Reviews request field names are TBC

--- a/server/data/incentivesApi.ts
+++ b/server/data/incentivesApi.ts
@@ -47,7 +47,7 @@ export const sortOptions = [
   'NEXT_REVIEW_DATE',
   'POSITIVE_BEHAVIOURS',
   'NEGATIVE_BEHAVIOURS',
-  'ACCT_STATUS',
+  'HAS_ACCT_OPEN',
 ] as const
 export const orderOptions = ['ASC', 'DESC'] as const
 
@@ -84,7 +84,7 @@ export interface IncentivesReview {
   nextReviewDate: Date
   positiveBehaviours: number
   negativeBehaviours: number
-  acctStatus: boolean
+  hasAcctOpen: boolean
 }
 
 export class IncentivesApi extends RestClient {

--- a/server/routes/reviewsTable.test.ts
+++ b/server/routes/reviewsTable.test.ts
@@ -7,7 +7,7 @@ import config from '../config'
 import { appWithAllRoutes } from './testutils/appSetup'
 import { getTestIncentivesReviews } from '../testData/incentivesApi'
 import HmppsAuthClient from '../data/hmppsAuthClient'
-import type { Level, IncentivesReviewsRequest, orderOptions } from '../data/incentivesApi'
+import type { Level, IncentivesReviewsRequest, sortOptions, orderOptions } from '../data/incentivesApi'
 import { IncentivesApi } from '../data/incentivesApi'
 
 jest.mock('../data/hmppsAuthClient')
@@ -138,30 +138,30 @@ describe('Reviews table', () => {
     },
     {
       name: 'with sort param',
-      urlSuffix: '?sort=name',
+      urlSuffix: '?sort=LAST_NAME',
       expectedRequest: {
-        sort: 'name',
+        sort: 'LAST_NAME',
         order: 'asc',
       },
     },
     {
       name: 'with incorrect sort param',
-      urlSuffix: '?sort=unknown',
+      urlSuffix: '?sort=PRISON',
       expectedRequest: {},
     },
     {
       name: 'with sort and order params',
-      urlSuffix: '?order=desc&sort=name',
+      urlSuffix: '?order=desc&sort=LAST_NAME',
       expectedRequest: {
-        sort: 'name',
+        sort: 'LAST_NAME',
         order: 'desc',
       },
     },
     {
       name: 'with sort param but incorrect order',
-      urlSuffix: '?order=reversed&sort=name',
+      urlSuffix: '?order=reversed&sort=LAST_NAME',
       expectedRequest: {
-        sort: 'name',
+        sort: 'LAST_NAME',
         order: 'asc',
       },
     },
@@ -175,21 +175,21 @@ describe('Reviews table', () => {
     },
     {
       name: 'with level, sort and page params',
-      urlSuffix: '?page=3&level=ENH&sort=acctStatus',
+      urlSuffix: '?page=3&level=ENH&sort=ACCT_STATUS',
       expectedRequest: {
         levelCode: 'ENH',
         page: 3,
-        sort: 'acctStatus',
+        sort: 'ACCT_STATUS',
         order: 'desc',
       },
     },
     {
       name: 'with level, sort, order and page params',
-      urlSuffix: '?level=BAS&sort=negativeBehaviours&order=asc&page=4',
+      urlSuffix: '?level=BAS&sort=NEGATIVE_BEHAVIOURS&order=asc&page=4',
       expectedRequest: {
         levelCode: 'BAS',
         page: 4,
-        sort: 'negativeBehaviours',
+        sort: 'NEGATIVE_BEHAVIOURS',
         order: 'asc',
       },
     },
@@ -201,7 +201,7 @@ describe('Reviews table', () => {
         agencyId: 'MDI',
         locationPrefix: 'MDI-1',
         levelCode: 'STD',
-        sort: 'nextReviewDate',
+        sort: 'NEXT_REVIEW_DATE',
         order: 'asc',
         page: 1,
         pageSize: 20,
@@ -224,7 +224,7 @@ describe('Reviews table', () => {
     name: string
     givenUrl: string
     expectedLevel: string
-    expectedSort: string
+    expectedSort: typeof sortOptions[number]
     expectedOrder: typeof orderOptions[number]
   }
   const tabScenarios: TabScenario[] = [
@@ -232,42 +232,42 @@ describe('Reviews table', () => {
       name: 'shows each available level',
       givenUrl: '',
       expectedLevel: 'STD',
-      expectedSort: 'nextReviewDate',
+      expectedSort: 'NEXT_REVIEW_DATE',
       expectedOrder: 'asc',
     },
     {
       name: 'highlights requested level tab',
       givenUrl: '?level=ENH',
       expectedLevel: 'ENH',
-      expectedSort: 'nextReviewDate',
+      expectedSort: 'NEXT_REVIEW_DATE',
       expectedOrder: 'asc',
     },
     {
       name: 'falls back to default when given incorrect level',
       givenUrl: '?level=EN2',
       expectedLevel: 'STD',
-      expectedSort: 'nextReviewDate',
+      expectedSort: 'NEXT_REVIEW_DATE',
       expectedOrder: 'asc',
     },
     {
       name: 'preserves sort',
-      givenUrl: '?sort=name',
+      givenUrl: '?sort=LAST_NAME',
       expectedLevel: 'STD',
-      expectedSort: 'name',
+      expectedSort: 'LAST_NAME',
       expectedOrder: 'asc',
     },
     {
       name: 'preserves sort and order',
-      givenUrl: '?sort=negativeBehaviours&order=asc',
+      givenUrl: '?sort=NEGATIVE_BEHAVIOURS&order=asc',
       expectedLevel: 'STD',
-      expectedSort: 'negativeBehaviours',
+      expectedSort: 'NEGATIVE_BEHAVIOURS',
       expectedOrder: 'asc',
     },
     {
       name: 'accepts all parameters',
-      givenUrl: '?level=BAS&sort=acctStatus&order=desc&page=3',
+      givenUrl: '?level=BAS&sort=ACCT_STATUS&order=desc&page=3',
       expectedLevel: 'BAS',
-      expectedSort: 'acctStatus',
+      expectedSort: 'ACCT_STATUS',
       expectedOrder: 'desc',
     },
   ]
@@ -354,7 +354,7 @@ describe('Reviews table', () => {
     name: string
     givenUrl: string
     expectedLevel: string
-    expectedSort: string
+    expectedSort: typeof sortOptions[number]
     expectedOrder: typeof orderOptions[number]
   }
   const sortingScenarios: SortingScenario[] = [
@@ -362,77 +362,77 @@ describe('Reviews table', () => {
       name: 'uses default level and sorting if not provided',
       givenUrl: '',
       expectedLevel: 'STD',
-      expectedSort: 'nextReviewDate',
+      expectedSort: 'NEXT_REVIEW_DATE',
       expectedOrder: 'asc',
     },
     {
       name: 'preserves level and uses default sorting if not provided',
       givenUrl: '?level=ENH',
       expectedLevel: 'ENH',
-      expectedSort: 'nextReviewDate',
+      expectedSort: 'NEXT_REVIEW_DATE',
       expectedOrder: 'asc',
     },
     {
       name: 'preserves level, dropping page, and uses default sorting if not provided',
       givenUrl: '?level=ENH&page=3',
       expectedLevel: 'ENH',
-      expectedSort: 'nextReviewDate',
+      expectedSort: 'NEXT_REVIEW_DATE',
       expectedOrder: 'asc',
     },
     {
       name: 'accepts provided sort and uses default level',
-      givenUrl: '?sort=name',
+      givenUrl: '?sort=LAST_NAME',
       expectedLevel: 'STD',
-      expectedSort: 'name',
+      expectedSort: 'LAST_NAME',
       expectedOrder: 'asc',
     },
     {
       name: 'accepts provided sort & ordering and uses default level',
-      givenUrl: '?sort=name&order=desc',
+      givenUrl: '?sort=LAST_NAME&order=desc',
       expectedLevel: 'STD',
-      expectedSort: 'name',
+      expectedSort: 'LAST_NAME',
       expectedOrder: 'desc',
     },
     {
       name: 'accepts provided sort and uses default level',
-      givenUrl: '?sort=positiveBehaviours',
+      givenUrl: '?sort=POSITIVE_BEHAVIOURS',
       expectedLevel: 'STD',
-      expectedSort: 'positiveBehaviours',
+      expectedSort: 'POSITIVE_BEHAVIOURS',
       expectedOrder: 'desc',
     },
     {
       name: 'accepts provided sort & ordering and uses default level',
-      givenUrl: '?sort=positiveBehaviours&order=desc',
+      givenUrl: '?sort=POSITIVE_BEHAVIOURS&order=desc',
       expectedLevel: 'STD',
-      expectedSort: 'positiveBehaviours',
+      expectedSort: 'POSITIVE_BEHAVIOURS',
       expectedOrder: 'desc',
     },
     {
       name: 'accepts provided sort and preserves level',
-      givenUrl: '?sort=name&level=BAS',
+      givenUrl: '?sort=LAST_NAME&level=BAS',
       expectedLevel: 'BAS',
-      expectedSort: 'name',
+      expectedSort: 'LAST_NAME',
       expectedOrder: 'asc',
     },
     {
       name: 'accepts provided sort & ordering and preserves level',
-      givenUrl: '?sort=name&order=desc&level=BAS',
+      givenUrl: '?sort=LAST_NAME&order=desc&level=BAS',
       expectedLevel: 'BAS',
-      expectedSort: 'name',
+      expectedSort: 'LAST_NAME',
       expectedOrder: 'desc',
     },
     {
       name: 'accepts provided sort and preserves level',
-      givenUrl: '?sort=positiveBehaviours&level=BAS',
+      givenUrl: '?sort=POSITIVE_BEHAVIOURS&level=BAS',
       expectedLevel: 'BAS',
-      expectedSort: 'positiveBehaviours',
+      expectedSort: 'POSITIVE_BEHAVIOURS',
       expectedOrder: 'desc',
     },
     {
       name: 'accepts provided sort & ordering and preserves level',
-      givenUrl: '?sort=positiveBehaviours&order=desc&level=BAS',
+      givenUrl: '?sort=POSITIVE_BEHAVIOURS&order=desc&level=BAS',
       expectedLevel: 'BAS',
-      expectedSort: 'positiveBehaviours',
+      expectedSort: 'POSITIVE_BEHAVIOURS',
       expectedOrder: 'desc',
     },
   ]
@@ -494,7 +494,7 @@ describe('Reviews table', () => {
     name: string
     givenUrl: string
     expectedLevel: string
-    expectedSort: string
+    expectedSort: typeof sortOptions[number]
     expectedOrder: typeof orderOptions[number]
     expectedPages: number[]
   }
@@ -503,7 +503,7 @@ describe('Reviews table', () => {
       name: 'preserves level and uses default sorting; defaults to page 1',
       givenUrl: '?level=ENH',
       expectedLevel: 'ENH',
-      expectedSort: 'nextReviewDate',
+      expectedSort: 'NEXT_REVIEW_DATE',
       expectedOrder: 'asc',
       expectedPages: [1, 2, 6, 7],
     },
@@ -511,7 +511,7 @@ describe('Reviews table', () => {
       name: 'preserves level and uses default sorting; accepts page',
       givenUrl: '?level=ENH&page=1',
       expectedLevel: 'ENH',
-      expectedSort: 'nextReviewDate',
+      expectedSort: 'NEXT_REVIEW_DATE',
       expectedOrder: 'asc',
       expectedPages: [1, 2, 6, 7],
     },
@@ -519,7 +519,7 @@ describe('Reviews table', () => {
       name: 'preserves level and uses default sorting; accepts another page',
       givenUrl: '?page=3&level=STD',
       expectedLevel: 'STD',
-      expectedSort: 'nextReviewDate',
+      expectedSort: 'NEXT_REVIEW_DATE',
       expectedOrder: 'asc',
       expectedPages: [1, 2, 3, 4, 6, 7],
     },
@@ -527,7 +527,7 @@ describe('Reviews table', () => {
       name: 'uses default level and sorting if not provided',
       givenUrl: '',
       expectedLevel: 'STD',
-      expectedSort: 'nextReviewDate',
+      expectedSort: 'NEXT_REVIEW_DATE',
       expectedOrder: 'asc',
       expectedPages: [1, 2, 6, 7],
     },
@@ -535,23 +535,23 @@ describe('Reviews table', () => {
       name: 'uses default level and sorting if not provided; accepts page',
       givenUrl: '?page=7',
       expectedLevel: 'STD',
-      expectedSort: 'nextReviewDate',
+      expectedSort: 'NEXT_REVIEW_DATE',
       expectedOrder: 'asc',
       expectedPages: [1, 2, 6, 7],
     },
     {
       name: 'preserves sort and uses default level if not provided',
-      givenUrl: '?page=7&sort=name',
+      givenUrl: '?page=7&sort=LAST_NAME',
       expectedLevel: 'STD',
-      expectedSort: 'name',
+      expectedSort: 'LAST_NAME',
       expectedOrder: 'asc',
       expectedPages: [1, 2, 6, 7],
     },
     {
       name: 'preserves sort and order, but uses default level if not provided',
-      givenUrl: '?page=7&order=desc&sort=name',
+      givenUrl: '?page=7&order=desc&sort=LAST_NAME',
       expectedLevel: 'STD',
-      expectedSort: 'name',
+      expectedSort: 'LAST_NAME',
       expectedOrder: 'desc',
       expectedPages: [1, 2, 6, 7],
     },

--- a/server/routes/reviewsTable.test.ts
+++ b/server/routes/reviewsTable.test.ts
@@ -126,9 +126,9 @@ describe('Reviews table', () => {
     },
     {
       name: 'with order param',
-      urlSuffix: '?order=desc',
+      urlSuffix: '?order=DESC',
       expectedRequest: {
-        order: 'desc',
+        order: 'DESC',
       },
     },
     {
@@ -141,7 +141,7 @@ describe('Reviews table', () => {
       urlSuffix: '?sort=LAST_NAME',
       expectedRequest: {
         sort: 'LAST_NAME',
-        order: 'asc',
+        order: 'ASC',
       },
     },
     {
@@ -151,10 +151,10 @@ describe('Reviews table', () => {
     },
     {
       name: 'with sort and order params',
-      urlSuffix: '?order=desc&sort=LAST_NAME',
+      urlSuffix: '?order=DESC&sort=LAST_NAME',
       expectedRequest: {
         sort: 'LAST_NAME',
-        order: 'desc',
+        order: 'DESC',
       },
     },
     {
@@ -162,7 +162,7 @@ describe('Reviews table', () => {
       urlSuffix: '?order=reversed&sort=LAST_NAME',
       expectedRequest: {
         sort: 'LAST_NAME',
-        order: 'asc',
+        order: 'ASC',
       },
     },
     {
@@ -180,17 +180,17 @@ describe('Reviews table', () => {
         levelCode: 'ENH',
         page: 3,
         sort: 'ACCT_STATUS',
-        order: 'desc',
+        order: 'DESC',
       },
     },
     {
       name: 'with level, sort, order and page params',
-      urlSuffix: '?level=BAS&sort=NEGATIVE_BEHAVIOURS&order=asc&page=4',
+      urlSuffix: '?level=BAS&sort=NEGATIVE_BEHAVIOURS&order=ASC&page=4',
       expectedRequest: {
         levelCode: 'BAS',
         page: 4,
         sort: 'NEGATIVE_BEHAVIOURS',
-        order: 'asc',
+        order: 'ASC',
       },
     },
   ]
@@ -202,7 +202,7 @@ describe('Reviews table', () => {
         locationPrefix: 'MDI-1',
         levelCode: 'STD',
         sort: 'NEXT_REVIEW_DATE',
-        order: 'asc',
+        order: 'ASC',
         page: 1,
         pageSize: 20,
       }
@@ -233,42 +233,42 @@ describe('Reviews table', () => {
       givenUrl: '',
       expectedLevel: 'STD',
       expectedSort: 'NEXT_REVIEW_DATE',
-      expectedOrder: 'asc',
+      expectedOrder: 'ASC',
     },
     {
       name: 'highlights requested level tab',
       givenUrl: '?level=ENH',
       expectedLevel: 'ENH',
       expectedSort: 'NEXT_REVIEW_DATE',
-      expectedOrder: 'asc',
+      expectedOrder: 'ASC',
     },
     {
       name: 'falls back to default when given incorrect level',
       givenUrl: '?level=EN2',
       expectedLevel: 'STD',
       expectedSort: 'NEXT_REVIEW_DATE',
-      expectedOrder: 'asc',
+      expectedOrder: 'ASC',
     },
     {
       name: 'preserves sort',
       givenUrl: '?sort=LAST_NAME',
       expectedLevel: 'STD',
       expectedSort: 'LAST_NAME',
-      expectedOrder: 'asc',
+      expectedOrder: 'ASC',
     },
     {
       name: 'preserves sort and order',
-      givenUrl: '?sort=NEGATIVE_BEHAVIOURS&order=asc',
+      givenUrl: '?sort=NEGATIVE_BEHAVIOURS&order=ASC',
       expectedLevel: 'STD',
       expectedSort: 'NEGATIVE_BEHAVIOURS',
-      expectedOrder: 'asc',
+      expectedOrder: 'ASC',
     },
     {
       name: 'accepts all parameters',
-      givenUrl: '?level=BAS&sort=ACCT_STATUS&order=desc&page=3',
+      givenUrl: '?level=BAS&sort=ACCT_STATUS&order=DESC&page=3',
       expectedLevel: 'BAS',
       expectedSort: 'ACCT_STATUS',
-      expectedOrder: 'desc',
+      expectedOrder: 'DESC',
     },
   ]
   describe.each(tabScenarios)(
@@ -363,77 +363,77 @@ describe('Reviews table', () => {
       givenUrl: '',
       expectedLevel: 'STD',
       expectedSort: 'NEXT_REVIEW_DATE',
-      expectedOrder: 'asc',
+      expectedOrder: 'ASC',
     },
     {
       name: 'preserves level and uses default sorting if not provided',
       givenUrl: '?level=ENH',
       expectedLevel: 'ENH',
       expectedSort: 'NEXT_REVIEW_DATE',
-      expectedOrder: 'asc',
+      expectedOrder: 'ASC',
     },
     {
       name: 'preserves level, dropping page, and uses default sorting if not provided',
       givenUrl: '?level=ENH&page=3',
       expectedLevel: 'ENH',
       expectedSort: 'NEXT_REVIEW_DATE',
-      expectedOrder: 'asc',
+      expectedOrder: 'ASC',
     },
     {
       name: 'accepts provided sort and uses default level',
       givenUrl: '?sort=LAST_NAME',
       expectedLevel: 'STD',
       expectedSort: 'LAST_NAME',
-      expectedOrder: 'asc',
+      expectedOrder: 'ASC',
     },
     {
       name: 'accepts provided sort & ordering and uses default level',
-      givenUrl: '?sort=LAST_NAME&order=desc',
+      givenUrl: '?sort=LAST_NAME&order=DESC',
       expectedLevel: 'STD',
       expectedSort: 'LAST_NAME',
-      expectedOrder: 'desc',
+      expectedOrder: 'DESC',
     },
     {
       name: 'accepts provided sort and uses default level',
       givenUrl: '?sort=POSITIVE_BEHAVIOURS',
       expectedLevel: 'STD',
       expectedSort: 'POSITIVE_BEHAVIOURS',
-      expectedOrder: 'desc',
+      expectedOrder: 'DESC',
     },
     {
       name: 'accepts provided sort & ordering and uses default level',
-      givenUrl: '?sort=POSITIVE_BEHAVIOURS&order=desc',
+      givenUrl: '?sort=POSITIVE_BEHAVIOURS&order=DESC',
       expectedLevel: 'STD',
       expectedSort: 'POSITIVE_BEHAVIOURS',
-      expectedOrder: 'desc',
+      expectedOrder: 'DESC',
     },
     {
       name: 'accepts provided sort and preserves level',
       givenUrl: '?sort=LAST_NAME&level=BAS',
       expectedLevel: 'BAS',
       expectedSort: 'LAST_NAME',
-      expectedOrder: 'asc',
+      expectedOrder: 'ASC',
     },
     {
       name: 'accepts provided sort & ordering and preserves level',
-      givenUrl: '?sort=LAST_NAME&order=desc&level=BAS',
+      givenUrl: '?sort=LAST_NAME&order=DESC&level=BAS',
       expectedLevel: 'BAS',
       expectedSort: 'LAST_NAME',
-      expectedOrder: 'desc',
+      expectedOrder: 'DESC',
     },
     {
       name: 'accepts provided sort and preserves level',
       givenUrl: '?sort=POSITIVE_BEHAVIOURS&level=BAS',
       expectedLevel: 'BAS',
       expectedSort: 'POSITIVE_BEHAVIOURS',
-      expectedOrder: 'desc',
+      expectedOrder: 'DESC',
     },
     {
       name: 'accepts provided sort & ordering and preserves level',
-      givenUrl: '?sort=POSITIVE_BEHAVIOURS&order=desc&level=BAS',
+      givenUrl: '?sort=POSITIVE_BEHAVIOURS&order=DESC&level=BAS',
       expectedLevel: 'BAS',
       expectedSort: 'POSITIVE_BEHAVIOURS',
-      expectedOrder: 'desc',
+      expectedOrder: 'DESC',
     },
   ]
   describe.each(sortingScenarios)(
@@ -441,7 +441,7 @@ describe('Reviews table', () => {
     ({ name, givenUrl, expectedLevel, expectedSort, expectedOrder }) => {
       // NB: sorting resets page, but preserves level
 
-      const oppositeOrder = expectedOrder === 'asc' ? 'desc' : 'asc'
+      const oppositeOrder = expectedOrder === 'ASC' ? 'DESC' : 'ASC'
 
       it(name, () => {
         const $ = jquery(new JSDOM().window) as unknown as typeof jquery
@@ -474,7 +474,7 @@ describe('Reviews table', () => {
               expect(href).not.toContain('page=')
               if (column === expectedSort) {
                 // column by which table is sorted
-                const expectedAriaSortOrder = { asc: 'ascending', desc: 'descending' }[expectedOrder]
+                const expectedAriaSortOrder = { ASC: 'ascending', DESC: 'descending' }[expectedOrder]
                 expect(ariaSortOrder).toEqual(expectedAriaSortOrder)
                 // sorted column's link should flip order
                 expect(href).toContain(`sort=${column}&order=${oppositeOrder}`)
@@ -504,7 +504,7 @@ describe('Reviews table', () => {
       givenUrl: '?level=ENH',
       expectedLevel: 'ENH',
       expectedSort: 'NEXT_REVIEW_DATE',
-      expectedOrder: 'asc',
+      expectedOrder: 'ASC',
       expectedPages: [1, 2, 6, 7],
     },
     {
@@ -512,7 +512,7 @@ describe('Reviews table', () => {
       givenUrl: '?level=ENH&page=1',
       expectedLevel: 'ENH',
       expectedSort: 'NEXT_REVIEW_DATE',
-      expectedOrder: 'asc',
+      expectedOrder: 'ASC',
       expectedPages: [1, 2, 6, 7],
     },
     {
@@ -520,7 +520,7 @@ describe('Reviews table', () => {
       givenUrl: '?page=3&level=STD',
       expectedLevel: 'STD',
       expectedSort: 'NEXT_REVIEW_DATE',
-      expectedOrder: 'asc',
+      expectedOrder: 'ASC',
       expectedPages: [1, 2, 3, 4, 6, 7],
     },
     {
@@ -528,7 +528,7 @@ describe('Reviews table', () => {
       givenUrl: '',
       expectedLevel: 'STD',
       expectedSort: 'NEXT_REVIEW_DATE',
-      expectedOrder: 'asc',
+      expectedOrder: 'ASC',
       expectedPages: [1, 2, 6, 7],
     },
     {
@@ -536,7 +536,7 @@ describe('Reviews table', () => {
       givenUrl: '?page=7',
       expectedLevel: 'STD',
       expectedSort: 'NEXT_REVIEW_DATE',
-      expectedOrder: 'asc',
+      expectedOrder: 'ASC',
       expectedPages: [1, 2, 6, 7],
     },
     {
@@ -544,15 +544,15 @@ describe('Reviews table', () => {
       givenUrl: '?page=7&sort=LAST_NAME',
       expectedLevel: 'STD',
       expectedSort: 'LAST_NAME',
-      expectedOrder: 'asc',
+      expectedOrder: 'ASC',
       expectedPages: [1, 2, 6, 7],
     },
     {
       name: 'preserves sort and order, but uses default level if not provided',
-      givenUrl: '?page=7&order=desc&sort=LAST_NAME',
+      givenUrl: '?page=7&order=DESC&sort=LAST_NAME',
       expectedLevel: 'STD',
       expectedSort: 'LAST_NAME',
-      expectedOrder: 'desc',
+      expectedOrder: 'DESC',
       expectedPages: [1, 2, 6, 7],
     },
   ]

--- a/server/routes/reviewsTable.test.ts
+++ b/server/routes/reviewsTable.test.ts
@@ -175,11 +175,11 @@ describe('Reviews table', () => {
     },
     {
       name: 'with level, sort and page params',
-      urlSuffix: '?page=3&level=ENH&sort=ACCT_STATUS',
+      urlSuffix: '?page=3&level=ENH&sort=HAS_ACCT_OPEN',
       expectedRequest: {
         levelCode: 'ENH',
         page: 3,
-        sort: 'ACCT_STATUS',
+        sort: 'HAS_ACCT_OPEN',
         order: 'DESC',
       },
     },
@@ -265,9 +265,9 @@ describe('Reviews table', () => {
     },
     {
       name: 'accepts all parameters',
-      givenUrl: '?level=BAS&sort=ACCT_STATUS&order=DESC&page=3',
+      givenUrl: '?level=BAS&sort=HAS_ACCT_OPEN&order=DESC&page=3',
       expectedLevel: 'BAS',
-      expectedSort: 'ACCT_STATUS',
+      expectedSort: 'HAS_ACCT_OPEN',
       expectedOrder: 'DESC',
     },
   ]
@@ -324,14 +324,8 @@ describe('Reviews table', () => {
       .expect(res => {
         const $body = $(res.text)
         const firstRowCells: HTMLTableCellElement[] = $body.find('.app-reviews-table tbody tr').first().find('td').get()
-        const [
-          photoCell,
-          nameCell,
-          nextReviewDateCell,
-          positiveBehavioursCell,
-          negativeBehavioursCell,
-          acctStatusCell,
-        ] = firstRowCells
+        const [photoCell, nameCell, nextReviewDateCell, positiveBehavioursCell, negativeBehavioursCell, acctCell] =
+          firstRowCells
 
         expect(photoCell.innerHTML).toContain('Photo of G6123VU')
         expect(nameCell.textContent).toContain('Saunders, John')
@@ -346,7 +340,7 @@ describe('Reviews table', () => {
         expect(negativeBehavioursCell.innerHTML).toContain(
           '/prisoner/G6123VU/case-notes?type=NEG&amp;fromDate=09/07/2022',
         )
-        expect(acctStatusCell.textContent).toContain('ACCT open')
+        expect(acctCell.textContent).toContain('ACCT open')
       })
   })
 

--- a/server/routes/reviewsTable.test.ts
+++ b/server/routes/reviewsTable.test.ts
@@ -7,7 +7,7 @@ import config from '../config'
 import { appWithAllRoutes } from './testutils/appSetup'
 import { getTestIncentivesReviews } from '../testData/incentivesApi'
 import HmppsAuthClient from '../data/hmppsAuthClient'
-import type { Level, IncentivesReviewsRequest } from '../data/incentivesApi'
+import type { Level, IncentivesReviewsRequest, orderOptions } from '../data/incentivesApi'
 import { IncentivesApi } from '../data/incentivesApi'
 
 jest.mock('../data/hmppsAuthClient')
@@ -126,9 +126,9 @@ describe('Reviews table', () => {
     },
     {
       name: 'with order param',
-      urlSuffix: '?order=descending',
+      urlSuffix: '?order=desc',
       expectedRequest: {
-        order: 'descending',
+        order: 'desc',
       },
     },
     {
@@ -141,7 +141,7 @@ describe('Reviews table', () => {
       urlSuffix: '?sort=name',
       expectedRequest: {
         sort: 'name',
-        order: 'ascending',
+        order: 'asc',
       },
     },
     {
@@ -151,10 +151,10 @@ describe('Reviews table', () => {
     },
     {
       name: 'with sort and order params',
-      urlSuffix: '?order=descending&sort=name',
+      urlSuffix: '?order=desc&sort=name',
       expectedRequest: {
         sort: 'name',
-        order: 'descending',
+        order: 'desc',
       },
     },
     {
@@ -162,7 +162,7 @@ describe('Reviews table', () => {
       urlSuffix: '?order=reversed&sort=name',
       expectedRequest: {
         sort: 'name',
-        order: 'ascending',
+        order: 'asc',
       },
     },
     {
@@ -180,17 +180,17 @@ describe('Reviews table', () => {
         levelCode: 'ENH',
         page: 3,
         sort: 'acctStatus',
-        order: 'descending',
+        order: 'desc',
       },
     },
     {
       name: 'with level, sort, order and page params',
-      urlSuffix: '?level=BAS&sort=negativeBehaviours&order=ascending&page=4',
+      urlSuffix: '?level=BAS&sort=negativeBehaviours&order=asc&page=4',
       expectedRequest: {
         levelCode: 'BAS',
         page: 4,
         sort: 'negativeBehaviours',
-        order: 'ascending',
+        order: 'asc',
       },
     },
   ]
@@ -202,7 +202,7 @@ describe('Reviews table', () => {
         locationPrefix: 'MDI-1',
         levelCode: 'STD',
         sort: 'nextReviewDate',
-        order: 'ascending',
+        order: 'asc',
         page: 1,
         pageSize: 20,
       }
@@ -225,7 +225,7 @@ describe('Reviews table', () => {
     givenUrl: string
     expectedLevel: string
     expectedSort: string
-    expectedOrder: 'ascending' | 'descending'
+    expectedOrder: typeof orderOptions[number]
   }
   const tabScenarios: TabScenario[] = [
     {
@@ -233,42 +233,42 @@ describe('Reviews table', () => {
       givenUrl: '',
       expectedLevel: 'STD',
       expectedSort: 'nextReviewDate',
-      expectedOrder: 'ascending',
+      expectedOrder: 'asc',
     },
     {
       name: 'highlights requested level tab',
       givenUrl: '?level=ENH',
       expectedLevel: 'ENH',
       expectedSort: 'nextReviewDate',
-      expectedOrder: 'ascending',
+      expectedOrder: 'asc',
     },
     {
       name: 'falls back to default when given incorrect level',
       givenUrl: '?level=EN2',
       expectedLevel: 'STD',
       expectedSort: 'nextReviewDate',
-      expectedOrder: 'ascending',
+      expectedOrder: 'asc',
     },
     {
       name: 'preserves sort',
       givenUrl: '?sort=name',
       expectedLevel: 'STD',
       expectedSort: 'name',
-      expectedOrder: 'ascending',
+      expectedOrder: 'asc',
     },
     {
       name: 'preserves sort and order',
-      givenUrl: '?sort=negativeBehaviours&order=ascending',
+      givenUrl: '?sort=negativeBehaviours&order=asc',
       expectedLevel: 'STD',
       expectedSort: 'negativeBehaviours',
-      expectedOrder: 'ascending',
+      expectedOrder: 'asc',
     },
     {
       name: 'accepts all parameters',
-      givenUrl: '?level=BAS&sort=acctStatus&order=descending&page=3',
+      givenUrl: '?level=BAS&sort=acctStatus&order=desc&page=3',
       expectedLevel: 'BAS',
       expectedSort: 'acctStatus',
-      expectedOrder: 'descending',
+      expectedOrder: 'desc',
     },
   ]
   describe.each(tabScenarios)(
@@ -355,7 +355,7 @@ describe('Reviews table', () => {
     givenUrl: string
     expectedLevel: string
     expectedSort: string
-    expectedOrder: 'ascending' | 'descending'
+    expectedOrder: typeof orderOptions[number]
   }
   const sortingScenarios: SortingScenario[] = [
     {
@@ -363,77 +363,77 @@ describe('Reviews table', () => {
       givenUrl: '',
       expectedLevel: 'STD',
       expectedSort: 'nextReviewDate',
-      expectedOrder: 'ascending',
+      expectedOrder: 'asc',
     },
     {
       name: 'preserves level and uses default sorting if not provided',
       givenUrl: '?level=ENH',
       expectedLevel: 'ENH',
       expectedSort: 'nextReviewDate',
-      expectedOrder: 'ascending',
+      expectedOrder: 'asc',
     },
     {
       name: 'preserves level, dropping page, and uses default sorting if not provided',
       givenUrl: '?level=ENH&page=3',
       expectedLevel: 'ENH',
       expectedSort: 'nextReviewDate',
-      expectedOrder: 'ascending',
+      expectedOrder: 'asc',
     },
     {
       name: 'accepts provided sort and uses default level',
       givenUrl: '?sort=name',
       expectedLevel: 'STD',
       expectedSort: 'name',
-      expectedOrder: 'ascending',
+      expectedOrder: 'asc',
     },
     {
       name: 'accepts provided sort & ordering and uses default level',
-      givenUrl: '?sort=name&order=descending',
+      givenUrl: '?sort=name&order=desc',
       expectedLevel: 'STD',
       expectedSort: 'name',
-      expectedOrder: 'descending',
+      expectedOrder: 'desc',
     },
     {
       name: 'accepts provided sort and uses default level',
       givenUrl: '?sort=positiveBehaviours',
       expectedLevel: 'STD',
       expectedSort: 'positiveBehaviours',
-      expectedOrder: 'descending',
+      expectedOrder: 'desc',
     },
     {
       name: 'accepts provided sort & ordering and uses default level',
-      givenUrl: '?sort=positiveBehaviours&order=descending',
+      givenUrl: '?sort=positiveBehaviours&order=desc',
       expectedLevel: 'STD',
       expectedSort: 'positiveBehaviours',
-      expectedOrder: 'descending',
+      expectedOrder: 'desc',
     },
     {
       name: 'accepts provided sort and preserves level',
       givenUrl: '?sort=name&level=BAS',
       expectedLevel: 'BAS',
       expectedSort: 'name',
-      expectedOrder: 'ascending',
+      expectedOrder: 'asc',
     },
     {
       name: 'accepts provided sort & ordering and preserves level',
-      givenUrl: '?sort=name&order=descending&level=BAS',
+      givenUrl: '?sort=name&order=desc&level=BAS',
       expectedLevel: 'BAS',
       expectedSort: 'name',
-      expectedOrder: 'descending',
+      expectedOrder: 'desc',
     },
     {
       name: 'accepts provided sort and preserves level',
       givenUrl: '?sort=positiveBehaviours&level=BAS',
       expectedLevel: 'BAS',
       expectedSort: 'positiveBehaviours',
-      expectedOrder: 'descending',
+      expectedOrder: 'desc',
     },
     {
       name: 'accepts provided sort & ordering and preserves level',
-      givenUrl: '?sort=positiveBehaviours&order=descending&level=BAS',
+      givenUrl: '?sort=positiveBehaviours&order=desc&level=BAS',
       expectedLevel: 'BAS',
       expectedSort: 'positiveBehaviours',
-      expectedOrder: 'descending',
+      expectedOrder: 'desc',
     },
   ]
   describe.each(sortingScenarios)(
@@ -441,7 +441,7 @@ describe('Reviews table', () => {
     ({ name, givenUrl, expectedLevel, expectedSort, expectedOrder }) => {
       // NB: sorting resets page, but preserves level
 
-      const oppositeOrder = expectedOrder === 'ascending' ? 'descending' : 'ascending'
+      const oppositeOrder = expectedOrder === 'asc' ? 'desc' : 'asc'
 
       it(name, () => {
         const $ = jquery(new JSDOM().window) as unknown as typeof jquery
@@ -454,19 +454,19 @@ describe('Reviews table', () => {
               .find('.app-reviews-table thead tr th')
               .map((index, th: HTMLTableCellElement) => {
                 const href = $(th).find('a').attr('href')
-                const order = th.getAttribute('aria-sort')
+                const ariaSortOrder = th.getAttribute('aria-sort')
                 if (index === 0) {
                   // first column is not sortable and has no link
                   expect(href).toBeUndefined()
-                  expect(order).toBeNull()
+                  expect(ariaSortOrder).toBeNull()
                 }
-                return { href, order }
+                return { href, ariaSortOrder }
               })
               .get()
               .slice(1)
 
             // eslint-disable-next-line no-restricted-syntax
-            for (const { href, order } of columns) {
+            for (const { href, ariaSortOrder } of columns) {
               const column = /sort=([^&]+)/.exec(href)[1]
               // level should be preserved
               expect(href).toContain(`?level=${expectedLevel}&`)
@@ -474,12 +474,13 @@ describe('Reviews table', () => {
               expect(href).not.toContain('page=')
               if (column === expectedSort) {
                 // column by which table is sorted
-                expect(order).toEqual(expectedOrder)
+                const expectedAriaSortOrder = { asc: 'ascending', desc: 'descending' }[expectedOrder]
+                expect(ariaSortOrder).toEqual(expectedAriaSortOrder)
                 // sorted column's link should flip order
                 expect(href).toContain(`sort=${column}&order=${oppositeOrder}`)
               } else {
                 // column by which table is not sorted
-                expect(order).toEqual('none')
+                expect(ariaSortOrder).toEqual('none')
                 // unsorted column's link should replicate order
                 expect(href).toContain(`sort=${column}&order=${expectedOrder}`)
               }
@@ -494,7 +495,7 @@ describe('Reviews table', () => {
     givenUrl: string
     expectedLevel: string
     expectedSort: string
-    expectedOrder: 'ascending' | 'descending'
+    expectedOrder: typeof orderOptions[number]
     expectedPages: number[]
   }
   const paginationScenarios: PaginationScenario[] = [
@@ -503,7 +504,7 @@ describe('Reviews table', () => {
       givenUrl: '?level=ENH',
       expectedLevel: 'ENH',
       expectedSort: 'nextReviewDate',
-      expectedOrder: 'ascending',
+      expectedOrder: 'asc',
       expectedPages: [1, 2, 6, 7],
     },
     {
@@ -511,7 +512,7 @@ describe('Reviews table', () => {
       givenUrl: '?level=ENH&page=1',
       expectedLevel: 'ENH',
       expectedSort: 'nextReviewDate',
-      expectedOrder: 'ascending',
+      expectedOrder: 'asc',
       expectedPages: [1, 2, 6, 7],
     },
     {
@@ -519,7 +520,7 @@ describe('Reviews table', () => {
       givenUrl: '?page=3&level=STD',
       expectedLevel: 'STD',
       expectedSort: 'nextReviewDate',
-      expectedOrder: 'ascending',
+      expectedOrder: 'asc',
       expectedPages: [1, 2, 3, 4, 6, 7],
     },
     {
@@ -527,7 +528,7 @@ describe('Reviews table', () => {
       givenUrl: '',
       expectedLevel: 'STD',
       expectedSort: 'nextReviewDate',
-      expectedOrder: 'ascending',
+      expectedOrder: 'asc',
       expectedPages: [1, 2, 6, 7],
     },
     {
@@ -535,7 +536,7 @@ describe('Reviews table', () => {
       givenUrl: '?page=7',
       expectedLevel: 'STD',
       expectedSort: 'nextReviewDate',
-      expectedOrder: 'ascending',
+      expectedOrder: 'asc',
       expectedPages: [1, 2, 6, 7],
     },
     {
@@ -543,15 +544,15 @@ describe('Reviews table', () => {
       givenUrl: '?page=7&sort=name',
       expectedLevel: 'STD',
       expectedSort: 'name',
-      expectedOrder: 'ascending',
+      expectedOrder: 'asc',
       expectedPages: [1, 2, 6, 7],
     },
     {
       name: 'preserves sort and order, but uses default level if not provided',
-      givenUrl: '?page=7&order=descending&sort=name',
+      givenUrl: '?page=7&order=desc&sort=name',
       expectedLevel: 'STD',
       expectedSort: 'name',
-      expectedOrder: 'descending',
+      expectedOrder: 'desc',
       expectedPages: [1, 2, 6, 7],
     },
   ]

--- a/server/routes/reviewsTable.ts
+++ b/server/routes/reviewsTable.ts
@@ -114,10 +114,10 @@ function parseSorting(sortString: string | undefined, orderString: string | unde
     // these columns prefer descending order:
     if (['positiveBehaviours', 'negativeBehaviours', 'acctStatus'].includes(sortString)) {
       // eslint-disable-next-line no-param-reassign
-      orderString = 'descending'
+      orderString = 'desc'
     } else {
       // eslint-disable-next-line no-param-reassign
-      orderString = 'ascending'
+      orderString = 'asc'
     }
   }
 

--- a/server/routes/reviewsTable.ts
+++ b/server/routes/reviewsTable.ts
@@ -22,11 +22,11 @@ const PAGE_SIZE = 20
 
 const tableColumns: Parameters<typeof sortableTableHead<string>>[0] = [
   { column: 'photo', escapedHtml: '<span class="govuk-visually-hidden">Prisoner photo</span>', unsortable: true },
-  { column: 'name', escapedHtml: 'Name and prison number' },
-  { column: 'nextReviewDate', escapedHtml: 'Date of next review' },
-  { column: 'positiveBehaviours', escapedHtml: 'Positive behaviours <br /> in the last 3 months' },
-  { column: 'negativeBehaviours', escapedHtml: 'Negative behaviours <br /> in the last 3 months' },
-  { column: 'acctStatus', escapedHtml: 'ACCT status' },
+  { column: 'LAST_NAME', escapedHtml: 'Name and prison number' },
+  { column: 'NEXT_REVIEW_DATE', escapedHtml: 'Date of next review' },
+  { column: 'POSITIVE_BEHAVIOURS', escapedHtml: 'Positive behaviours <br /> in the last 3 months' },
+  { column: 'NEGATIVE_BEHAVIOURS', escapedHtml: 'Negative behaviours <br /> in the last 3 months' },
+  { column: 'ACCT_STATUS', escapedHtml: 'ACCT status' },
 ]
 
 export default function routes(router: Router): Router {
@@ -106,13 +106,13 @@ function parseSorting(sortString: string | undefined, orderString: string | unde
   // default to sorting by next review date if not provided or invalid
   if (!sortOptions.includes(sortString as Sort)) {
     // eslint-disable-next-line no-param-reassign
-    sortString = 'nextReviewDate'
+    sortString = 'NEXT_REVIEW_DATE'
   }
 
   // default ordering if not provided or invalid
   if (!orderOptions.includes(orderString as Order)) {
     // these columns prefer descending order:
-    if (['positiveBehaviours', 'negativeBehaviours', 'acctStatus'].includes(sortString)) {
+    if (['POSITIVE_BEHAVIOURS', 'NEGATIVE_BEHAVIOURS', 'ACCT_STATUS'].includes(sortString)) {
       // eslint-disable-next-line no-param-reassign
       orderString = 'desc'
     } else {

--- a/server/routes/reviewsTable.ts
+++ b/server/routes/reviewsTable.ts
@@ -26,7 +26,7 @@ const tableColumns: Parameters<typeof sortableTableHead<string>>[0] = [
   { column: 'NEXT_REVIEW_DATE', escapedHtml: 'Date of next review' },
   { column: 'POSITIVE_BEHAVIOURS', escapedHtml: 'Positive behaviours <br /> in the last 3 months' },
   { column: 'NEGATIVE_BEHAVIOURS', escapedHtml: 'Negative behaviours <br /> in the last 3 months' },
-  { column: 'ACCT_STATUS', escapedHtml: 'ACCT status' },
+  { column: 'HAS_ACCT_OPEN', escapedHtml: 'ACCT status' },
 ]
 
 export default function routes(router: Router): Router {
@@ -112,7 +112,7 @@ function parseSorting(sortString: string | undefined, orderString: string | unde
   // default ordering if not provided or invalid
   if (!orderOptions.includes(orderString as Order)) {
     // these columns prefer descending order:
-    if (['POSITIVE_BEHAVIOURS', 'NEGATIVE_BEHAVIOURS', 'ACCT_STATUS'].includes(sortString)) {
+    if (['POSITIVE_BEHAVIOURS', 'NEGATIVE_BEHAVIOURS', 'HAS_ACCT_OPEN'].includes(sortString)) {
       // eslint-disable-next-line no-param-reassign
       orderString = 'DESC'
     } else {

--- a/server/routes/reviewsTable.ts
+++ b/server/routes/reviewsTable.ts
@@ -114,10 +114,10 @@ function parseSorting(sortString: string | undefined, orderString: string | unde
     // these columns prefer descending order:
     if (['POSITIVE_BEHAVIOURS', 'NEGATIVE_BEHAVIOURS', 'ACCT_STATUS'].includes(sortString)) {
       // eslint-disable-next-line no-param-reassign
-      orderString = 'desc'
+      orderString = 'DESC'
     } else {
       // eslint-disable-next-line no-param-reassign
-      orderString = 'asc'
+      orderString = 'ASC'
     }
   }
 

--- a/server/testData/incentivesApi.ts
+++ b/server/testData/incentivesApi.ts
@@ -90,7 +90,7 @@ export function getTestIncentivesReviews(): IncentivesReviewsResponse {
         nextReviewDate: new Date(2022, 6, 12),
         positiveBehaviours: 3,
         negativeBehaviours: 2,
-        acctStatus: true,
+        hasAcctOpen: true,
       },
       {
         firstName: 'Flem',
@@ -101,7 +101,7 @@ export function getTestIncentivesReviews(): IncentivesReviewsResponse {
         nextReviewDate: new Date(2023, 9, 10),
         positiveBehaviours: 2,
         negativeBehaviours: 0,
-        acctStatus: false,
+        hasAcctOpen: false,
       },
     ],
   }

--- a/server/utils/sortableTable.test.ts
+++ b/server/utils/sortableTable.test.ts
@@ -9,21 +9,21 @@ const sampleColumns: Parameters<typeof sortableTableHead<Colum>>[0] = [
 describe('sortableTableHead', () => {
   describe('should label sorted column with aria attribute', () => {
     it('when a column is sorted ascending', () => {
-      expect(sortableTableHead<Colum>(sampleColumns, '?size=large', 'month', 'ascending')).toEqual<HeaderCell[]>([
+      expect(sortableTableHead<Colum>(sampleColumns, '?size=large', 'month', 'asc')).toEqual<HeaderCell[]>([
         { html: expect.stringContaining('Month you apply'), attributes: { 'aria-sort': 'ascending' } },
         { html: expect.stringContaining('Rate for vehicles'), attributes: { 'aria-sort': 'none' } },
       ])
     })
 
     it('when a different column is sorted descending', () => {
-      expect(sortableTableHead<Colum>(sampleColumns, '?size=large', 'rate', 'descending')).toEqual<HeaderCell[]>([
+      expect(sortableTableHead<Colum>(sampleColumns, '?size=large', 'rate', 'desc')).toEqual<HeaderCell[]>([
         { html: expect.stringContaining('Month you apply'), attributes: { 'aria-sort': 'none' } },
         { html: expect.stringContaining('Rate for vehicles'), attributes: { 'aria-sort': 'descending' } },
       ])
     })
 
     it('when an uknown column is sorted', () => {
-      expect(sortableTableHead<string>(sampleColumns, '?size=large', 'unknown', 'descending')).toEqual<HeaderCell[]>([
+      expect(sortableTableHead<string>(sampleColumns, '?size=large', 'unknown', 'desc')).toEqual<HeaderCell[]>([
         { html: expect.stringContaining('Month you apply'), attributes: { 'aria-sort': 'none' } },
         { html: expect.stringContaining('Rate for vehicles'), attributes: { 'aria-sort': 'none' } },
       ])
@@ -32,29 +32,29 @@ describe('sortableTableHead', () => {
 
   describe('should link column to sort action', () => {
     it('when a column is sorted ascending', () => {
-      expect(sortableTableHead<Colum>(sampleColumns, '?size=large', 'month', 'ascending')).toEqual([
+      expect(sortableTableHead<Colum>(sampleColumns, '?size=large', 'month', 'asc')).toEqual([
         // flip order if same column clicked
-        expect.objectContaining({ html: expect.stringContaining('?size=large&sort=month&order=descending') }),
+        expect.objectContaining({ html: expect.stringContaining('?size=large&amp;sort=month&amp;order=desc') }),
         // preserve same order if different column clicked
-        expect.objectContaining({ html: expect.stringContaining('?size=large&sort=rate&order=ascending') }),
+        expect.objectContaining({ html: expect.stringContaining('?size=large&amp;sort=rate&amp;order=asc') }),
       ])
     })
 
     it('when a different column is sorted descending', () => {
-      expect(sortableTableHead<Colum>(sampleColumns, '?size=large', 'rate', 'descending')).toEqual([
+      expect(sortableTableHead<Colum>(sampleColumns, '?size=large', 'rate', 'desc')).toEqual([
         // preserve same order if different column clicked
-        expect.objectContaining({ html: expect.stringContaining('?size=large&sort=month&order=descending') }),
+        expect.objectContaining({ html: expect.stringContaining('?size=large&amp;sort=month&amp;order=desc') }),
         // flip order if same column clicked
-        expect.objectContaining({ html: expect.stringContaining('?size=large&sort=rate&order=ascending') }),
+        expect.objectContaining({ html: expect.stringContaining('?size=large&amp;sort=rate&amp;order=asc') }),
       ])
     })
 
     it('when an uknown column is sorted', () => {
-      expect(sortableTableHead<string>(sampleColumns, '?size=large', 'unknown', 'descending')).toEqual([
+      expect(sortableTableHead<string>(sampleColumns, '?size=large', 'unknown', 'desc')).toEqual([
         // preserve same order if different column clicked
-        expect.objectContaining({ html: expect.stringContaining('?size=large&sort=month&order=descending') }),
+        expect.objectContaining({ html: expect.stringContaining('?size=large&amp;sort=month&amp;order=desc') }),
         // preserve same order if different column clicked
-        expect.objectContaining({ html: expect.stringContaining('?size=large&sort=rate&order=descending') }),
+        expect.objectContaining({ html: expect.stringContaining('?size=large&amp;sort=rate&amp;order=desc') }),
       ])
     })
   })
@@ -66,7 +66,7 @@ describe('sortableTableHead', () => {
     ]
 
     it('when another column is sorted', () => {
-      const tableHead = sortableTableHead<string>(sampleColumnsWithUnsortable, '?size=large', 'month', 'ascending')
+      const tableHead = sortableTableHead<string>(sampleColumnsWithUnsortable, '?size=large', 'month', 'asc')
       expect(tableHead).toEqual<HeaderCell[]>([
         { html: '<span class="govuk-visually-hidden">Icon &amp; label</span>' },
         { html: expect.stringContaining('Month you apply'), attributes: { 'aria-sort': 'ascending' } },
@@ -75,7 +75,7 @@ describe('sortableTableHead', () => {
     })
 
     it('when the unsortable column is sorted', () => {
-      const tableHead = sortableTableHead<string>(sampleColumnsWithUnsortable, '?size=large', 'icon', 'descending')
+      const tableHead = sortableTableHead<string>(sampleColumnsWithUnsortable, '?size=large', 'icon', 'desc')
       expect(tableHead).toEqual<HeaderCell[]>([
         { html: '<span class="govuk-visually-hidden">Icon &amp; label</span>' },
         { html: expect.stringContaining('Month you apply'), attributes: { 'aria-sort': 'none' } },

--- a/server/utils/sortableTable.test.ts
+++ b/server/utils/sortableTable.test.ts
@@ -9,21 +9,21 @@ const sampleColumns: Parameters<typeof sortableTableHead<Colum>>[0] = [
 describe('sortableTableHead', () => {
   describe('should label sorted column with aria attribute', () => {
     it('when a column is sorted ascending', () => {
-      expect(sortableTableHead<Colum>(sampleColumns, '?size=large', 'month', 'asc')).toEqual<HeaderCell[]>([
+      expect(sortableTableHead<Colum>(sampleColumns, '?size=large', 'month', 'ASC')).toEqual<HeaderCell[]>([
         { html: expect.stringContaining('Month you apply'), attributes: { 'aria-sort': 'ascending' } },
         { html: expect.stringContaining('Rate for vehicles'), attributes: { 'aria-sort': 'none' } },
       ])
     })
 
     it('when a different column is sorted descending', () => {
-      expect(sortableTableHead<Colum>(sampleColumns, '?size=large', 'rate', 'desc')).toEqual<HeaderCell[]>([
+      expect(sortableTableHead<Colum>(sampleColumns, '?size=large', 'rate', 'DESC')).toEqual<HeaderCell[]>([
         { html: expect.stringContaining('Month you apply'), attributes: { 'aria-sort': 'none' } },
         { html: expect.stringContaining('Rate for vehicles'), attributes: { 'aria-sort': 'descending' } },
       ])
     })
 
     it('when an uknown column is sorted', () => {
-      expect(sortableTableHead<string>(sampleColumns, '?size=large', 'unknown', 'desc')).toEqual<HeaderCell[]>([
+      expect(sortableTableHead<string>(sampleColumns, '?size=large', 'unknown', 'DESC')).toEqual<HeaderCell[]>([
         { html: expect.stringContaining('Month you apply'), attributes: { 'aria-sort': 'none' } },
         { html: expect.stringContaining('Rate for vehicles'), attributes: { 'aria-sort': 'none' } },
       ])
@@ -32,29 +32,29 @@ describe('sortableTableHead', () => {
 
   describe('should link column to sort action', () => {
     it('when a column is sorted ascending', () => {
-      expect(sortableTableHead<Colum>(sampleColumns, '?size=large', 'month', 'asc')).toEqual([
+      expect(sortableTableHead<Colum>(sampleColumns, '?size=large', 'month', 'ASC')).toEqual([
         // flip order if same column clicked
-        expect.objectContaining({ html: expect.stringContaining('?size=large&amp;sort=month&amp;order=desc') }),
+        expect.objectContaining({ html: expect.stringContaining('?size=large&amp;sort=month&amp;order=DESC') }),
         // preserve same order if different column clicked
-        expect.objectContaining({ html: expect.stringContaining('?size=large&amp;sort=rate&amp;order=asc') }),
+        expect.objectContaining({ html: expect.stringContaining('?size=large&amp;sort=rate&amp;order=ASC') }),
       ])
     })
 
     it('when a different column is sorted descending', () => {
-      expect(sortableTableHead<Colum>(sampleColumns, '?size=large', 'rate', 'desc')).toEqual([
+      expect(sortableTableHead<Colum>(sampleColumns, '?size=large', 'rate', 'DESC')).toEqual([
         // preserve same order if different column clicked
-        expect.objectContaining({ html: expect.stringContaining('?size=large&amp;sort=month&amp;order=desc') }),
+        expect.objectContaining({ html: expect.stringContaining('?size=large&amp;sort=month&amp;order=DESC') }),
         // flip order if same column clicked
-        expect.objectContaining({ html: expect.stringContaining('?size=large&amp;sort=rate&amp;order=asc') }),
+        expect.objectContaining({ html: expect.stringContaining('?size=large&amp;sort=rate&amp;order=ASC') }),
       ])
     })
 
     it('when an uknown column is sorted', () => {
-      expect(sortableTableHead<string>(sampleColumns, '?size=large', 'unknown', 'desc')).toEqual([
+      expect(sortableTableHead<string>(sampleColumns, '?size=large', 'unknown', 'DESC')).toEqual([
         // preserve same order if different column clicked
-        expect.objectContaining({ html: expect.stringContaining('?size=large&amp;sort=month&amp;order=desc') }),
+        expect.objectContaining({ html: expect.stringContaining('?size=large&amp;sort=month&amp;order=DESC') }),
         // preserve same order if different column clicked
-        expect.objectContaining({ html: expect.stringContaining('?size=large&amp;sort=rate&amp;order=desc') }),
+        expect.objectContaining({ html: expect.stringContaining('?size=large&amp;sort=rate&amp;order=DESC') }),
       ])
     })
   })
@@ -66,7 +66,7 @@ describe('sortableTableHead', () => {
     ]
 
     it('when another column is sorted', () => {
-      const tableHead = sortableTableHead<string>(sampleColumnsWithUnsortable, '?size=large', 'month', 'asc')
+      const tableHead = sortableTableHead<string>(sampleColumnsWithUnsortable, '?size=large', 'month', 'ASC')
       expect(tableHead).toEqual<HeaderCell[]>([
         { html: '<span class="govuk-visually-hidden">Icon &amp; label</span>' },
         { html: expect.stringContaining('Month you apply'), attributes: { 'aria-sort': 'ascending' } },
@@ -75,7 +75,7 @@ describe('sortableTableHead', () => {
     })
 
     it('when the unsortable column is sorted', () => {
-      const tableHead = sortableTableHead<string>(sampleColumnsWithUnsortable, '?size=large', 'icon', 'desc')
+      const tableHead = sortableTableHead<string>(sampleColumnsWithUnsortable, '?size=large', 'icon', 'DESC')
       expect(tableHead).toEqual<HeaderCell[]>([
         { html: '<span class="govuk-visually-hidden">Icon &amp; label</span>' },
         { html: expect.stringContaining('Month you apply'), attributes: { 'aria-sort': 'none' } },

--- a/server/utils/sortableTable.ts
+++ b/server/utils/sortableTable.ts
@@ -1,8 +1,11 @@
+import { orderOptions } from '../data/incentivesApi'
+
+type AriaSort = 'ascending' | 'descending' | 'none'
 export type HeaderCell =
   | {
       html: string
       attributes: {
-        'aria-sort': 'ascending' | 'descending' | 'none'
+        'aria-sort': AriaSort
       }
     }
   | { html: string }
@@ -15,7 +18,7 @@ export function sortableTableHead<Column = string>(
   columns: { column: Column; escapedHtml: string; unsortable?: true }[],
   urlPrefix: string,
   sortColumn: Column,
-  order: 'ascending' | 'descending',
+  order: typeof orderOptions[number],
 ): HeaderCell[] {
   return columns.map(({ column, escapedHtml, unsortable }) => {
     if (unsortable) {
@@ -25,22 +28,29 @@ export function sortableTableHead<Column = string>(
     let sortQuery: string
     let sortDescription: string
     if (column === sortColumn) {
-      if (order === 'ascending') {
-        sortQuery = `sort=${column}&order=descending`
+      // flips order of the currently sorted column
+      if (order === 'asc') {
+        sortQuery = `sort=${column}&amp;order=desc`
         sortDescription = '<span class="govuk-visually-hidden">(sorted ascending)</span>'
       } else {
-        sortQuery = `sort=${column}&order=ascending`
+        sortQuery = `sort=${column}&amp;order=asc`
         sortDescription = '<span class="govuk-visually-hidden">(sorted descending)</span>'
       }
     } else {
-      sortQuery = `sort=${column}&order=${order}`
+      // preserves order if another column is sorted by
+      sortQuery = `sort=${column}&amp;order=${order}`
       sortDescription = ''
     }
     return {
-      html: `<a href="${urlPrefix}&${sortQuery}">${escapedHtml} ${sortDescription}</a>`,
+      html: `<a href="${urlPrefix}&amp;${sortQuery}">${escapedHtml} ${sortDescription}</a>`,
       attributes: {
-        'aria-sort': column === sortColumn ? order : 'none',
+        'aria-sort': column === sortColumn ? ariaSort[order] : 'none',
       },
     }
   })
+}
+
+const ariaSort: Record<typeof orderOptions[number], AriaSort> = {
+  asc: 'ascending',
+  desc: 'descending',
 }

--- a/server/utils/sortableTable.ts
+++ b/server/utils/sortableTable.ts
@@ -29,11 +29,11 @@ export function sortableTableHead<Column = string>(
     let sortDescription: string
     if (column === sortColumn) {
       // flips order of the currently sorted column
-      if (order === 'asc') {
-        sortQuery = `sort=${column}&amp;order=desc`
+      if (order === 'ASC') {
+        sortQuery = `sort=${column}&amp;order=DESC`
         sortDescription = '<span class="govuk-visually-hidden">(sorted ascending)</span>'
       } else {
-        sortQuery = `sort=${column}&amp;order=asc`
+        sortQuery = `sort=${column}&amp;order=ASC`
         sortDescription = '<span class="govuk-visually-hidden">(sorted descending)</span>'
       }
     } else {
@@ -51,6 +51,6 @@ export function sortableTableHead<Column = string>(
 }
 
 const ariaSort: Record<typeof orderOptions[number], AriaSort> = {
-  asc: 'ascending',
-  desc: 'descending',
+  ASC: 'ascending',
+  DESC: 'descending',
 }

--- a/server/views/pages/reviewsTable.njk
+++ b/server/views/pages/reviewsTable.njk
@@ -76,7 +76,7 @@
       {html: nextReviewDate},
       {html: positiveBehaviours},
       {html: negativeBehaviours},
-      {text: "ACCT open" if review.acctStatus else ""}
+      {text: "ACCT open" if review.hasAcctOpen else ""}
     ]), tableRows) %}
   {% endfor %}
 


### PR DESCRIPTION
NB: sort & order options have been renamed to use upper snake case because incentives-api follows Java & Spring Data convention

Depends on [api#270](https://github.com/ministryofjustice/hmpps-incentives-api/pull/270)