### PR TITLE
Update minor node version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ parameters:
 
   node-version:
     type: string
-    default: 18.13-browsers
+    default: 18.14-browsers
 
   python-version:
     type: string
@@ -25,7 +25,7 @@ executors:
   # same as hmpps/node_redis executor with the addition of minio containers
   integration-tests:
     docker:
-      - image: cimg/node:18.13-browsers
+      - image: cimg/node:18.14-browsers
       - image: cimg/redis:6.2
       - image: minio/minio
         command: server --address :9000 /data

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Stage: base image
-FROM node:18.13-bullseye-slim as base
+FROM node:18.14-bullseye-slim as base
 
 ARG BUILD_NUMBER=1_0_0
 ARG GIT_REF=not-available

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   },
   "engines": {
     "node": "^18",
-    "npm": "^8"
+    "npm": "^9"
   },
   "jest": {
     "preset": "ts-jest",

--- a/renovate.json
+++ b/renovate.json
@@ -33,7 +33,7 @@
     {
       "matchDatasources": ["orb"],
       "matchPackageNames": ["cimg/node"],
-      "allowedVersions": "18.13-browsers"
+      "allowedVersions": "18.14-browsers"
     },
     {
       "matchDatasources": ["orb"],


### PR DESCRIPTION
…which now includes npm v9 as was [specified in upstream template](https://github.com/ministryofjustice/hmpps-template-typescript/blob/92b5a338218aed85add3ddb524168ef301a5d47a/package.json#L33)