### PR TITLE
INC-1040: Reviews table: 'Basic' tab selected by default

### DIFF
--- a/server/routes/reviewsTable.test.ts
+++ b/server/routes/reviewsTable.test.ts
@@ -215,7 +215,7 @@ describe('Reviews table', () => {
       const defaultRequest: IncentivesReviewsRequest = {
         agencyId: 'MDI',
         locationPrefix: 'MDI-1',
-        levelCode: 'STD',
+        levelCode: 'BAS',
         sort: 'NEXT_REVIEW_DATE',
         order: 'ASC',
         page: 0,
@@ -246,7 +246,7 @@ describe('Reviews table', () => {
     {
       name: 'shows each available level',
       givenUrl: '',
-      expectedLevel: 'STD',
+      expectedLevel: 'BAS',
       expectedSort: 'NEXT_REVIEW_DATE',
       expectedOrder: 'ASC',
     },
@@ -260,21 +260,21 @@ describe('Reviews table', () => {
     {
       name: 'falls back to default when given incorrect level',
       givenUrl: '?level=EN2',
-      expectedLevel: 'STD',
+      expectedLevel: 'BAS',
       expectedSort: 'NEXT_REVIEW_DATE',
       expectedOrder: 'ASC',
     },
     {
       name: 'preserves sort',
       givenUrl: '?sort=LAST_NAME',
-      expectedLevel: 'STD',
+      expectedLevel: 'BAS',
       expectedSort: 'LAST_NAME',
       expectedOrder: 'ASC',
     },
     {
       name: 'preserves sort and order',
       givenUrl: '?sort=NEGATIVE_BEHAVIOURS&order=ASC',
-      expectedLevel: 'STD',
+      expectedLevel: 'BAS',
       expectedSort: 'NEGATIVE_BEHAVIOURS',
       expectedOrder: 'ASC',
     },
@@ -375,7 +375,7 @@ describe('Reviews table', () => {
         const firstRowCells: HTMLTableCellElement[] = $body.find('.app-reviews-table tbody tr').first().find('td').get()
         expect(firstRowCells.length).toEqual(1)
         const [messageCell] = firstRowCells
-        expect(messageCell.textContent).toContain('There are no prisoners at Houseblock 1 on Standard')
+        expect(messageCell.textContent).toContain('There are no prisoners at Houseblock 1 on Basic')
       })
   })
 
@@ -390,7 +390,7 @@ describe('Reviews table', () => {
     {
       name: 'uses default level and sorting if not provided',
       givenUrl: '',
-      expectedLevel: 'STD',
+      expectedLevel: 'BAS',
       expectedSort: 'NEXT_REVIEW_DATE',
       expectedOrder: 'ASC',
     },
@@ -411,28 +411,28 @@ describe('Reviews table', () => {
     {
       name: 'accepts provided sort and uses default level',
       givenUrl: '?sort=LAST_NAME',
-      expectedLevel: 'STD',
+      expectedLevel: 'BAS',
       expectedSort: 'LAST_NAME',
       expectedOrder: 'ASC',
     },
     {
       name: 'accepts provided sort & ordering and uses default level',
       givenUrl: '?sort=LAST_NAME&order=DESC',
-      expectedLevel: 'STD',
+      expectedLevel: 'BAS',
       expectedSort: 'LAST_NAME',
       expectedOrder: 'DESC',
     },
     {
       name: 'accepts provided sort and uses default level',
       givenUrl: '?sort=POSITIVE_BEHAVIOURS',
-      expectedLevel: 'STD',
+      expectedLevel: 'BAS',
       expectedSort: 'POSITIVE_BEHAVIOURS',
       expectedOrder: 'DESC',
     },
     {
       name: 'accepts provided sort & ordering and uses default level',
       givenUrl: '?sort=POSITIVE_BEHAVIOURS&order=DESC',
-      expectedLevel: 'STD',
+      expectedLevel: 'BAS',
       expectedSort: 'POSITIVE_BEHAVIOURS',
       expectedOrder: 'DESC',
     },
@@ -555,7 +555,7 @@ describe('Reviews table', () => {
     {
       name: 'uses default level and sorting if not provided',
       givenUrl: '',
-      expectedLevel: 'STD',
+      expectedLevel: 'BAS',
       expectedSort: 'NEXT_REVIEW_DATE',
       expectedOrder: 'ASC',
       expectedPages: [1, 2, 6, 7],
@@ -563,7 +563,7 @@ describe('Reviews table', () => {
     {
       name: 'uses default level and sorting if not provided; accepts page',
       givenUrl: '?page=7',
-      expectedLevel: 'STD',
+      expectedLevel: 'BAS',
       expectedSort: 'NEXT_REVIEW_DATE',
       expectedOrder: 'ASC',
       expectedPages: [1, 2, 6, 7],
@@ -571,7 +571,7 @@ describe('Reviews table', () => {
     {
       name: 'preserves sort and uses default level if not provided',
       givenUrl: '?page=7&sort=LAST_NAME',
-      expectedLevel: 'STD',
+      expectedLevel: 'BAS',
       expectedSort: 'LAST_NAME',
       expectedOrder: 'ASC',
       expectedPages: [1, 2, 6, 7],
@@ -579,7 +579,7 @@ describe('Reviews table', () => {
     {
       name: 'preserves sort and order, but uses default level if not provided',
       givenUrl: '?page=7&order=DESC&sort=LAST_NAME',
-      expectedLevel: 'STD',
+      expectedLevel: 'BAS',
       expectedSort: 'LAST_NAME',
       expectedOrder: 'DESC',
       expectedPages: [1, 2, 6, 7],

--- a/server/routes/reviewsTable.ts
+++ b/server/routes/reviewsTable.ts
@@ -51,11 +51,13 @@ export default function routes(router: Router): Router {
 
     const agencyId = locationPrefix.split('-')[0]
     const levels = await incentivesApi.getAvailableLevels(agencyId)
-    let selectedLevelDescription = levels.find(level => level.iepLevel === selectedLevelCode)?.iepDescription
-    const defaultLevel = levels.find(level => level.default) ?? levels[0]
-    if (!levels.some(level => level.iepLevel === selectedLevelCode)) {
-      selectedLevelCode = defaultLevel.iepLevel
-      selectedLevelDescription = defaultLevel.iepDescription
+
+    const selectedLevel = levels.find(level => level.iepLevel === selectedLevelCode)
+    let selectedLevelDescription = selectedLevel?.iepDescription
+    if (!selectedLevel) {
+      const basicOrFirstLevel = levels.find(level => level.iepDescription === 'Basic') ?? levels[0]
+      selectedLevelCode = basicOrFirstLevel.iepLevel
+      selectedLevelDescription = basicOrFirstLevel.iepDescription
     }
 
     const response = await incentivesApi.getReviews({


### PR DESCRIPTION
When the user didn't select any incentive level yet page will show the 'Basic' level instead of the prison default level. If 'Basic' is not available at the prison for whatever reason the first level will be shown (this behaviour was there before).

Users want to focus on prisoners on 'Basic' so that they can be reviewed and possibly moved to a better incentive level as soon as possible.