### PR TITLE
INC-971: GA tracking for new Reviews table

### DIFF
--- a/assets/js/gaSendEvents.js
+++ b/assets/js/gaSendEvents.js
@@ -1,0 +1,31 @@
+function gaSendEvent(event) {
+  const elem = $(this)
+
+  const gaCategory = elem.data('ga-category')
+  let gaAction = elem.data('ga-action')
+  const gaLabel = $('#ga-label').data('ga-label')
+
+  // for sorting events, add sort order to GA action
+  const previousSortOrder = elem.attr('aria-sort')
+  if (previousSortOrder) {
+    if (previousSortOrder === 'ascending') {
+      gaAction += ' (descending)'
+    } else {
+      gaAction += ' (ascending)'
+    }
+  }
+
+  if (typeof ga === typeof Function) ga('send', 'event', gaCategory, gaAction, gaLabel)
+
+  if (typeof gtag === typeof Function) {
+    gtag('event', 'incentives_event', {
+      category: gaCategory,
+      action: gaAction,
+      label: gaLabel,
+    })
+  }
+}
+
+$('.govuk-tabs__tab[data-ga-category]').on('focus', gaSendEvent)
+$('.govuk-table a[data-ga-category]').on('click', gaSendEvent)
+$('.govuk-table .govuk-table__header[data-ga-category]').on('click', gaSendEvent)

