### PR TITLE
INC-1073: Show number of prisoners and overdue by level

### DIFF
--- a/server/data/incentivesApi.test.ts
+++ b/server/data/incentivesApi.test.ts
@@ -60,6 +60,26 @@ describe('IncentiveApi', () => {
           locationDescription: '1 wing',
           overdueCount: 0,
           reviewCount: 0,
+          levels: [
+            {
+              levelCode: 'BAS',
+              levelName: 'Basic',
+              reviewCount: 0,
+              overdueCount: 0,
+            },
+            {
+              levelCode: 'STD',
+              levelName: 'Standard',
+              reviewCount: 0,
+              overdueCount: 0,
+            },
+            {
+              levelCode: 'ENH',
+              levelName: 'Enhanced',
+              reviewCount: 0,
+              overdueCount: 0,
+            },
+          ],
           reviews: [],
         })
 
@@ -73,6 +93,26 @@ describe('IncentiveApi', () => {
         locationDescription: '1 wing',
         overdueCount: 0,
         reviewCount: 0,
+        levels: [
+          {
+            levelCode: 'BAS',
+            levelName: 'Basic',
+            reviewCount: 0,
+            overdueCount: 0,
+          },
+          {
+            levelCode: 'STD',
+            levelName: 'Standard',
+            reviewCount: 0,
+            overdueCount: 0,
+          },
+          {
+            levelCode: 'ENH',
+            levelName: 'Enhanced',
+            reviewCount: 0,
+            overdueCount: 0,
+          },
+        ],
         reviews: [],
       })
     })
