### PR TITLE
Make prettier rules match eslint in terms of trailing commas

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,5 +1,5 @@
 {
-  "trailingComma": "es5",
+  "trailingComma": "all",
   "singleQuote": true,
   "printWidth": 120,
   "semi": false,


### PR DESCRIPTION
cf. [hmpps-template-typescript#135](https://github.com/ministryofjustice/hmpps-template-typescript/pull/135)