--- a/assets/js/gaSendEvents.js
+++ b/assets/js/gaSendEvents.js
@@ -1,4 +1,4 @@
-function gaSendEvent(event) {
+function gaSendEvent() {
   const elem = $(this)
 
   const gaCategory = elem.data('ga-category')

--- a/server/routes/reviewsTable.ts
+++ b/server/routes/reviewsTable.ts
@@ -76,6 +76,7 @@ export default function routes(router: Router): Router {
     res.render('pages/reviewsTable', {
       dpsUrl: config.dpsUrl,
       feedbackUrl: config.feedbackUrlForReviewsTable || config.feedbackUrlForTable || config.feedbackUrl,
+      locationPrefix,
       locationDescription: response.locationDescription,
       overdueCount: response.overdueCount,
       levels,

--- a/server/routes/reviewsTable.ts
+++ b/server/routes/reviewsTable.ts
@@ -19,7 +19,7 @@ const hmppsAuthClient = new HmppsAuthClient(new TokenStore(createRedisClient('ro
 
 const PAGE_SIZE = 20
 
-const tableColumns: Parameters<typeof sortableTableHead<string>>[0] = [
+const tableColumns: Parameters<typeof sortableTableHead<string>>[1] = [
   { column: 'photo', escapedHtml: '<span class="govuk-visually-hidden">Prisoner photo</span>', unsortable: true },
   { column: 'LAST_NAME', escapedHtml: 'Name and prison number' },
   { column: 'NEXT_REVIEW_DATE', escapedHtml: 'Date of next review' },
@@ -67,7 +67,7 @@ export default function routes(router: Router): Router {
       pageSize: PAGE_SIZE,
     })
 
-    const tableHead = sortableTableHead(tableColumns, `?level=${selectedLevelCode}`, sort, order)
+    const tableHead = sortableTableHead('Reviews table', tableColumns, `?level=${selectedLevelCode}`, sort, order)
 
     const pageCount = Math.ceil(response.reviewCount / PAGE_SIZE)
     const paginationUrlPrefix = `?level=${selectedLevelCode}&sort=${sort}&order=${order}&`

--- a/server/routes/reviewsTable.ts
+++ b/server/routes/reviewsTable.ts
@@ -3,7 +3,7 @@ import { NotFound } from 'http-errors'
 
 import config from '../config'
 import { pagination } from '../utils/pagination'
-import { sortableTableHead } from '../utils/sortableTable'
+import { type SortableTableColumns, sortableTableHead } from '../utils/sortableTable'
 import asyncMiddleware from '../middleware/asyncMiddleware'
 import HmppsAuthClient from '../data/hmppsAuthClient'
 import { createRedisClient } from '../data/redisClient'
@@ -19,7 +19,7 @@ const hmppsAuthClient = new HmppsAuthClient(new TokenStore(createRedisClient('ro
 
 const PAGE_SIZE = 20
 
-const tableColumns: Parameters<typeof sortableTableHead<string>>[1] = [
+const tableColumns: SortableTableColumns<string> = [
   { column: 'photo', escapedHtml: '<span class="govuk-visually-hidden">Prisoner photo</span>', unsortable: true },
   { column: 'LAST_NAME', escapedHtml: 'Name and prison number' },
   { column: 'NEXT_REVIEW_DATE', escapedHtml: 'Date of next review' },
@@ -67,7 +67,13 @@ export default function routes(router: Router): Router {
       pageSize: PAGE_SIZE,
     })
 
-    const tableHead = sortableTableHead('Reviews table', tableColumns, `?level=${selectedLevelCode}`, sort, order)
+    const tableHead = sortableTableHead({
+      gaPrefix: 'Reviews table',
+      columns: tableColumns,
+      urlPrefix: `?level=${selectedLevelCode}`,
+      sortColumn: sort,
+      order,
+    })
 
     const pageCount = Math.ceil(response.reviewCount / PAGE_SIZE)
     const paginationUrlPrefix = `?level=${selectedLevelCode}&sort=${sort}&order=${order}&`

--- a/server/utils/sortableTable.test.ts
+++ b/server/utils/sortableTable.test.ts
@@ -11,12 +11,74 @@ describe('sortableTableHead', () => {
     it('when a column is sorted ascending', () => {
       expect(
         sortableTableHead<Column>({
-          gaPrefix: 'Reviews table',
           columns: sampleColumns,
           urlPrefix: '?size=large',
           sortColumn: 'month',
           order: 'ASC',
-        })
+        }),
+      ).toEqual<HeaderCell[]>([
+        {
+          html: expect.stringContaining('Month you apply'),
+          attributes: { 'aria-sort': 'ascending' },
+        },
+        {
+          html: expect.stringContaining('Rate for vehicles'),
+          attributes: { 'aria-sort': 'none' },
+        },
+      ])
+    })
+
+    it('when a different column is sorted descending', () => {
+      expect(
+        sortableTableHead<Column>({
+          columns: sampleColumns,
+          urlPrefix: '?size=large',
+          sortColumn: 'rate',
+          order: 'DESC',
+        }),
+      ).toEqual<HeaderCell[]>([
+        {
+          html: expect.stringContaining('Month you apply'),
+          attributes: { 'aria-sort': 'none' },
+        },
+        {
+          html: expect.stringContaining('Rate for vehicles'),
+          attributes: { 'aria-sort': 'descending' },
+        },
+      ])
+    })
+
+    it('when an uknown column is sorted', () => {
+      expect(
+        sortableTableHead<string>({
+          columns: sampleColumns,
+          urlPrefix: '?size=large',
+          sortColumn: 'unknown',
+          order: 'DESC',
+        }),
+      ).toEqual<HeaderCell[]>([
+        {
+          html: expect.stringContaining('Month you apply'),
+          attributes: { 'aria-sort': 'none' },
+        },
+        {
+          html: expect.stringContaining('Rate for vehicles'),
+          attributes: { 'aria-sort': 'none' },
+        },
+      ])
+    })
+  })
+
+  describe('should include GA event tracking attributes', () => {
+    it('when a column is sorted ascending', () => {
+      expect(
+        sortableTableHead<Column>({
+          columns: sampleColumns,
+          urlPrefix: '?size=large',
+          sortColumn: 'month',
+          order: 'ASC',
+          gaPrefix: 'Reviews table',
+        }),
       ).toEqual<HeaderCell[]>([
         {
           html: expect.stringContaining('Month you apply'),
@@ -40,12 +102,12 @@ describe('sortableTableHead', () => {
     it('when a different column is sorted descending', () => {
       expect(
         sortableTableHead<Column>({
-          gaPrefix: 'Reviews table',
           columns: sampleColumns,
           urlPrefix: '?size=large',
           sortColumn: 'rate',
           order: 'DESC',
-        })
+          gaPrefix: 'Reviews table',
+        }),
       ).toEqual<HeaderCell[]>([
         {
           html: expect.stringContaining('Month you apply'),
@@ -65,47 +127,17 @@ describe('sortableTableHead', () => {
         },
       ])
     })
-
-    it('when an uknown column is sorted', () => {
-      expect(
-        sortableTableHead<string>({
-          gaPrefix: 'Reviews table',
-          columns: sampleColumns,
-          urlPrefix: '?size=large',
-          sortColumn: 'unknown',
-          order: 'DESC',
-        })
-      ).toEqual<HeaderCell[]>([
-        {
-          html: expect.stringContaining('Month you apply'),
-          attributes: {
-            'aria-sort': 'none',
-            'data-ga-category': 'Reviews table > Sorted table',
-            'data-ga-action': 'by month',
-          },
-        },
-        {
-          html: expect.stringContaining('Rate for vehicles'),
-          attributes: {
-            'aria-sort': 'none',
-            'data-ga-category': 'Reviews table > Sorted table',
-            'data-ga-action': 'by rate',
-          },
-        },
-      ])
-    })
   })
 
   describe('should link column to sort action', () => {
     it('when a column is sorted ascending', () => {
       expect(
         sortableTableHead<Column>({
-          gaPrefix: 'Reviews table',
           columns: sampleColumns,
           urlPrefix: '?size=large',
           sortColumn: 'month',
           order: 'ASC',
-        })
+        }),
       ).toEqual([
         // flip order if same column clicked
         expect.objectContaining({ html: expect.stringContaining('?size=large&amp;sort=month&amp;order=DESC') }),
@@ -117,12 +149,11 @@ describe('sortableTableHead', () => {
     it('when a different column is sorted descending', () => {
       expect(
         sortableTableHead<Column>({
-          gaPrefix: 'Reviews table',
           columns: sampleColumns,
           urlPrefix: '?size=large',
           sortColumn: 'rate',
           order: 'DESC',
-        })
+        }),
       ).toEqual([
         // preserve same order if different column clicked
         expect.objectContaining({ html: expect.stringContaining('?size=large&amp;sort=month&amp;order=DESC') }),
@@ -134,12 +165,11 @@ describe('sortableTableHead', () => {
     it('when an uknown column is sorted', () => {
       expect(
         sortableTableHead<string>({
-          gaPrefix: 'Reviews table',
           columns: sampleColumns,
           urlPrefix: '?size=large',
           sortColumn: 'unknown',
           order: 'DESC',
-        })
+        }),
       ).toEqual([
         // preserve same order if different column clicked
         expect.objectContaining({ html: expect.stringContaining('?size=large&amp;sort=month&amp;order=DESC') }),
@@ -157,7 +187,6 @@ describe('sortableTableHead', () => {
 
     it('when another column is sorted', () => {
       const tableHead = sortableTableHead<string>({
-        gaPrefix: 'Reviews table',
         columns: sampleColumnsWithUnsortable,
         urlPrefix: '?size=large',
         sortColumn: 'month',
@@ -167,26 +196,17 @@ describe('sortableTableHead', () => {
         { html: '<span class="govuk-visually-hidden">Icon &amp; label</span>' },
         {
           html: expect.stringContaining('Month you apply'),
-          attributes: {
-            'aria-sort': 'ascending',
-            'data-ga-category': 'Reviews table > Sorted table',
-            'data-ga-action': 'by month',
-          },
+          attributes: { 'aria-sort': 'ascending' },
         },
         {
           html: expect.stringContaining('Rate for vehicles'),
-          attributes: {
-            'aria-sort': 'none',
-            'data-ga-category': 'Reviews table > Sorted table',
-            'data-ga-action': 'by rate',
-          },
+          attributes: { 'aria-sort': 'none' },
         },
       ])
     })
 
     it('when the unsortable column is sorted', () => {
       const tableHead = sortableTableHead<string>({
-        gaPrefix: 'Reviews table',
         columns: sampleColumnsWithUnsortable,
         urlPrefix: '?size=large',
         sortColumn: 'icon',
@@ -196,19 +216,11 @@ describe('sortableTableHead', () => {
         { html: '<span class="govuk-visually-hidden">Icon &amp; label</span>' },
         {
           html: expect.stringContaining('Month you apply'),
-          attributes: {
-            'aria-sort': 'none',
-            'data-ga-category': 'Reviews table > Sorted table',
-            'data-ga-action': 'by month',
-          },
+          attributes: { 'aria-sort': 'none' },
         },
         {
           html: expect.stringContaining('Rate for vehicles'),
-          attributes: {
-            'aria-sort': 'none',
-            'data-ga-category': 'Reviews table > Sorted table',
-            'data-ga-action': 'by rate',
-          },
+          attributes: { 'aria-sort': 'none' },
         },
       ])
     })

--- a/server/utils/sortableTable.test.ts
+++ b/server/utils/sortableTable.test.ts
@@ -1,7 +1,7 @@
 import { type HeaderCell, sortableTableHead } from './sortableTable'
 
-type Colum = 'month' | 'rate'
-const sampleColumns: Parameters<typeof sortableTableHead<Colum>>[0] = [
+type Column = 'month' | 'rate'
+const sampleColumns: Parameters<typeof sortableTableHead<Column>>[0] = [
   { column: 'month', escapedHtml: 'Month you apply' },
   { column: 'rate', escapedHtml: 'Rate for vehicles' },
 ]
@@ -9,14 +9,14 @@ const sampleColumns: Parameters<typeof sortableTableHead<Colum>>[0] = [
 describe('sortableTableHead', () => {
   describe('should label sorted column with aria attribute', () => {
     it('when a column is sorted ascending', () => {
-      expect(sortableTableHead<Colum>(sampleColumns, '?size=large', 'month', 'ASC')).toEqual<HeaderCell[]>([
+      expect(sortableTableHead<Column>(sampleColumns, '?size=large', 'month', 'ASC')).toEqual<HeaderCell[]>([
         { html: expect.stringContaining('Month you apply'), attributes: { 'aria-sort': 'ascending' } },
         { html: expect.stringContaining('Rate for vehicles'), attributes: { 'aria-sort': 'none' } },
       ])
     })
 
     it('when a different column is sorted descending', () => {
-      expect(sortableTableHead<Colum>(sampleColumns, '?size=large', 'rate', 'DESC')).toEqual<HeaderCell[]>([
+      expect(sortableTableHead<Column>(sampleColumns, '?size=large', 'rate', 'DESC')).toEqual<HeaderCell[]>([
         { html: expect.stringContaining('Month you apply'), attributes: { 'aria-sort': 'none' } },
         { html: expect.stringContaining('Rate for vehicles'), attributes: { 'aria-sort': 'descending' } },
       ])
@@ -32,7 +32,7 @@ describe('sortableTableHead', () => {
 
   describe('should link column to sort action', () => {
     it('when a column is sorted ascending', () => {
-      expect(sortableTableHead<Colum>(sampleColumns, '?size=large', 'month', 'ASC')).toEqual([
+      expect(sortableTableHead<Column>(sampleColumns, '?size=large', 'month', 'ASC')).toEqual([
         // flip order if same column clicked
         expect.objectContaining({ html: expect.stringContaining('?size=large&amp;sort=month&amp;order=DESC') }),
         // preserve same order if different column clicked
@@ -41,7 +41,7 @@ describe('sortableTableHead', () => {
     })
 
     it('when a different column is sorted descending', () => {
-      expect(sortableTableHead<Colum>(sampleColumns, '?size=large', 'rate', 'DESC')).toEqual([
+      expect(sortableTableHead<Column>(sampleColumns, '?size=large', 'rate', 'DESC')).toEqual([
         // preserve same order if different column clicked
         expect.objectContaining({ html: expect.stringContaining('?size=large&amp;sort=month&amp;order=DESC') }),
         // flip order if same column clicked

--- a/server/utils/sortableTable.test.ts
+++ b/server/utils/sortableTable.test.ts
@@ -1,7 +1,7 @@
 import { type HeaderCell, sortableTableHead } from './sortableTable'
 
 type Column = 'month' | 'rate'
-const sampleColumns: Parameters<typeof sortableTableHead<Column>>[0] = [
+const sampleColumns: Parameters<typeof sortableTableHead<Column>>[1] = [
   { column: 'month', escapedHtml: 'Month you apply' },
   { column: 'rate', escapedHtml: 'Rate for vehicles' },
 ]
@@ -9,30 +9,78 @@ const sampleColumns: Parameters<typeof sortableTableHead<Column>>[0] = [
 describe('sortableTableHead', () => {
   describe('should label sorted column with aria attribute', () => {
     it('when a column is sorted ascending', () => {
-      expect(sortableTableHead<Column>(sampleColumns, '?size=large', 'month', 'ASC')).toEqual<HeaderCell[]>([
-        { html: expect.stringContaining('Month you apply'), attributes: { 'aria-sort': 'ascending' } },
-        { html: expect.stringContaining('Rate for vehicles'), attributes: { 'aria-sort': 'none' } },
+      expect(sortableTableHead<Column>('Reviews table', sampleColumns, '?size=large', 'month', 'ASC')).toEqual<
+        HeaderCell[]
+      >([
+        {
+          html: expect.stringContaining('Month you apply'),
+          attributes: {
+            'aria-sort': 'ascending',
+            'data-ga-category': 'Reviews table > Sorted table',
+            'data-ga-action': 'by month',
+          },
+        },
+        {
+          html: expect.stringContaining('Rate for vehicles'),
+          attributes: {
+            'aria-sort': 'none',
+            'data-ga-category': 'Reviews table > Sorted table',
+            'data-ga-action': 'by rate',
+          },
+        },
       ])
     })
 
     it('when a different column is sorted descending', () => {
-      expect(sortableTableHead<Column>(sampleColumns, '?size=large', 'rate', 'DESC')).toEqual<HeaderCell[]>([
-        { html: expect.stringContaining('Month you apply'), attributes: { 'aria-sort': 'none' } },
-        { html: expect.stringContaining('Rate for vehicles'), attributes: { 'aria-sort': 'descending' } },
+      expect(sortableTableHead<Column>('Reviews table', sampleColumns, '?size=large', 'rate', 'DESC')).toEqual<
+        HeaderCell[]
+      >([
+        {
+          html: expect.stringContaining('Month you apply'),
+          attributes: {
+            'aria-sort': 'none',
+            'data-ga-category': 'Reviews table > Sorted table',
+            'data-ga-action': 'by month',
+          },
+        },
+        {
+          html: expect.stringContaining('Rate for vehicles'),
+          attributes: {
+            'aria-sort': 'descending',
+            'data-ga-category': 'Reviews table > Sorted table',
+            'data-ga-action': 'by rate',
+          },
+        },
       ])
     })
 
     it('when an uknown column is sorted', () => {
-      expect(sortableTableHead<string>(sampleColumns, '?size=large', 'unknown', 'DESC')).toEqual<HeaderCell[]>([
-        { html: expect.stringContaining('Month you apply'), attributes: { 'aria-sort': 'none' } },
-        { html: expect.stringContaining('Rate for vehicles'), attributes: { 'aria-sort': 'none' } },
+      expect(sortableTableHead<string>('Reviews table', sampleColumns, '?size=large', 'unknown', 'DESC')).toEqual<
+        HeaderCell[]
+      >([
+        {
+          html: expect.stringContaining('Month you apply'),
+          attributes: {
+            'aria-sort': 'none',
+            'data-ga-category': 'Reviews table > Sorted table',
+            'data-ga-action': 'by month',
+          },
+        },
+        {
+          html: expect.stringContaining('Rate for vehicles'),
+          attributes: {
+            'aria-sort': 'none',
+            'data-ga-category': 'Reviews table > Sorted table',
+            'data-ga-action': 'by rate',
+          },
+        },
       ])
     })
   })
 
   describe('should link column to sort action', () => {
     it('when a column is sorted ascending', () => {
-      expect(sortableTableHead<Column>(sampleColumns, '?size=large', 'month', 'ASC')).toEqual([
+      expect(sortableTableHead<Column>('Reviews table', sampleColumns, '?size=large', 'month', 'ASC')).toEqual([
         // flip order if same column clicked
         expect.objectContaining({ html: expect.stringContaining('?size=large&amp;sort=month&amp;order=DESC') }),
         // preserve same order if different column clicked
@@ -41,7 +89,7 @@ describe('sortableTableHead', () => {
     })
 
     it('when a different column is sorted descending', () => {
-      expect(sortableTableHead<Column>(sampleColumns, '?size=large', 'rate', 'DESC')).toEqual([
+      expect(sortableTableHead<Column>('Reviews table', sampleColumns, '?size=large', 'rate', 'DESC')).toEqual([
         // preserve same order if different column clicked
         expect.objectContaining({ html: expect.stringContaining('?size=large&amp;sort=month&amp;order=DESC') }),
         // flip order if same column clicked
@@ -50,7 +98,7 @@ describe('sortableTableHead', () => {
     })
 
     it('when an uknown column is sorted', () => {
-      expect(sortableTableHead<string>(sampleColumns, '?size=large', 'unknown', 'DESC')).toEqual([
+      expect(sortableTableHead<string>('Reviews table', sampleColumns, '?size=large', 'unknown', 'DESC')).toEqual([
         // preserve same order if different column clicked
         expect.objectContaining({ html: expect.stringContaining('?size=large&amp;sort=month&amp;order=DESC') }),
         // preserve same order if different column clicked
@@ -60,26 +108,66 @@ describe('sortableTableHead', () => {
   })
 
   describe('should work with unsortable columns', () => {
-    const sampleColumnsWithUnsortable: Parameters<typeof sortableTableHead<string>>[0] = [
+    const sampleColumnsWithUnsortable: Parameters<typeof sortableTableHead<string>>[1] = [
       { column: 'icon', escapedHtml: '<span class="govuk-visually-hidden">Icon &amp; label</span>', unsortable: true },
       ...sampleColumns,
     ]
 
     it('when another column is sorted', () => {
-      const tableHead = sortableTableHead<string>(sampleColumnsWithUnsortable, '?size=large', 'month', 'ASC')
+      const tableHead = sortableTableHead<string>(
+        'Reviews table',
+        sampleColumnsWithUnsortable,
+        '?size=large',
+        'month',
+        'ASC',
+      )
       expect(tableHead).toEqual<HeaderCell[]>([
         { html: '<span class="govuk-visually-hidden">Icon &amp; label</span>' },
-        { html: expect.stringContaining('Month you apply'), attributes: { 'aria-sort': 'ascending' } },
-        { html: expect.stringContaining('Rate for vehicles'), attributes: { 'aria-sort': 'none' } },
+        {
+          html: expect.stringContaining('Month you apply'),
+          attributes: {
+            'aria-sort': 'ascending',
+            'data-ga-category': 'Reviews table > Sorted table',
+            'data-ga-action': 'by month',
+          },
+        },
+        {
+          html: expect.stringContaining('Rate for vehicles'),
+          attributes: {
+            'aria-sort': 'none',
+            'data-ga-category': 'Reviews table > Sorted table',
+            'data-ga-action': 'by rate',
+          },
+        },
       ])
     })
 
     it('when the unsortable column is sorted', () => {
-      const tableHead = sortableTableHead<string>(sampleColumnsWithUnsortable, '?size=large', 'icon', 'DESC')
+      const tableHead = sortableTableHead<string>(
+        'Reviews table',
+        sampleColumnsWithUnsortable,
+        '?size=large',
+        'icon',
+        'DESC',
+      )
       expect(tableHead).toEqual<HeaderCell[]>([
         { html: '<span class="govuk-visually-hidden">Icon &amp; label</span>' },
-        { html: expect.stringContaining('Month you apply'), attributes: { 'aria-sort': 'none' } },
-        { html: expect.stringContaining('Rate for vehicles'), attributes: { 'aria-sort': 'none' } },
+        {
+          html: expect.stringContaining('Month you apply'),
+          attributes: {
+            'aria-sort': 'none',
+            'data-ga-category': 'Reviews table > Sorted table',
+            'data-ga-action': 'by month',
+          },
+        },
+        {
+          html: expect.stringContaining('Rate for vehicles'),
+          attributes: {
+            'aria-sort': 'none',
+            'data-ga-category': 'Reviews table > Sorted table',
+            'data-ga-action': 'by rate',
+          },
+        },
       ])
     })
   })

--- a/server/utils/sortableTable.test.ts
+++ b/server/utils/sortableTable.test.ts
@@ -1,7 +1,7 @@
-import { type HeaderCell, sortableTableHead } from './sortableTable'
+import { type HeaderCell, type SortableTableColumns, sortableTableHead } from './sortableTable'
 
 type Column = 'month' | 'rate'
-const sampleColumns: Parameters<typeof sortableTableHead<Column>>[1] = [
+const sampleColumns: SortableTableColumns<Column> = [
   { column: 'month', escapedHtml: 'Month you apply' },
   { column: 'rate', escapedHtml: 'Rate for vehicles' },
 ]
@@ -9,9 +9,15 @@ const sampleColumns: Parameters<typeof sortableTableHead<Column>>[1] = [
 describe('sortableTableHead', () => {
   describe('should label sorted column with aria attribute', () => {
     it('when a column is sorted ascending', () => {
-      expect(sortableTableHead<Column>('Reviews table', sampleColumns, '?size=large', 'month', 'ASC')).toEqual<
-        HeaderCell[]
-      >([
+      expect(
+        sortableTableHead<Column>({
+          gaPrefix: 'Reviews table',
+          columns: sampleColumns,
+          urlPrefix: '?size=large',
+          sortColumn: 'month',
+          order: 'ASC',
+        })
+      ).toEqual<HeaderCell[]>([
         {
           html: expect.stringContaining('Month you apply'),
           attributes: {
@@ -32,9 +38,15 @@ describe('sortableTableHead', () => {
     })
 
     it('when a different column is sorted descending', () => {
-      expect(sortableTableHead<Column>('Reviews table', sampleColumns, '?size=large', 'rate', 'DESC')).toEqual<
-        HeaderCell[]
-      >([
+      expect(
+        sortableTableHead<Column>({
+          gaPrefix: 'Reviews table',
+          columns: sampleColumns,
+          urlPrefix: '?size=large',
+          sortColumn: 'rate',
+          order: 'DESC',
+        })
+      ).toEqual<HeaderCell[]>([
         {
           html: expect.stringContaining('Month you apply'),
           attributes: {
@@ -55,9 +67,15 @@ describe('sortableTableHead', () => {
     })
 
     it('when an uknown column is sorted', () => {
-      expect(sortableTableHead<string>('Reviews table', sampleColumns, '?size=large', 'unknown', 'DESC')).toEqual<
-        HeaderCell[]
-      >([
+      expect(
+        sortableTableHead<string>({
+          gaPrefix: 'Reviews table',
+          columns: sampleColumns,
+          urlPrefix: '?size=large',
+          sortColumn: 'unknown',
+          order: 'DESC',
+        })
+      ).toEqual<HeaderCell[]>([
         {
           html: expect.stringContaining('Month you apply'),
           attributes: {
@@ -80,7 +98,15 @@ describe('sortableTableHead', () => {
 
   describe('should link column to sort action', () => {
     it('when a column is sorted ascending', () => {
-      expect(sortableTableHead<Column>('Reviews table', sampleColumns, '?size=large', 'month', 'ASC')).toEqual([
+      expect(
+        sortableTableHead<Column>({
+          gaPrefix: 'Reviews table',
+          columns: sampleColumns,
+          urlPrefix: '?size=large',
+          sortColumn: 'month',
+          order: 'ASC',
+        })
+      ).toEqual([
         // flip order if same column clicked
         expect.objectContaining({ html: expect.stringContaining('?size=large&amp;sort=month&amp;order=DESC') }),
         // preserve same order if different column clicked
@@ -89,7 +115,15 @@ describe('sortableTableHead', () => {
     })
 
     it('when a different column is sorted descending', () => {
-      expect(sortableTableHead<Column>('Reviews table', sampleColumns, '?size=large', 'rate', 'DESC')).toEqual([
+      expect(
+        sortableTableHead<Column>({
+          gaPrefix: 'Reviews table',
+          columns: sampleColumns,
+          urlPrefix: '?size=large',
+          sortColumn: 'rate',
+          order: 'DESC',
+        })
+      ).toEqual([
         // preserve same order if different column clicked
         expect.objectContaining({ html: expect.stringContaining('?size=large&amp;sort=month&amp;order=DESC') }),
         // flip order if same column clicked
@@ -98,7 +132,15 @@ describe('sortableTableHead', () => {
     })
 
     it('when an uknown column is sorted', () => {
-      expect(sortableTableHead<string>('Reviews table', sampleColumns, '?size=large', 'unknown', 'DESC')).toEqual([
+      expect(
+        sortableTableHead<string>({
+          gaPrefix: 'Reviews table',
+          columns: sampleColumns,
+          urlPrefix: '?size=large',
+          sortColumn: 'unknown',
+          order: 'DESC',
+        })
+      ).toEqual([
         // preserve same order if different column clicked
         expect.objectContaining({ html: expect.stringContaining('?size=large&amp;sort=month&amp;order=DESC') }),
         // preserve same order if different column clicked
@@ -108,19 +150,19 @@ describe('sortableTableHead', () => {
   })
 
   describe('should work with unsortable columns', () => {
-    const sampleColumnsWithUnsortable: Parameters<typeof sortableTableHead<string>>[1] = [
+    const sampleColumnsWithUnsortable: SortableTableColumns<string> = [
       { column: 'icon', escapedHtml: '<span class="govuk-visually-hidden">Icon &amp; label</span>', unsortable: true },
       ...sampleColumns,
     ]
 
     it('when another column is sorted', () => {
-      const tableHead = sortableTableHead<string>(
-        'Reviews table',
-        sampleColumnsWithUnsortable,
-        '?size=large',
-        'month',
-        'ASC',
-      )
+      const tableHead = sortableTableHead<string>({
+        gaPrefix: 'Reviews table',
+        columns: sampleColumnsWithUnsortable,
+        urlPrefix: '?size=large',
+        sortColumn: 'month',
+        order: 'ASC',
+      })
       expect(tableHead).toEqual<HeaderCell[]>([
         { html: '<span class="govuk-visually-hidden">Icon &amp; label</span>' },
         {
@@ -143,13 +185,13 @@ describe('sortableTableHead', () => {
     })
 
     it('when the unsortable column is sorted', () => {
-      const tableHead = sortableTableHead<string>(
-        'Reviews table',
-        sampleColumnsWithUnsortable,
-        '?size=large',
-        'icon',
-        'DESC',
-      )
+      const tableHead = sortableTableHead<string>({
+        gaPrefix: 'Reviews table',
+        columns: sampleColumnsWithUnsortable,
+        urlPrefix: '?size=large',
+        sortColumn: 'icon',
+        order: 'DESC',
+      })
       expect(tableHead).toEqual<HeaderCell[]>([
         { html: '<span class="govuk-visually-hidden">Icon &amp; label</span>' },
         {

--- a/server/utils/sortableTable.ts
+++ b/server/utils/sortableTable.ts
@@ -16,13 +16,19 @@ export type HeaderCell =
  * Produces parameters for head of GOV.UK Table component macro
  * to label sortable columns and add links
  */
-export function sortableTableHead<Column = string>(
-  gaPrefix: string,
-  columns: { column: Column; escapedHtml: string; unsortable?: true }[],
-  urlPrefix: string,
-  sortColumn: Column,
-  order: typeof orderOptions[number],
-): HeaderCell[] {
+export function sortableTableHead<Column = string>({
+  gaPrefix,
+  columns,
+  urlPrefix,
+  sortColumn,
+  order,
+}: {
+  gaPrefix: string
+  columns: { column: Column; escapedHtml: string; unsortable?: true }[]
+  urlPrefix: string
+  sortColumn: Column
+  order: typeof orderOptions[number]
+}): HeaderCell[] {
   return columns.map(({ column, escapedHtml, unsortable }) => {
     if (unsortable) {
       return { html: escapedHtml }
@@ -54,6 +60,8 @@ export function sortableTableHead<Column = string>(
     }
   })
 }
+
+export type SortableTableColumns<T> = Parameters<typeof sortableTableHead<T>>[0]['columns']
 
 const ariaSort: Record<typeof orderOptions[number], AriaSort> = {
   ASC: 'ascending',

--- a/server/utils/sortableTable.ts
+++ b/server/utils/sortableTable.ts
@@ -6,6 +6,8 @@ export type HeaderCell =
       html: string
       attributes: {
         'aria-sort': AriaSort
+        'data-ga-category': string
+        'data-ga-action': string
       }
     }
   | { html: string }
@@ -15,6 +17,7 @@ export type HeaderCell =
  * to label sortable columns and add links
  */
 export function sortableTableHead<Column = string>(
+  gaPrefix: string,
   columns: { column: Column; escapedHtml: string; unsortable?: true }[],
   urlPrefix: string,
   sortColumn: Column,
@@ -45,6 +48,8 @@ export function sortableTableHead<Column = string>(
       html: `<a href="${urlPrefix}&amp;${sortQuery}">${escapedHtml} ${sortDescription}</a>`,
       attributes: {
         'aria-sort': column === sortColumn ? ariaSort[order] : 'none',
+        'data-ga-category': `${gaPrefix} > Sorted table`,
+        'data-ga-action': `by ${column}`,
       },
     }
   })

--- a/server/utils/sortableTable.ts
+++ b/server/utils/sortableTable.ts
@@ -6,8 +6,8 @@ export type HeaderCell =
       html: string
       attributes: {
         'aria-sort': AriaSort
-        'data-ga-category': string
-        'data-ga-action': string
+        'data-ga-category'?: string
+        'data-ga-action'?: string
       }
     }
   | { html: string }
@@ -17,17 +17,17 @@ export type HeaderCell =
  * to label sortable columns and add links
  */
 export function sortableTableHead<Column = string>({
-  gaPrefix,
   columns,
   urlPrefix,
   sortColumn,
   order,
+  gaPrefix,
 }: {
-  gaPrefix: string
   columns: { column: Column; escapedHtml: string; unsortable?: true }[]
   urlPrefix: string
   sortColumn: Column
   order: typeof orderOptions[number]
+  gaPrefix?: string
 }): HeaderCell[] {
   return columns.map(({ column, escapedHtml, unsortable }) => {
     if (unsortable) {
@@ -54,8 +54,12 @@ export function sortableTableHead<Column = string>({
       html: `<a href="${urlPrefix}&amp;${sortQuery}">${escapedHtml} ${sortDescription}</a>`,
       attributes: {
         'aria-sort': column === sortColumn ? ariaSort[order] : 'none',
-        'data-ga-category': `${gaPrefix} > Sorted table`,
-        'data-ga-action': `by ${column}`,
+        ...(gaPrefix
+          ? {
+              'data-ga-category': `${gaPrefix} > Sorted table`,
+              'data-ga-action': `by ${column}`,
+            }
+          : {}),
       },
     }
   })

--- a/server/views/pages/incentives-table.njk
+++ b/server/views/pages/incentives-table.njk
@@ -6,6 +6,8 @@
 {% set pageTitle = applicationName + " – Incentives information" %}
 
 {% block content %}
+  <span id="ga-label" data-ga-label="{{ locationPrefix }}"></span>
+
   <h1 class="govuk-heading-xl govuk-!-margin-bottom-4">
     Incentive information
   </h1>

--- a/server/views/pages/incentives-table.njk
+++ b/server/views/pages/incentives-table.njk
@@ -214,38 +214,5 @@
 
 {% block bodyEnd %}
   {{ super() }}
-
-  <script nonce="{{ cspNonce }}">
-    function gaSendEvent() {
-      const elem = $(this)
-
-      const gaCategory = elem.data('ga-category')
-      let gaAction = elem.data('ga-action')
-      const gaLabel = '{{ locationPrefix }}'
-
-      // for sorting events, add sort order to GA action
-      const previousSortOrder = elem.attr('aria-sort')
-      if (previousSortOrder) {
-        if (previousSortOrder === 'ascending') {
-          gaAction += ' (descending)'
-        } else {
-          gaAction += ' (ascending)'
-        }
-      }
-
-      if (typeof ga === typeof Function) ga('send', 'event', gaCategory, gaAction, gaLabel)
-
-      if (typeof gtag === typeof Function) {
-        gtag('event', 'incentives_event', {
-          category: gaCategory,
-          action: gaAction,
-          label: gaLabel,
-        })
-      }
-    }
-
-    $('.govuk-tabs__tab[data-ga-category]').on('focus', gaSendEvent)
-    $('.govuk-table a[data-ga-category]').on('click', gaSendEvent)
-    $('.govuk-table .govuk-table__header[data-ga-category]').on('click', gaSendEvent)
-  </script>
+  <script src="/assets/gaSendEvents.js"></script>
 {% endblock bodyEnd %}

--- a/server/views/pages/reviewsTable.njk
+++ b/server/views/pages/reviewsTable.njk
@@ -5,6 +5,8 @@
 {% set pageTitle = applicationName + " – Manage incentive reviews" %}
 
 {% block content %}
+  <span id="ga-label" data-ga-label="{{ locationPrefix }}"></span>
+
   <h1 class="govuk-heading-xl govuk-!-margin-bottom-4">
     Manage incentive reviews
   </h1>
@@ -101,3 +103,42 @@
     {{ govukPagination(paginationParams) }}
   </div>
 {% endblock %}
+
+{# TODO: Move to static JavaScript #}
+{% block bodyEnd %}
+  {{ super() }}
+
+  <script nonce="{{ cspNonce }}">
+    function gaSendEvent(event) {
+      const elem = $(this)
+
+      const gaCategory = elem.data('ga-category')
+      let gaAction = elem.data('ga-action')
+      const gaLabel = $('#ga-label').data('ga-label')
+
+      // for sorting events, add sort order to GA action
+      const previousSortOrder = elem.attr('aria-sort')
+      if (previousSortOrder) {
+        if (previousSortOrder === 'ascending') {
+          gaAction += ' (descending)'
+        } else {
+          gaAction += ' (ascending)'
+        }
+      }
+
+      if (typeof ga === typeof Function) ga('send', 'event', gaCategory, gaAction, gaLabel)
+
+      if (typeof gtag === typeof Function) {
+        gtag('event', 'incentives_event', {
+          category: gaCategory,
+          action: gaAction,
+          label: gaLabel,
+        })
+      }
+    }
+
+    $('.govuk-tabs__tab[data-ga-category]').on('focus', gaSendEvent)
+    $('.govuk-table a[data-ga-category]').on('click', gaSendEvent)
+    $('.govuk-table .govuk-table__header[data-ga-category]').on('click', gaSendEvent)
+  </script>
+{% endblock bodyEnd %}

--- a/server/views/pages/reviewsTable.njk
+++ b/server/views/pages/reviewsTable.njk
@@ -27,7 +27,7 @@
   <ul class="govuk-tabs__list">
     {% for level in levels %}
       <li class="govuk-tabs__list-item {% if level.iepLevel == selectedLevelCode %}govuk-tabs__list-item--selected{% endif %}">
-        <a class="govuk-tabs__tab" href="?level={{ level.iepLevel }}&amp;sort={{ sort }}&amp;order={{ order }}">
+        <a class="govuk-tabs__tab" href="?level={{ level.iepLevel }}&amp;sort={{ sort }}&amp;order={{ order }}" data-ga-category="Reviews table > Clicked on incentive level tab" data-ga-action = "{{ level.iepDescription }}">
           {{ level.iepDescription }}
         </a>
       </li>

--- a/server/views/pages/reviewsTable.njk
+++ b/server/views/pages/reviewsTable.njk
@@ -104,41 +104,7 @@
   </div>
 {% endblock %}
 
-{# TODO: Move to static JavaScript #}
 {% block bodyEnd %}
   {{ super() }}
-
-  <script nonce="{{ cspNonce }}">
-    function gaSendEvent(event) {
-      const elem = $(this)
-
-      const gaCategory = elem.data('ga-category')
-      let gaAction = elem.data('ga-action')
-      const gaLabel = $('#ga-label').data('ga-label')
-
-      // for sorting events, add sort order to GA action
-      const previousSortOrder = elem.attr('aria-sort')
-      if (previousSortOrder) {
-        if (previousSortOrder === 'ascending') {
-          gaAction += ' (descending)'
-        } else {
-          gaAction += ' (ascending)'
-        }
-      }
-
-      if (typeof ga === typeof Function) ga('send', 'event', gaCategory, gaAction, gaLabel)
-
-      if (typeof gtag === typeof Function) {
-        gtag('event', 'incentives_event', {
-          category: gaCategory,
-          action: gaAction,
-          label: gaLabel,
-        })
-      }
-    }
-
-    $('.govuk-tabs__tab[data-ga-category]').on('focus', gaSendEvent)
-    $('.govuk-table a[data-ga-category]').on('click', gaSendEvent)
-    $('.govuk-table .govuk-table__header[data-ga-category]').on('click', gaSendEvent)
-  </script>
+  <script src="/assets/gaSendEvents.js"></script>
 {% endblock bodyEnd %}

--- a/server/views/pages/reviewsTable.njk
+++ b/server/views/pages/reviewsTable.njk
@@ -41,7 +41,7 @@
     {% endset %}
 
     {% set profileLink %}
-      <a href="{{ dpsUrl }}/prisoner/{{ review.prisonerNumber }}">
+      <a href="{{ dpsUrl }}/prisoner/{{ review.prisonerNumber }}" data-ga-category="Reviews table > Clicked on link" data-ga-action="prisoner name">
         {{ review.lastName }}, {{ review.firstName }}
         <br />
         {{ review.prisonerNumber }}
@@ -61,13 +61,13 @@
     {% endset %}
 
     {% set positiveBehaviours %}
-      <a href="{{ dpsUrl }}/prisoner/{{ review.prisonerNumber }}/case-notes?type=POS&amp;{{ caseNoteFilter }}">
+      <a href="{{ dpsUrl }}/prisoner/{{ review.prisonerNumber }}/case-notes?type=POS&amp;{{ caseNoteFilter }}" data-ga-category="Reviews table > Clicked on link" data-ga-action="positive behaviours">
         {{ review.positiveBehaviours }}
       </a>
     {% endset %}
 
     {% set negativeBehaviours %}
-      <a href="{{ dpsUrl }}/prisoner/{{ review.prisonerNumber }}/case-notes?type=NEG&amp;{{ caseNoteFilter }}">
+      <a href="{{ dpsUrl }}/prisoner/{{ review.prisonerNumber }}/case-notes?type=NEG&amp;{{ caseNoteFilter }}" data-ga-category="Reviews table > Clicked on link" data-ga-action="negative behaviours">
         {{ review.negativeBehaviours }}
       </a>
     {% endset %}


### PR DESCRIPTION
Similar to what we were tracking in the old Behaviour table:
- track clicks on Incentive levels tabs
- track sorting of table
- track clicks on links in the table

I've made the tracking JavaScript code static and moved into an asset file (now used by both old and new table)