### PR TITLE
INC-931: Use 0-based page numbering for incentives reviews api

### DIFF
--- a/server/data/incentivesApi.ts
+++ b/server/data/incentivesApi.ts
@@ -51,7 +51,6 @@ export const sortOptions = [
 ] as const
 export const orderOptions = ['ASC', 'DESC'] as const
 
-// NB: Reviews request field names are TBC
 export type IncentivesReviewsPaginationAndSorting = {
   sort?: typeof sortOptions[number]
   order?: typeof orderOptions[number]
@@ -59,14 +58,12 @@ export type IncentivesReviewsPaginationAndSorting = {
   pageSize?: number
 }
 
-// NB: Reviews request field names are TBC
 export type IncentivesReviewsRequest = {
   agencyId: string
   locationPrefix: string
   levelCode: string
 } & IncentivesReviewsPaginationAndSorting
 
-// NB: Reviews response field names are TBC
 export interface IncentivesReviewsResponse {
   locationDescription: string
   overdueCount: number
@@ -74,7 +71,6 @@ export interface IncentivesReviewsResponse {
   reviews: IncentivesReview[]
 }
 
-// NB: Reviews response field names are TBC
 export interface IncentivesReview {
   firstName: string
   lastName: string

--- a/server/routes/reviewsTable.test.ts
+++ b/server/routes/reviewsTable.test.ts
@@ -109,7 +109,7 @@ describe('Reviews table', () => {
       name: 'with page param',
       urlSuffix: '?page=6',
       expectedRequest: {
-        page: 6,
+        page: 5,
       },
     },
     {
@@ -170,7 +170,7 @@ describe('Reviews table', () => {
       urlSuffix: '?level=ENH&page=2',
       expectedRequest: {
         levelCode: 'ENH',
-        page: 2,
+        page: 1,
       },
     },
     {
@@ -178,7 +178,7 @@ describe('Reviews table', () => {
       urlSuffix: '?page=3&level=ENH&sort=HAS_ACCT_OPEN',
       expectedRequest: {
         levelCode: 'ENH',
-        page: 3,
+        page: 2,
         sort: 'HAS_ACCT_OPEN',
         order: 'DESC',
       },
@@ -188,7 +188,7 @@ describe('Reviews table', () => {
       urlSuffix: '?level=BAS&sort=NEGATIVE_BEHAVIOURS&order=ASC&page=4',
       expectedRequest: {
         levelCode: 'BAS',
-        page: 4,
+        page: 3,
         sort: 'NEGATIVE_BEHAVIOURS',
         order: 'ASC',
       },
@@ -203,7 +203,7 @@ describe('Reviews table', () => {
         levelCode: 'STD',
         sort: 'NEXT_REVIEW_DATE',
         order: 'ASC',
-        page: 1,
+        page: 0,
         pageSize: 20,
       }
 

--- a/server/routes/reviewsTable.ts
+++ b/server/routes/reviewsTable.ts
@@ -62,7 +62,7 @@ export default function routes(router: Router): Router {
       levelCode: selectedLevelCode,
       sort,
       order,
-      page,
+      page: page - 1,
       pageSize: PAGE_SIZE,
     })
 


### PR DESCRIPTION
In the user interface, pages are still numbered starting from 1 as users would expect. However, incentives-api now starts counting pages from 0.

Depends on [api#277](https://github.com/ministryofjustice/hmpps-incentives-api/pull/277)