@@ -85,6 +125,26 @@ describe('IncentiveApi', () => {
           locationDescription: '1 wing',
           overdueCount: 2,
           reviewCount: 1,
+          levels: [
+            {
+              levelCode: 'BAS',
+              levelName: 'Basic',
+              reviewCount: 10,
+              overdueCount: 0,
+            },
+            {
+              levelCode: 'STD',
+              levelName: 'Standard',
+              reviewCount: 1,
+              overdueCount: 0,
+            },
+            {
+              levelCode: 'ENH',
+              levelName: 'Enhanced',
+              reviewCount: 10,
+              overdueCount: 2,
+            },
+          ],
           reviews: [
             {
               firstName: 'Flem',
@@ -105,6 +165,26 @@ describe('IncentiveApi', () => {
         locationDescription: '1 wing',
         overdueCount: 2,
         reviewCount: 1,
+        levels: [
+          {
+            levelCode: 'BAS',
+            levelName: 'Basic',
+            reviewCount: 10,
+            overdueCount: 0,
+          },
+          {
+            levelCode: 'STD',
+            levelName: 'Standard',
+            reviewCount: 1,
+            overdueCount: 0,
+          },
+          {
+            levelCode: 'ENH',
+            levelName: 'Enhanced',
+            reviewCount: 10,
+            overdueCount: 2,
+          },
+        ],
         reviews: [
           {
             firstName: 'Flem',

--- a/server/data/incentivesApi.ts
+++ b/server/data/incentivesApi.ts
@@ -64,10 +64,17 @@ export type IncentivesReviewsRequest = {
   levelCode: string
 } & IncentivesReviewsPaginationAndSorting
 
+export interface IncentivesReviewsLevel {
+  levelCode: string
+  levelName: string
+  reviewCount: number
+  overdueCount: number
+}
 export interface IncentivesReviewsResponse {
   locationDescription: string
   overdueCount: number
   reviewCount: number
+  levels: IncentivesReviewsLevel[]
   reviews: IncentivesReview[]
 }
 

--- a/server/routes/reviewsTable.ts
+++ b/server/routes/reviewsTable.ts
@@ -78,7 +78,8 @@ export default function routes(router: Router): Router {
       order,
     })
 
-    const pageCount = Math.ceil(response.reviewCount / PAGE_SIZE)
+    const { reviewCount } = response.levels.find(level => level.levelCode === selectedLevelCode)
+    const pageCount = Math.ceil(reviewCount / PAGE_SIZE)
     const paginationUrlPrefix = `?level=${selectedLevelCode}&sort=${sort}&order=${order}&`
     const paginationParams = pagination(page, pageCount, paginationUrlPrefix)
 
@@ -90,8 +91,7 @@ export default function routes(router: Router): Router {
       feedbackUrl: config.feedbackUrlForReviewsTable || config.feedbackUrlForTable || config.feedbackUrl,
       locationPrefix,
       locationDescription: response.locationDescription,
-      overdueCount: response.overdueCount,
-      levels,
+      levels: response.levels,
       caseNoteFilter,
       selectedLevelCode,
       selectedLevelDescription,

--- a/server/testData/incentivesApi.ts
+++ b/server/testData/incentivesApi.ts
@@ -80,6 +80,26 @@ export function getTestIncentivesReviews(): IncentivesReviewsResponse {
     locationDescription: 'Houseblock 1',
     overdueCount: 16,
     reviewCount: 135,
+    levels: [
+      {
+        levelCode: 'BAS',
+        levelName: 'Basic',
+        reviewCount: 138,
+        overdueCount: 16,
+      },
+      {
+        levelCode: 'STD',
+        levelName: 'Standard',
+        reviewCount: 135,
+        overdueCount: 0,
+      },
+      {
+        levelCode: 'ENH',
+        levelName: 'Enhanced',
+        reviewCount: 130,
+        overdueCount: 0,
+      },
+    ],
     reviews: [
       {
         firstName: 'John',

--- a/server/views/pages/reviewsTable.njk
+++ b/server/views/pages/reviewsTable.njk
@@ -17,22 +17,28 @@
     <a href="/select-location">Select another location</a>
   </p>
 
-  <div class="govuk-grid-row govuk-!-margin-top-8 govuk-grid-row">
+  <div class="govuk-grid-row govuk-!-margin-top-8">
     <div class="govuk-grid-column-full">
       <h2 class="govuk-heading-l">Overdue reviews</h2>
     </div>
+  </div>
 
+  <div class="govuk-grid-row">
     {% for level in levels %}
-      <div class="govuk-grid-column-one-quarter" data-qa="overdue-at-level-{{ level.levelCode }}">
-        <p class="govuk-body govuk-!-margin-bottom-2">{{ level.levelName }}</p>
-        <span class="govuk-body govuk-!-font-size-36 govuk-!-font-weight-bold">
+      <div class="govuk-grid-column-one-quarter govuk-!-margin-bottom-7" data-qa="overdue-at-level-{{ level.levelCode }}">
+        <p class="govuk-body govuk-!-margin-bottom-7">{{ level.levelName }}</p>
+        <span class="govuk-body govuk-!-font-size-36 govuk-!-font-weight-bold govuk-!-margin-bottom-4">
           {{ level.overdueCount | default(0) }}
         </span>
       </div>
+      {% if loop.index0 % 4 == 3 %}
+        </div>
+        <div class="govuk-grid-row">
+      {% endif  %}
     {% endfor %}
   </div>
 
-  <h2 class="govuk-heading-l">Prisoner details and review status</h2>
+  <h2 class="govuk-heading-l govuk-!-margin-top-5">Prisoner details and review status</h2>
 
   {% if showNotification %}
     <input type="hidden" id="_csrf" name="_csrf" value="{{ csrfToken }}" />

--- a/server/views/pages/reviewsTable.njk
+++ b/server/views/pages/reviewsTable.njk
@@ -17,12 +17,20 @@
     <a href="/select-location">Select another location</a>
   </p>
 
-  <dl class="app-data-list govuk-!-margin-top-6 govuk-!-margin-bottom-8">
-    <dt>Overdue reviews</dt>
-    <dd>
-      {{- overdueCount -}}
-    </dd>
-  </dl>
+  <div class="govuk-grid-row govuk-!-margin-top-8 govuk-grid-row">
+    <div class="govuk-grid-column-full">
+      <h2 class="govuk-heading-l">Overdue reviews</h2>
+    </div>
+
+    {% for level in levels %}
+      <div class="govuk-grid-column-one-quarter" data-qa="number-at-level-{{ level.levelCode }}">
+        <p class="govuk-body govuk-!-margin-bottom-2">{{ level.levelName }}</p>
+        <span class="govuk-body govuk-!-font-size-36 govuk-!-font-weight-bold">
+          {{ level.overdueCount | default(0) }}
+        </span>
+      </div>
+    {% endfor %}
+  </div>
 
   <h2 class="govuk-heading-l">Prisoner details and review status</h2>
 
@@ -50,9 +58,9 @@
 
   <ul class="govuk-tabs__list">
     {% for level in levels %}
-      <li class="govuk-tabs__list-item {% if level.iepLevel == selectedLevelCode %}govuk-tabs__list-item--selected{% endif %}">
-        <a class="govuk-tabs__tab" href="?level={{ level.iepLevel }}&amp;sort={{ sort }}&amp;order={{ order }}" data-ga-category="Reviews table > Clicked on incentive level tab" data-ga-action="{{ level.iepDescription }}">
-          {{ level.iepDescription }}
+      <li class="govuk-tabs__list-item {% if level.levelCode == selectedLevelCode %}govuk-tabs__list-item--selected{% endif %}">
+        <a class="govuk-tabs__tab" href="?level={{ level.levelCode }}&amp;sort={{ sort }}&amp;order={{ order }}" data-ga-category="Reviews table > Clicked on incentive level tab" data-ga-action="{{ level.levelName }}">
+          {{ level.levelName }} ({{ level.reviewCount }})
         </a>
       </li>
     {% endfor %}

--- a/server/views/pages/reviewsTable.njk
+++ b/server/views/pages/reviewsTable.njk
@@ -23,7 +23,7 @@
     </div>
 
     {% for level in levels %}
-      <div class="govuk-grid-column-one-quarter" data-qa="number-at-level-{{ level.levelCode }}">
+      <div class="govuk-grid-column-one-quarter" data-qa="overdue-at-level-{{ level.levelCode }}">
         <p class="govuk-body govuk-!-margin-bottom-2">{{ level.levelName }}</p>
         <span class="govuk-body govuk-!-font-size-36 govuk-!-font-weight-bold">
           {{ level.overdueCount | default(0) }}


### PR DESCRIPTION
- Instead of showing the total number of prisoners overdue a review
  the page now breaks these down by Incentive level
- Show the total number of prisoners at each level in parenthesis
  on the tabs

This is using the updated 'reviews' endpoint: https://github.com/ministryofjustice/hmpps-incentives-api/pull/350

See prototype: https://www.figma.com/file/HBC8couSBqGFO5IjH5yyhk/INC-793---Incentives---%23-on-each-incentive-level-%2B-%23-of-overdue-reviews?node-id=615%3A21063&t=gif2TlUcyyZDUgoc-0