### PR TITLE
INC-1185: Enhance admin section to manage incentive level details in a prison

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020-2022 Crown Copyright (Ministry of Justice)
+Copyright (c) 2020-2023 Crown Copyright (Ministry of Justice)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/integration_tests/e2e/analytics/behaviourEntries.cy.ts
+++ b/integration_tests/e2e/analytics/behaviourEntries.cy.ts
@@ -9,7 +9,7 @@ import HomePage from '../../pages/home'
 import AnalyticsBehaviourEntries from '../../pages/analytics/behaviourEntries'
 import AnalyticsIncentiveLevels from '../../pages/analytics/incentiveLevels'
 import PgdRegionSelection from '../../pages/analytics/pgdRegionSelection'
-import { ChartId } from '../../../server/routes/analyticsChartTypes'
+import type { ChartId } from '../../../server/routes/analyticsChartTypes'
 
 context('Analytics section > Behaviour entries page', () => {
   beforeEach(() => {

--- a/integration_tests/e2e/analytics/incentiveLevels.cy.ts
+++ b/integration_tests/e2e/analytics/incentiveLevels.cy.ts
@@ -8,7 +8,7 @@ import Page from '../../pages/page'
 import HomePage from '../../pages/home'
 import AnalyticsIncentiveLevels from '../../pages/analytics/incentiveLevels'
 import PgdRegionSelection from '../../pages/analytics/pgdRegionSelection'
-import { ChartId } from '../../../server/routes/analyticsChartTypes'
+import type { ChartId } from '../../../server/routes/analyticsChartTypes'
 
 context('Analytics section > Incentive levels page', () => {
   beforeEach(() => {

--- a/integration_tests/e2e/login.cy.ts
+++ b/integration_tests/e2e/login.cy.ts
@@ -74,7 +74,7 @@ context('SignIn', () => {
     cy.request('/').its('body').should('contain', 'Sign in')
 
     cy.task('stubVerifyToken', true)
-    cy.task('stubAuthUser', 'bobby brown')
+    cy.task('stubAuthUser', { name: 'bobby brown' })
     cy.signIn()
 
     indexPage.headerUserName.contains('B. Brown')

--- a/integration_tests/e2e/login.cy.ts
+++ b/integration_tests/e2e/login.cy.ts
@@ -25,13 +25,13 @@ context('SignIn', () => {
   it('User name visible in header', () => {
     cy.signIn()
     const homePage = Page.verifyOnPage(HomePage)
-    homePage.headerUserName().should('contain.text', 'J. Smith')
+    homePage.headerUserName.should('contain.text', 'J. Smith')
   })
 
   it('User can log out', () => {
     cy.signIn()
     const homePage = Page.verifyOnPage(HomePage)
-    homePage.signOut().click()
+    homePage.signOut.click()
     Page.verifyOnPage(AuthSignInPage)
   })
 
@@ -39,8 +39,8 @@ context('SignIn', () => {
     cy.signIn()
     const homePage = Page.verifyOnPage(HomePage)
 
-    homePage.manageDetails().get('a').invoke('removeAttr', 'target')
-    homePage.manageDetails().click()
+    homePage.manageDetails.get('a').invoke('removeAttr', 'target')
+    homePage.manageDetails.click()
     Page.verifyOnPage(AuthManageDetailsPage)
   })
 
@@ -77,6 +77,6 @@ context('SignIn', () => {
     cy.task('stubAuthUser', 'bobby brown')
     cy.signIn()
 
-    indexPage.headerUserName().contains('B. Brown')
+    indexPage.headerUserName.contains('B. Brown')
   })
 })

--- a/integration_tests/e2e/prisonIncentiveLevels.cy.ts
+++ b/integration_tests/e2e/prisonIncentiveLevels.cy.ts
@@ -30,10 +30,7 @@ context('Prison incentive level management', () => {
     const listPage = Page.verifyOnPage(PrisonIncentiveLevelsPage)
     listPage.checkLastBreadcrumb()
     listPage.contentsOfTable.should('have.all.key', 'Basic', 'Standard', 'Enhanced')
-    listPage.contentsOfTable
-      .its('Standard')
-      .then(([tags, _links]) => tags)
-      .should('contain', 'Default')
+    listPage.contentsOfTable.its('Standard').its('tags').should('contain', 'Default')
 
     listPage.findTableLink(1, 'View settings').click()
 

--- a/integration_tests/e2e/prisonIncentiveLevels.cy.ts
+++ b/integration_tests/e2e/prisonIncentiveLevels.cy.ts
@@ -1,0 +1,48 @@
+import Page from '../pages/page'
+import type { UserRole } from '../../server/data/hmppsAuthClient'
+import HomePage from '../pages/home'
+import PrisonIncentiveLevelPage from '../pages/prisonIncentiveLevels/prisonIncentiveLevel'
+import PrisonIncentiveLevelsPage from '../pages/prisonIncentiveLevels/prisonIncentiveLevels'
+
+context('Prison incentive level management', () => {
+  beforeEach(() => {
+    const roles: UserRole[] = [{ roleCode: 'ROLE_MAINTAIN_PRISON_IEP_LEVELS' }]
+    cy.task('reset')
+    cy.task('stubSignIn', { roles })
+    cy.task('stubAuthUser', { roles })
+    cy.task('stubIncentiveLevels')
+    cy.task('stubIncentiveLevel')
+    cy.task('stubPrisonIncentiveLevels')
+    cy.task('stubPrisonIncentiveLevel')
+
+    cy.signIn()
+    const homePage = Page.verifyOnPage(HomePage)
+    homePage.managePrisonIncentiveLevelsLink().click()
+  })
+
+  it('shows list of levels and details of a level', () => {
+    const listPage = Page.verifyOnPage(PrisonIncentiveLevelsPage)
+    listPage.checkLastBreadcrumb()
+    listPage.contentsOfTable.should('have.all.key', 'Basic', 'Standard', 'Enhanced')
+    listPage.contentsOfTable
+      .its('Standard')
+      .then(([tags, _links]) => tags)
+      .should('contain', 'Default')
+
+    listPage.findTableLink(1, 'View settings').click()
+
+    const detailPage = Page.verifyOnPage(PrisonIncentiveLevelPage, 'Standard')
+    detailPage.checkLastBreadcrumb()
+    detailPage.contentsOfTables
+      .should('have.length', 4)
+      .should('deep.equal', [
+        { 'Default for new prisoners': 'Yes' },
+        { 'Remand prisoners': '£60.50 per week', 'Convicted prisoners': '£19.80 per week' },
+        { 'Remand prisoners': '£605', 'Convicted prisoners': '£198' },
+        { Visits: '1 per 2 weeks', 'Privileged visits': '2 per 4 weeks' },
+      ])
+
+    detailPage.returnLink.click()
+    Page.verifyOnPage(PrisonIncentiveLevelsPage)
+  })
+})

--- a/integration_tests/e2e/prisonIncentiveLevels.cy.ts
+++ b/integration_tests/e2e/prisonIncentiveLevels.cy.ts
@@ -5,6 +5,7 @@ import { sampleIncentiveLevels, samplePrisonIncentiveLevels } from '../../server
 import HomePage from '../pages/home'
 import PrisonIncentiveLevelPage from '../pages/prisonIncentiveLevels/prisonIncentiveLevel'
 import PrisonIncentiveLevelAddFormPage from '../pages/prisonIncentiveLevels/prisonIncentiveLevelAddForm'
+import PrisonIncentiveLevelDeactivateFormPage from '../pages/prisonIncentiveLevels/prisonIncentiveLevelDeactivateForm'
 import PrisonIncentiveLevelsPage from '../pages/prisonIncentiveLevels/prisonIncentiveLevels'
 
 context('Prison incentive level management', () => {
@@ -19,11 +20,12 @@ context('Prison incentive level management', () => {
     cy.task('stubPrisonIncentiveLevel')
 
     cy.signIn()
-    const homePage = Page.verifyOnPage(HomePage)
-    homePage.managePrisonIncentiveLevelsLink().click()
   })
 
   it('shows list of levels and details of a level', () => {
+    const homePage = Page.verifyOnPage(HomePage)
+    homePage.managePrisonIncentiveLevelsLink().click()
+
     const listPage = Page.verifyOnPage(PrisonIncentiveLevelsPage)
     listPage.checkLastBreadcrumb()
     listPage.contentsOfTable.should('have.all.key', 'Basic', 'Standard', 'Enhanced')
@@ -59,6 +61,9 @@ context('Prison incentive level management', () => {
     cy.task('stubPrisonIncentiveLevel', { prisonIncentiveLevel: enhanced3 })
     cy.task('stubIncentiveLevel', { incentiveLevel: sampleIncentiveLevels[4] })
 
+    const homePage = Page.verifyOnPage(HomePage)
+    homePage.managePrisonIncentiveLevelsLink().click()
+
     const listPage = Page.verifyOnPage(PrisonIncentiveLevelsPage)
     listPage.addLink.click()
 
@@ -87,5 +92,50 @@ context('Prison incentive level management', () => {
     detailPage.messages.should('contain.text', 'Enhanced 3')
     detailPage.messages.should('contain.text', 'added')
     detailPage.contentsOfTables.its(0).its('Default for new prisoners').should('eq', 'No')
+  })
+
+  it('should allow removing a non-required level', () => {
+    const enhanced2: PrisonIncentiveLevel = {
+      ...samplePrisonIncentiveLevels[2],
+      levelCode: 'EN2',
+      levelName: 'Enhanced 2',
+    }
+    const prisonIncentiveLevels: PrisonIncentiveLevel[] = [
+      ...samplePrisonIncentiveLevels.filter(prisonIncentiveLevel => prisonIncentiveLevel.active),
+      enhanced2,
+    ]
+    cy.task('stubPrisonIncentiveLevels', { prisonId: 'MDI', prisonIncentiveLevels })
+    cy.task('stubPatchPrisonIncentiveLevel', { prisonIncentiveLevel: { ...enhanced2, active: false } })
+    cy.task('stubPrisonIncentiveLevel', { prisonIncentiveLevel: enhanced2 })
+    cy.task('stubIncentiveLevel', { incentiveLevel: sampleIncentiveLevels[3] })
+
+    const homePage = Page.verifyOnPage(HomePage)
+    homePage.managePrisonIncentiveLevelsLink().click()
+    let listPage = Page.verifyOnPage(PrisonIncentiveLevelsPage)
+    listPage.contentsOfTable.should('have.all.key', 'Basic', 'Standard', 'Enhanced', 'Enhanced 2')
+
+    listPage.findTableLink(3, 'Remove level').click()
+
+    let deactivatePage = Page.verifyOnPage(PrisonIncentiveLevelDeactivateFormPage, 'Enhanced 2')
+    deactivatePage.checkLastBreadcrumb()
+
+    deactivatePage.form.submit() // empty form
+    Page.verifyOnPage(PrisonIncentiveLevelDeactivateFormPage, 'Enhanced 2')
+    deactivatePage.errorSummaryTitle.should('contain.text', 'There is a problem')
+
+    deactivatePage.confirmationRadios.eq(1).find('label').click()
+    deactivatePage.form.submit() // form should now be valid
+
+    listPage = Page.verifyOnPage(PrisonIncentiveLevelsPage)
+    listPage.messages.should('not.exist')
+
+    listPage.findTableLink(3, 'Remove level').click()
+
+    deactivatePage = Page.verifyOnPage(PrisonIncentiveLevelDeactivateFormPage, 'Enhanced 2')
+    deactivatePage.confirmationRadios.eq(0).find('label').click()
+    deactivatePage.form.submit() // form should now be valid
+
+    listPage = Page.verifyOnPage(PrisonIncentiveLevelsPage)
+    listPage.messages.should('contain.text', 'Enhanced 2').should('contain.text', 'no longer available')
   })
 })

--- a/integration_tests/e2e/prisonIncentiveLevels.cy.ts
+++ b/integration_tests/e2e/prisonIncentiveLevels.cy.ts
@@ -158,7 +158,7 @@ context('Prison incentive level management', () => {
     editPage.errorSummaryTitle.should('contain.text', 'There is a problem')
     editPage.errorSummaryItems.spread((...$lis) => {
       expect($lis).to.have.lengthOf(1)
-      expect($lis[0]).to.contain('Convicted transfer limit must be in pounds and pence')
+      expect($lis[0]).to.contain('Transfer limit for convicted prisoners must be in pounds and pence')
     })
 
     editPage.getInputField('convictedTransferLimit').type('5.80')

--- a/integration_tests/e2e/reviewsTablePage.cy.ts
+++ b/integration_tests/e2e/reviewsTablePage.cy.ts
@@ -19,7 +19,7 @@ context('Manage incentives (select a location)', () => {
     homePage.viewIncentivesLevelsLink().click()
   })
 
-  it(' has correct title', () => {
+  it('has correct title', () => {
     cy.title().should('eq', 'Manage incentives – Select a location')
   })
 
@@ -29,7 +29,7 @@ context('Manage incentives (select a location)', () => {
     locationSelectionPage.locationSelectOptions().should('contain.text', 'Houseblock 42')
   })
 
-  it('user selects location by clicking continue ', () => {
+  it('user selects location by clicking continue', () => {
     const locationSelectionPage = Page.verifyOnPage(LocationSelectionPage)
     locationSelectionPage.locationSelect().select('Houseblock 42')
     locationSelectionPage.continueButton().click()
@@ -64,21 +64,18 @@ context('Manage incentive reviews', () => {
     cy.get('.app-feedback-banner a').invoke('attr', 'href').should('equal', 'https://example.com/table-feedback')
   })
 
-  it('users will see selected location or select alternative ', () => {
-    // cy.get('.govuk-main-wrapper').contains((text) => {
-    //   return text.includes('Houseblock 42') || text.includes('Select another location');
-    // })
+  it('users will see selected location or select alternative', () => {
     cy.get('.govuk-main-wrapper').contains('Houseblock 42')
   })
 
-  it('has reviews table ', () => {
+  it('has reviews table', () => {
     const page = Page.verifyOnPage(ReviewsTablePage)
     page
       .getReviewsTable()
       .first()
       .then(table => {
         const rowTitles = table.find('td:first-child').text()
-        expect(rowTitles).to.contain('\n ')
+        expect(rowTitles).to.contain('\n')
       })
     page.getPrisonerName().should('contain.text', 'Saunders, John')
   })

--- a/integration_tests/mockApis/auth.ts
+++ b/integration_tests/mockApis/auth.ts
@@ -84,7 +84,7 @@ const manageDetails = () =>
     },
   })
 
-const token = () =>
+const token = (roles: UserRole[] = []) =>
   stubFor({
     request: {
       method: 'POST',
@@ -97,11 +97,11 @@ const token = () =>
         Location: 'http://localhost:3007/sign-in/callback?code=codexxxx&state=stateyyyy',
       },
       jsonBody: {
-        access_token: createUserToken([]),
+        access_token: createUserToken(roles.map(role => role.roleCode)),
         token_type: 'bearer',
         user_name: 'USER1',
         expires_in: 599,
-        scope: 'read',
+        scope: 'read,write',
         internalUser: true,
       },
     },
@@ -146,8 +146,27 @@ const stubUserRoles = (roles: UserRole[] = []) =>
 export default {
   getSignInUrl,
   stubAuthPing: ping,
-  stubSignIn: (): Promise<[Response, Response, Response, Response, Response, Response]> =>
-    Promise.all([favicon(), redirect(), signOut(), manageDetails(), token(), tokenVerification.stubVerifyToken()]),
-  stubAuthUser: (name = 'john smith'): Promise<[Response, Response, Response]> =>
-    Promise.all([stubUser(name), stubUserRoles(), nomisUserRolesApi.stubGetUserCaseloads()]),
+  stubSignIn: (
+    {
+      roles = [],
+    }: {
+      roles: UserRole[]
+    } = {
+      roles: [],
+    },
+  ): Promise<[Response, Response, Response, Response, Response, Response]> =>
+    Promise.all([favicon(), redirect(), signOut(), manageDetails(), token(roles), tokenVerification.stubVerifyToken()]),
+  stubAuthUser: (
+    {
+      name = 'john smith',
+      roles = [],
+    }: {
+      name: string
+      roles: UserRole[]
+    } = {
+      name: 'john smith',
+      roles: [],
+    },
+  ): Promise<[Response, Response, Response]> =>
+    Promise.all([stubUser(name), stubUserRoles(roles), nomisUserRolesApi.stubGetUserCaseloads()]),
 }

--- a/integration_tests/mockApis/auth.ts
+++ b/integration_tests/mockApis/auth.ts
@@ -1,22 +1,10 @@
-import jwt from 'jsonwebtoken'
 import { Response } from 'superagent'
 
+import type { UserRole } from '../../server/data/hmppsAuthClient'
+import createUserToken from '../../server/routes/testutils/createUserToken'
 import { stubFor, getMatchingRequests } from './wiremock'
 import tokenVerification from './tokenVerification'
 import nomisUserRolesApi from './nomisUserRolesApi'
-
-const createToken = () => {
-  const payload = {
-    user_name: 'USER1',
-    scope: ['read'],
-    auth_source: 'nomis',
-    authorities: [],
-    jti: '83b50a10-cca6-41db-985f-e87efb303ddb',
-    client_id: 'clientid',
-  }
-
-  return jwt.sign(payload, 'secret', { expiresIn: '1h' })
-}
 
 const getSignInUrl = (): Promise<string> =>
   getMatchingRequests({
@@ -109,7 +97,7 @@ const token = () =>
         Location: 'http://localhost:3007/sign-in/callback?code=codexxxx&state=stateyyyy',
       },
       jsonBody: {
-        access_token: createToken(),
+        access_token: createUserToken([]),
         token_type: 'bearer',
         user_name: 'USER1',
         expires_in: 599,
@@ -140,7 +128,7 @@ const stubUser = (name: string) =>
     },
   })
 
-const stubUserRoles = () =>
+const stubUserRoles = (roles: UserRole[] = []) =>
   stubFor({
     request: {
       method: 'GET',
@@ -151,7 +139,7 @@ const stubUserRoles = () =>
       headers: {
         'Content-Type': 'application/json;charset=UTF-8',
       },
-      jsonBody: [{ roleCode: 'SOME_USER_ROLE' }],
+      jsonBody: roles,
     },
   })
 

--- a/integration_tests/mockApis/incentivesApi.ts
+++ b/integration_tests/mockApis/incentivesApi.ts
@@ -1,6 +1,8 @@
 import { SuperAgentRequest } from 'superagent'
 
 import { stubFor } from './wiremock'
+import type { IncentiveLevel, PrisonIncentiveLevel } from '../../server/data/incentivesApi'
+import { sampleIncentiveLevels, samplePrisonIncentiveLevels } from '../../server/testData/incentivesApi'
 
 export default {
   stubPing: (): SuperAgentRequest => {
@@ -16,6 +18,117 @@ export default {
       },
     })
   },
+
+  stubIncentiveLevels: (
+    options: { inactive: boolean } | { incentiveLevels: IncentiveLevel[] } = {
+      inactive: false,
+    },
+  ): SuperAgentRequest => {
+    let incentiveLevels: IncentiveLevel[]
+    if ('incentiveLevels' in options) {
+      incentiveLevels = options.incentiveLevels
+    } else {
+      incentiveLevels = options.inactive
+        ? sampleIncentiveLevels
+        : sampleIncentiveLevels.filter(incentiveLevel => incentiveLevel.active)
+    }
+
+    return stubFor({
+      request: {
+        method: 'GET',
+        urlPattern: '/incentivesApi/incentive/levels',
+      },
+      response: {
+        status: 200,
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+        jsonBody: incentiveLevels,
+      },
+    })
+  },
+
+  stubIncentiveLevel: (
+    options: { incentiveLevel: IncentiveLevel } = { incentiveLevel: sampleIncentiveLevels[1] },
+  ): SuperAgentRequest => {
+    const { incentiveLevel } = options
+
+    return stubFor({
+      request: {
+        method: 'GET',
+        urlPattern: `/incentivesApi/incentive/levels/${incentiveLevel.code}`,
+      },
+      response: {
+        status: 200,
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+        jsonBody: incentiveLevel,
+      },
+    })
+  },
+
+  stubPrisonIncentiveLevels: (
+    options: { prisonId: string } & ({ inactive: boolean } | { prisonIncentiveLevels: PrisonIncentiveLevel[] }) = {
+      prisonId: 'MDI',
+      inactive: false,
+    },
+  ): SuperAgentRequest => {
+    let prisonIncentiveLevels: PrisonIncentiveLevel[]
+    if ('prisonIncentiveLevels' in options) {
+      prisonIncentiveLevels = options.prisonIncentiveLevels
+    } else {
+      prisonIncentiveLevels = options.inactive
+        ? samplePrisonIncentiveLevels
+        : samplePrisonIncentiveLevels.filter(incentiveLevel => incentiveLevel.active)
+    }
+
+    return stubFor({
+      request: {
+        method: 'GET',
+        urlPattern: `/incentivesApi/incentive/prison-levels/${options.prisonId}`,
+      },
+      response: {
+        status: 200,
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+        jsonBody: prisonIncentiveLevels,
+      },
+    })
+  },
+
+  stubPrisonIncentiveLevel: (
+    options: { prisonIncentiveLevel: PrisonIncentiveLevel } = { prisonIncentiveLevel: samplePrisonIncentiveLevels[1] },
+  ): SuperAgentRequest => {
+    const { prisonIncentiveLevel } = options
+
+    return stubFor({
+      request: {
+        method: 'GET',
+        urlPattern: `/incentivesApi/incentive/prison-levels/${prisonIncentiveLevel.prisonId}/level/${prisonIncentiveLevel.levelCode}`,
+      },
+      response: {
+        status: 200,
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+        jsonBody: prisonIncentiveLevel,
+      },
+    })
+  },
+
+  stubPatchPrisonIncentiveLevel: (options: { prisonIncentiveLevel: PrisonIncentiveLevel }): SuperAgentRequest => {
+    const { prisonIncentiveLevel } = options
+
+    return stubFor({
+      request: {
+        method: 'PATCH',
+        urlPattern: `/incentivesApi/incentive/prison-levels/${prisonIncentiveLevel.prisonId}/level/${prisonIncentiveLevel.levelCode}`,
+      },
+      response: {
+        status: 200,
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+        jsonBody: prisonIncentiveLevel,
+      },
+    })
+  },
+
+  /**
+   * @deprecated use stubIncentiveLevels once api switches over
+   */
   stubGetAvailableLevels: (): SuperAgentRequest => {
     return stubFor({
       request: {
@@ -48,6 +161,7 @@ export default {
       },
     })
   },
+
   stubGetIncentivesLevelBasic: (): SuperAgentRequest => {
     return stubFor({
       request: {
@@ -101,6 +215,7 @@ export default {
       },
     })
   },
+
   stubGetIncentivesLevelStandard: (): SuperAgentRequest => {
     return stubFor({
       request: {
@@ -154,6 +269,7 @@ export default {
       },
     })
   },
+
   stubGetIncentivesSorted: (): SuperAgentRequest => {
     return stubFor({
       request: {

--- a/integration_tests/mockApis/wiremock.ts
+++ b/integration_tests/mockApis/wiremock.ts
@@ -1,4 +1,4 @@
-import superagent, { SuperAgentRequest, Response } from 'superagent'
+import superagent, { type SuperAgentRequest, type Response } from 'superagent'
 
 const url = 'http://localhost:9091/__admin'
 

--- a/integration_tests/pages/home.ts
+++ b/integration_tests/pages/home.ts
@@ -15,6 +15,11 @@ export default class HomePage extends Page {
 
   aboutAnalyticsPageLink = (): PageElement<HTMLAnchorElement> => cy.get('[data-test="about-data"] a')
 
+  manageIncentiveLevelsLink = (): PageElement<HTMLAnchorElement> => cy.get('[data-test="manage-incentive-levels"] a')
+
+  managePrisonIncentiveLevelsLink = (): PageElement<HTMLAnchorElement> =>
+    cy.get('[data-test="manage-prison-incentive-levels"] a')
+
   get cards(): PageElement<HTMLDivElement> {
     return cy.get('.card')
   }

--- a/integration_tests/pages/page.ts
+++ b/integration_tests/pages/page.ts
@@ -1,8 +1,8 @@
 export type PageElement<TElement = HTMLElement> = Cypress.Chainable<JQuery<TElement>>
 
 export default abstract class Page {
-  static verifyOnPage<T extends Page>(constructor: new () => T): T {
-    return new constructor()
+  static verifyOnPage<T extends Page>(constructor: new (...args: unknown[]) => T, ...args: unknown[]): T {
+    return new constructor(...args)
   }
 
   constructor(private readonly title: string) {

--- a/integration_tests/pages/page.ts
+++ b/integration_tests/pages/page.ts
@@ -13,11 +13,17 @@ export default abstract class Page {
     cy.get('h1').contains(this.title)
   }
 
-  headerUserName = (): PageElement => cy.get('[data-qa=header-user-name]')
+  get headerUserName(): PageElement<HTMLSpanElement> {
+    return cy.get('[data-qa=header-user-name]')
+  }
 
-  signOut = (): PageElement => cy.get('[data-qa=signOut]')
+  get signOut(): PageElement<HTMLAnchorElement> {
+    return cy.get('[data-qa=signOut]')
+  }
 
-  manageDetails = (): PageElement => cy.get('[data-qa=manageDetails]')
+  get manageDetails(): PageElement<HTMLAnchorElement> {
+    return cy.get('[data-qa=manageDetails]')
+  }
 
   get messages(): PageElement<HTMLDivElement> {
     return cy.get('.moj-banner')

--- a/integration_tests/pages/page.ts
+++ b/integration_tests/pages/page.ts
@@ -25,6 +25,10 @@ export default abstract class Page {
     return cy.get('[data-qa=manageDetails]')
   }
 
+  get breadcrumbs(): PageElement<HTMLDivElement> {
+    return cy.get('.govuk-breadcrumbs')
+  }
+
   get messages(): PageElement<HTMLDivElement> {
     return cy.get('.moj-banner')
   }

--- a/integration_tests/pages/prisonIncentiveLevels/prisonIncentiveLevel.ts
+++ b/integration_tests/pages/prisonIncentiveLevels/prisonIncentiveLevel.ts
@@ -1,0 +1,42 @@
+import Page, { type PageElement } from '../page'
+
+export default class PrisonIncentiveLevelPage extends Page {
+  constructor(private readonly levelName: string = 'Standard') {
+    super(`View settings for ${levelName}`)
+  }
+
+  checkLastBreadcrumb() {
+    this.breadcrumbs.last().should('contain.text', `View settings for ${this.levelName}`)
+  }
+
+  get tables(): PageElement<HTMLTableElement> {
+    return cy.get('.govuk-table')
+  }
+
+  get contentsOfTables(): Cypress.Chainable<Record<string, string>[]> {
+    return this.tables.then($tables => {
+      const contentsOfTables: Record<string, string>[] = $tables
+        .map<Record<string, string>>((_index, table) => {
+          const contentsOfTable: [string, string][] = []
+          const rows = table.getElementsByTagName('tr')
+          for (let index = 0; index < rows.length; index += 1) {
+            const row = rows[index]
+            const cells = row.getElementsByTagName('td')
+            const [nameCell, valueCell] = [cells[0], cells[1]]
+            contentsOfTable.push([nameCell.textContent.trim(), valueCell.textContent.trim()])
+          }
+          return Object.fromEntries(contentsOfTable)
+        })
+        .toArray()
+      return cy.wrap(contentsOfTables)
+    })
+  }
+
+  get changeLink(): PageElement<HTMLAnchorElement> {
+    return cy.get('a:contains(Change)')
+  }
+
+  get returnLink(): PageElement<HTMLAnchorElement> {
+    return cy.get('a:contains(Return)')
+  }
+}

--- a/integration_tests/pages/prisonIncentiveLevels/prisonIncentiveLevelAddForm.ts
+++ b/integration_tests/pages/prisonIncentiveLevels/prisonIncentiveLevelAddForm.ts
@@ -1,0 +1,23 @@
+import Page, { type PageElement } from '../page'
+
+export default class PrisonIncentiveLevelAddFormPage extends Page {
+  constructor() {
+    super('Add a new incentive level')
+  }
+
+  checkLastBreadcrumb() {
+    this.breadcrumbs.last().should('contain.text', 'Add a new incentive level')
+  }
+
+  get form(): PageElement<HTMLFormElement> {
+    return cy.get('#form-prisonIncentiveLevelAddForm')
+  }
+
+  get levelCodeRadios(): PageElement<HTMLDivElement> {
+    return this.form.find('.govuk-radios__item')
+  }
+
+  getInputField(name: string): PageElement<HTMLInputElement> {
+    return this.form.find(`[name=${name}]`)
+  }
+}

--- a/integration_tests/pages/prisonIncentiveLevels/prisonIncentiveLevelDeactivateForm.ts
+++ b/integration_tests/pages/prisonIncentiveLevels/prisonIncentiveLevelDeactivateForm.ts
@@ -1,0 +1,19 @@
+import Page, { type PageElement } from '../page'
+
+export default class PrisonIncentiveLevelDeactivateFormPage extends Page {
+  constructor(private readonly levelName: string = 'Standard') {
+    super(`Are you sure you want to remove ${levelName}?`)
+  }
+
+  checkLastBreadcrumb() {
+    this.breadcrumbs.last().should('contain.text', `Are you sure you want to remove ${this.levelName}?`)
+  }
+
+  get form(): PageElement<HTMLFormElement> {
+    return cy.get('#form-prisonIncentiveLevelDeactivateForm')
+  }
+
+  get confirmationRadios(): PageElement<HTMLDivElement> {
+    return this.form.find('.govuk-radios__item')
+  }
+}

--- a/integration_tests/pages/prisonIncentiveLevels/prisonIncentiveLevelEditForm.ts
+++ b/integration_tests/pages/prisonIncentiveLevels/prisonIncentiveLevelEditForm.ts
@@ -1,0 +1,19 @@
+import Page, { type PageElement } from '../page'
+
+export default class PrisonIncentiveLevelEditFormPage extends Page {
+  constructor(private readonly levelName: string = 'Standard') {
+    super(`Change settings for ${levelName}`)
+  }
+
+  checkLastBreadcrumb() {
+    this.breadcrumbs.last().should('contain.text', `Change settings for ${this.levelName}`)
+  }
+
+  get form(): PageElement<HTMLFormElement> {
+    return cy.get('#form-prisonIncentiveLevelEditForm')
+  }
+
+  getInputField(name: string): PageElement<HTMLInputElement> {
+    return this.form.find(`[name=${name}]`)
+  }
+}

--- a/integration_tests/pages/prisonIncentiveLevels/prisonIncentiveLevels.ts
+++ b/integration_tests/pages/prisonIncentiveLevels/prisonIncentiveLevels.ts
@@ -1,0 +1,38 @@
+import Page, { type PageElement } from '../page'
+
+export default class PrisonIncentiveLevelsPage extends Page {
+  constructor() {
+    super('Incentive level settings')
+  }
+
+  checkLastBreadcrumb() {
+    this.breadcrumbs.last().should('contain.text', 'Incentive level settings')
+  }
+
+  get table(): PageElement<HTMLTableElement> {
+    return cy.get('.govuk-table')
+  }
+
+  get contentsOfTable(): Cypress.Chainable<Record<string, [string, string]>> {
+    return this.table.then($table => {
+      const contentsOfTable: [string, [string, string]][] = []
+      const rows = $table[0].getElementsByTagName('tr')
+      for (let index = 0; index < rows.length; index += 1) {
+        const row = rows[index]
+        const levelCell = row.getElementsByTagName('th')[0]
+        const cells = row.getElementsByTagName('td')
+        const [tagCell, linkCell] = [cells[0], cells[1]]
+        contentsOfTable.push([levelCell.textContent.trim(), [tagCell.textContent.trim(), linkCell.textContent.trim()]])
+      }
+      return cy.wrap(Object.fromEntries(contentsOfTable))
+    })
+  }
+
+  findTableLink(row: number, text: string): PageElement<HTMLAnchorElement> {
+    return this.table.find('tr').eq(row).find('td:last').scrollIntoView().find(`a:contains(${text})`)
+  }
+
+  get addLink(): PageElement<HTMLAnchorElement> {
+    return cy.get('a:contains(Add)')
+  }
+}

--- a/integration_tests/pages/prisonIncentiveLevels/prisonIncentiveLevels.ts
+++ b/integration_tests/pages/prisonIncentiveLevels/prisonIncentiveLevels.ts
@@ -1,5 +1,7 @@
 import Page, { type PageElement } from '../page'
 
+type TableRowContents = { tags: string; viewAction: string; removeAction: string | undefined }
+
 export default class PrisonIncentiveLevelsPage extends Page {
   constructor() {
     super('Incentive level settings')
@@ -13,23 +15,28 @@ export default class PrisonIncentiveLevelsPage extends Page {
     return cy.get('.govuk-table')
   }
 
-  get contentsOfTable(): Cypress.Chainable<Record<string, [string, string]>> {
+  get contentsOfTable(): Cypress.Chainable<Record<string, TableRowContents>> {
     return this.table.then($table => {
-      const contentsOfTable: [string, [string, string]][] = []
+      const contentsOfTable: [string, TableRowContents][] = []
       const rows = $table[0].getElementsByTagName('tr')
       for (let index = 0; index < rows.length; index += 1) {
         const row = rows[index]
         const levelCell = row.getElementsByTagName('th')[0]
         const cells = row.getElementsByTagName('td')
-        const [tagCell, linkCell] = [cells[0], cells[1]]
-        contentsOfTable.push([levelCell.textContent.trim(), [tagCell.textContent.trim(), linkCell.textContent.trim()]])
+        const [tagCell, viewCell, removeCell] = [cells[0], cells[1], cells[2]]
+        const contents = {
+          tags: tagCell.textContent.trim(),
+          viewAction: viewCell.textContent.trim(),
+          removeAction: removeCell?.textContent?.trim(),
+        }
+        contentsOfTable.push([levelCell.textContent.trim(), contents])
       }
       return cy.wrap(Object.fromEntries(contentsOfTable))
     })
   }
 
   findTableLink(row: number, text: string): PageElement<HTMLAnchorElement> {
-    return this.table.find('tr').eq(row).find('td:last').scrollIntoView().find(`a:contains(${text})`)
+    return this.table.find('tr').eq(row).scrollIntoView().find(`a:contains(${text})`)
   }
 
   get addLink(): PageElement<HTMLAnchorElement> {

--- a/integration_tests/plugins/index.ts
+++ b/integration_tests/plugins/index.ts
@@ -20,6 +20,11 @@ export default (on: (string, Record) => void): void => {
     stubGetIncentivesLevelStandard: incentivesApi.stubGetIncentivesLevelStandard,
     stubGetIncentivesSorted: incentivesApi.stubGetIncentivesSorted,
 
+    stubIncentiveLevels: incentivesApi.stubIncentiveLevels,
+    stubIncentiveLevel: incentivesApi.stubIncentiveLevel,
+    stubPrisonIncentiveLevels: incentivesApi.stubPrisonIncentiveLevels,
+    stubPrisonIncentiveLevel: incentivesApi.stubPrisonIncentiveLevel,
+
     stubNomisUserRolesApiPing: nomisUserRolesApi.stubPing,
     stubNomisUserRolesApiUserCaseloads: nomisUserRolesApi.stubGetUserCaseloads,
 

--- a/integration_tests/plugins/index.ts
+++ b/integration_tests/plugins/index.ts
@@ -24,6 +24,7 @@ export default (on: (string, Record) => void): void => {
     stubIncentiveLevel: incentivesApi.stubIncentiveLevel,
     stubPrisonIncentiveLevels: incentivesApi.stubPrisonIncentiveLevels,
     stubPrisonIncentiveLevel: incentivesApi.stubPrisonIncentiveLevel,
+    stubPatchPrisonIncentiveLevel: incentivesApi.stubPatchPrisonIncentiveLevel,
 
     stubNomisUserRolesApiPing: nomisUserRolesApi.stubPing,
     stubNomisUserRolesApiUserCaseloads: nomisUserRolesApi.stubGetUserCaseloads,

--- a/server/routes/forms/prisonIncentiveLevelAddForm.test.ts
+++ b/server/routes/forms/prisonIncentiveLevelAddForm.test.ts
@@ -17,16 +17,22 @@ describe('PrisonIncentiveLevelAddForm', () => {
   }
 
   it.each(validLevelCodes)('with valid data: %s', (levelCode: string) => {
-    const form = new PrisonIncentiveLevelAddForm(formId, validLevelCodes)
+    const form = new PrisonIncentiveLevelAddForm(formId, validLevelCodes, false)
     form.submit({ ...validBaseData, levelCode })
     expect(form.hasErrors).toBeFalsy()
   })
 
   it.each([undefined, null, '', 'EN2', 'bas'])('with invalid data: %s', (levelCode: unknown) => {
-    const form = new PrisonIncentiveLevelAddForm(formId, validLevelCodes)
+    const form = new PrisonIncentiveLevelAddForm(formId, validLevelCodes, false)
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
     form.submit({ ...validBaseData, levelCode })
+    expect(form.hasErrors).toBeTruthy()
+  })
+
+  it('when defaultOnAdmission is required but not checked', () => {
+    const form = new PrisonIncentiveLevelAddForm(formId, validLevelCodes, true)
+    form.submit({ ...validBaseData, levelCode: 'STD' })
     expect(form.hasErrors).toBeTruthy()
   })
 })

--- a/server/routes/forms/prisonIncentiveLevelAddForm.ts
+++ b/server/routes/forms/prisonIncentiveLevelAddForm.ts
@@ -15,7 +15,7 @@ export default class PrisonIncentiveLevelAddForm extends PrisonIncentiveLevelEdi
 
   protected validate(): void {
     if (!this.validLevelCodes.includes(this.data.levelCode)) {
-      this.addError('levelCode', 'Please select a level to add')
+      this.addError('levelCode', 'Select a level to add')
     }
 
     super.validate()

--- a/server/routes/forms/prisonIncentiveLevelAddForm.ts
+++ b/server/routes/forms/prisonIncentiveLevelAddForm.ts
@@ -5,8 +5,12 @@ export interface PrisonIncentiveLevelAddData extends PrisonIncentiveLevelEditDat
 }
 
 export default class PrisonIncentiveLevelAddForm extends PrisonIncentiveLevelEditForm<PrisonIncentiveLevelAddData> {
-  constructor(formId: string, private readonly validLevelCodes: string[]) {
-    super(formId)
+  protected mustBeDefaultOnAdmissionError =
+    'The first level added must be the default level for new prisoners. ' +
+    'You can change this later when adding other levels.'
+
+  constructor(formId: string, private readonly validLevelCodes: string[], mustBeDefaultOnAdmission: boolean) {
+    super(formId, mustBeDefaultOnAdmission)
   }
 
   protected validate(): void {

--- a/server/routes/forms/prisonIncentiveLevelDeactivateForm.ts
+++ b/server/routes/forms/prisonIncentiveLevelDeactivateForm.ts
@@ -7,7 +7,7 @@ export interface PrisonIncentiveLevelDeactivateData extends BaseFormData {
 export default class PrisonIncentiveLevelDeactivateForm extends Form<PrisonIncentiveLevelDeactivateData> {
   protected validate(): void {
     if (!['yes', 'no'].includes(this.data.confirmation)) {
-      this.addError('confirmation', 'Please select yes or no')
+      this.addError('confirmation', 'Select yes or no')
     }
   }
 }

--- a/server/routes/forms/prisonIncentiveLevelEditForm.test.ts
+++ b/server/routes/forms/prisonIncentiveLevelEditForm.test.ts
@@ -24,7 +24,7 @@ describe('PrisonIncentiveLevelEditForm', () => {
     },
   ]
   it.each(validData)('with valid data', (testCase: Partial<PrisonIncentiveLevelEditData>) => {
-    const form = new PrisonIncentiveLevelEditForm(formId)
+    const form = new PrisonIncentiveLevelEditForm(formId, false)
     form.submit({ formId, ...testCase })
     expect(form.hasErrors).toBeFalsy()
   })
@@ -67,7 +67,7 @@ describe('PrisonIncentiveLevelEditForm', () => {
     ],
   ]
   it.each(invalidData)('with invalid data: %s', (_, testCase: unknown) => {
-    const form = new PrisonIncentiveLevelEditForm(formId)
+    const form = new PrisonIncentiveLevelEditForm(formId, false)
     form.submit({ formId, ...(testCase as Partial<PrisonIncentiveLevelEditData>) })
     expect(form.hasErrors).toBeTruthy()
   })
@@ -81,7 +81,7 @@ describe('PrisonIncentiveLevelEditForm', () => {
     'privilegedVisitOrders',
   ]
   describe.each(currencyFields)('with invalid %s field', (amountFiend: keyof PrisonIncentiveLevelEditData) => {
-    const form = new PrisonIncentiveLevelEditForm(formId)
+    const form = new PrisonIncentiveLevelEditForm(formId, false)
 
     it.each(['', 'one', '£1.00', '1.1', '-1', '1.000'])('having value %s', (value: string) => {
       // valid data
@@ -102,5 +102,21 @@ describe('PrisonIncentiveLevelEditForm', () => {
       form.submit(data)
       expect(form.hasErrors).toBeTruthy()
     })
+  })
+
+  it('when defaultOnAdmission is required but unchecked', () => {
+    const form = new PrisonIncentiveLevelEditForm(formId, true)
+    const data: PrisonIncentiveLevelEditData = {
+      formId,
+      remandTransferLimit: '60.50',
+      remandSpendLimit: '605.00',
+      convictedTransferLimit: '30.90',
+      convictedSpendLimit: '309.00',
+
+      visitOrders: '1',
+      privilegedVisitOrders: '1',
+    }
+    form.submit(data)
+    expect(form.hasErrors).toBeTruthy()
   })
 })

--- a/server/routes/forms/prisonIncentiveLevelEditForm.ts
+++ b/server/routes/forms/prisonIncentiveLevelEditForm.ts
@@ -16,9 +16,18 @@ export interface PrisonIncentiveLevelEditData extends BaseFormData {
 export default class PrisonIncentiveLevelEditForm<
   Data extends PrisonIncentiveLevelEditData = PrisonIncentiveLevelEditData,
 > extends Form<Data> {
+  protected mustBeDefaultOnAdmissionError =
+    'There must be a default level for new prisoners. Please select another one to be the default first.'
+
+  constructor(formId: string, protected readonly mustBeDefaultOnAdmission: boolean) {
+    super(formId)
+  }
+
   protected validate(): void {
     if (this.data.defaultOnAdmission && this.data.defaultOnAdmission !== 'yes') {
       this.addError('defaultOnAdmission', 'Invalid value')
+    } else if (this.mustBeDefaultOnAdmission && this.data.defaultOnAdmission !== 'yes') {
+      this.addError('defaultOnAdmission', this.mustBeDefaultOnAdmissionError)
     }
 
     if (!currencyInputRE.test(this.data.remandTransferLimit)) {

--- a/server/routes/forms/prisonIncentiveLevelEditForm.ts
+++ b/server/routes/forms/prisonIncentiveLevelEditForm.ts
@@ -31,17 +31,17 @@ export default class PrisonIncentiveLevelEditForm<
     }
 
     if (!currencyInputRE.test(this.data.remandTransferLimit)) {
-      this.addError('remandTransferLimit', 'Remand transfer limit must be in pounds and pence')
+      this.addError('remandTransferLimit', 'Transfer limit for remand prisoners must be in pounds and pence')
     }
     if (!currencyInputRE.test(this.data.convictedTransferLimit)) {
-      this.addError('convictedTransferLimit', 'Convicted transfer limit must be in pounds and pence')
+      this.addError('convictedTransferLimit', 'Transfer limit for convicted prisoners must be in pounds and pence')
     }
 
     if (!currencyInputRE.test(this.data.remandSpendLimit)) {
-      this.addError('remandSpendLimit', 'Remand spend limit must be in pounds and pence')
+      this.addError('remandSpendLimit', 'Spend limit for remand prisoners must be in pounds and pence')
     }
     if (!currencyInputRE.test(this.data.convictedSpendLimit)) {
-      this.addError('convictedSpendLimit', 'Convicted spend limit must be in pounds and pence')
+      this.addError('convictedSpendLimit', 'Spend limit for convicted prisoners must be in pounds and pence')
     }
 
     const number = /^\d+$/

--- a/server/routes/prisonIncentiveLevels.test.ts
+++ b/server/routes/prisonIncentiveLevels.test.ts
@@ -324,6 +324,24 @@ describe('Prison incentive level management', () => {
           })
       })
 
+      it('should show error message returned by api', () => {
+        incentivesApi.updatePrisonIncentiveLevel.mockRejectedValue({
+          status: 400,
+          userMessage: 'Validation failure: A level must be active if it is required',
+          developerMessage: 'A level must be active if it is required',
+        })
+
+        return request(app)
+          .post('/prison-incentive-levels/remove/EN2')
+          .set('authorization', `bearer ${tokenWithNecessaryRole}`)
+          .send({ formId: 'prisonIncentiveLevelDeactivateForm', confirmation: 'yes' })
+          .redirects(1)
+          .expect(res => {
+            expect(res.text).toContain('Incentive level was not removed!')
+            expect(res.text).toContain('A level must be active if it is required')
+          })
+      })
+
       it('should deactivate level if confirmed', () => {
         incentivesApi.updatePrisonIncentiveLevel.mockResolvedValue({
           ...samplePrisonIncentiveLevels[2],
@@ -495,6 +513,36 @@ describe('Prison incentive level management', () => {
             expect(errorSummary.text()).toContain(errorMessage)
 
             expect(incentivesApi.updatePrisonIncentiveLevel).not.toHaveBeenCalled()
+          })
+      })
+
+      it('should show error message returned by api', () => {
+        incentivesApi.updatePrisonIncentiveLevel.mockRejectedValue({
+          status: 400,
+          userMessage: 'Validation failure: There must be an active default level for admission in a prison',
+          developerMessage: 'There must be an active default level for admission in a prison',
+        })
+
+        const validForm: PrisonIncentiveLevelEditData = {
+          formId: 'prisonIncentiveLevelEditForm',
+
+          remandTransferLimit: '60.50',
+          remandSpendLimit: '605',
+          convictedTransferLimit: '19.80',
+          convictedSpendLimit: '198',
+
+          visitOrders: '1',
+          privilegedVisitOrders: '1',
+        }
+
+        return request(app)
+          .post('/prison-incentive-levels/edit/STD')
+          .set('authorization', `bearer ${tokenWithNecessaryRole}`)
+          .send(validForm)
+          .redirects(1)
+          .expect(res => {
+            expect(res.text).toContain('Incentive level settings were not saved!')
+            expect(res.text).toContain('There must be an active default level for admission in a prison')
           })
       })
 
@@ -751,6 +799,38 @@ describe('Prison incentive level management', () => {
             expect(errorSummary.text()).toContain(errorMessage)
 
             expect(incentivesApi.updatePrisonIncentiveLevel).not.toHaveBeenCalled()
+          })
+      })
+
+      it('should show error message returned by api', () => {
+        incentivesApi.updatePrisonIncentiveLevel.mockRejectedValue({
+          status: 400,
+          userMessage: 'Validation failure: There must be an active default level for admission in a prison',
+          developerMessage: 'There must be an active default level for admission in a prison',
+        })
+
+        const validForm: PrisonIncentiveLevelAddData = {
+          formId: 'prisonIncentiveLevelAddForm',
+
+          levelCode: 'EN2',
+
+          remandTransferLimit: '66',
+          remandSpendLimit: '660',
+          convictedTransferLimit: '44',
+          convictedSpendLimit: '440',
+
+          visitOrders: '1',
+          privilegedVisitOrders: '3',
+        }
+
+        return request(app)
+          .post('/prison-incentive-levels/add')
+          .set('authorization', `bearer ${tokenWithNecessaryRole}`)
+          .send(validForm)
+          .redirects(1)
+          .expect(res => {
+            expect(res.text).toContain('Incentive level was not added!')
+            expect(res.text).toContain('There must be an active default level for admission in a prison')
           })
       })
 

--- a/server/routes/prisonIncentiveLevels.test.ts
+++ b/server/routes/prisonIncentiveLevels.test.ts
@@ -88,7 +88,7 @@ describe('Prison incentive level management', () => {
         })
     })
 
-    it('should lable the default level for new prisoners', () => {
+    it('should label the default level for new prisoners', () => {
       const $ = jquery(new JSDOM().window) as unknown as typeof jquery
 
       return request(app)
@@ -127,8 +127,9 @@ describe('Prison incentive level management', () => {
           const $tableRows = $body.find('[data-qa="prison-incentive-levels-table"] tbody tr')
           const linkTexts = $tableRows
             .map((_index, tr) => {
-              const linkCell = $(tr).find('td')[1]
-              return linkCell.textContent
+              const $cells = $(tr).find('td')
+              expect($cells).toHaveLength(3)
+              return $cells[2].textContent
             })
             .toArray()
           expect(linkTexts).toHaveLength(3)

--- a/server/routes/prisonIncentiveLevels.test.ts
+++ b/server/routes/prisonIncentiveLevels.test.ts
@@ -352,7 +352,7 @@ describe('Prison incentive level management', () => {
           .set('authorization', `bearer ${tokenWithNecessaryRole}`)
           .send({ formId: 'prisonIncentiveLevelDeactivateForm' })
           .expect(res => {
-            expect(res.text).toContain('Please select yes or no')
+            expect(res.text).toContain('Select yes or no')
             expect(incentivesApi.updatePrisonIncentiveLevel).not.toHaveBeenCalled()
           })
       })
@@ -516,7 +516,7 @@ describe('Prison incentive level management', () => {
             visitOrders: '1',
             privilegedVisitOrders: '1',
           },
-          'Remand transfer limit must be in pounds and pence',
+          'Transfer limit for remand prisoners must be in pounds and pence',
         ],
         [
           'empty number field',
@@ -823,7 +823,7 @@ describe('Prison incentive level management', () => {
             visitOrders: '1',
             privilegedVisitOrders: '1',
           },
-          'Please select a level to add',
+          'Select a level to add',
         ],
         [
           'unavailable level chosen',
@@ -839,7 +839,7 @@ describe('Prison incentive level management', () => {
             visitOrders: '1',
             privilegedVisitOrders: '1',
           },
-          'Please select a level to add',
+          'Select a level to add',
         ],
         [
           'mistyped amount',
@@ -855,7 +855,7 @@ describe('Prison incentive level management', () => {
             visitOrders: '1',
             privilegedVisitOrders: '1',
           },
-          'Remand spend limit must be in pounds and pence',
+          'Spend limit for remand prisoners must be in pounds and pence',
         ],
         [
           'mistyped number',

--- a/server/routes/prisonIncentiveLevels.test.ts
+++ b/server/routes/prisonIncentiveLevels.test.ts
@@ -283,6 +283,38 @@ describe('Prison incentive level management', () => {
         })
     })
 
+    it('should indicate bad request if level is default for admissions', () => {
+      incentivesApi.getIncentiveLevel.mockResolvedValue({ ...sampleIncentiveLevels[1], required: false })
+      incentivesApi.getPrisonIncentiveLevel.mockResolvedValue(samplePrisonIncentiveLevels[1])
+
+      return request(app)
+        .get('/prison-incentive-levels/remove/STD')
+        .set('authorization', `bearer ${tokenWithNecessaryRole}`)
+        .expect(400)
+        .expect(() => {
+          expect(incentivesApi.updatePrisonIncentiveLevel).not.toHaveBeenCalled()
+        })
+    })
+
+    it('should indicate bad request if level is default for admissions (POST)', () => {
+      incentivesApi.getIncentiveLevel.mockResolvedValue({ ...sampleIncentiveLevels[1], required: false })
+      incentivesApi.getPrisonIncentiveLevel.mockResolvedValue(samplePrisonIncentiveLevels[1])
+
+      const validForm: PrisonIncentiveLevelDeactivateData = {
+        formId: 'prisonIncentiveLevelDeactivateForm',
+        confirmation: 'yes',
+      }
+
+      return request(app)
+        .post('/prison-incentive-levels/remove/STD')
+        .set('authorization', `bearer ${tokenWithNecessaryRole}`)
+        .send(validForm)
+        .expect(400)
+        .expect(() => {
+          expect(incentivesApi.updatePrisonIncentiveLevel).not.toHaveBeenCalled()
+        })
+    })
+
     describe('when deactivation is allowed', () => {
       beforeEach(() => {
         // pretend that ENH is not globally required

--- a/server/routes/prisonIncentiveLevels.ts
+++ b/server/routes/prisonIncentiveLevels.ts
@@ -115,7 +115,7 @@ export default function routes(router: Router): Router {
           req.flash('success', message)
         } catch (error) {
           logger.error('Failed to deactivate prison incentive level', error)
-          // TODO: handle errors
+          req.flash('warning', `Incentive level was not removed! ${error?.userMessage || ''}`)
         }
       }
 
@@ -212,7 +212,7 @@ export default function routes(router: Router): Router {
         logger.info(message)
       } catch (error) {
         logger.error('Failed to update prison incentive level', error)
-        // TODO: handle errors
+        req.flash('warning', `Incentive level settings were not saved! ${error?.userMessage || ''}`)
       }
 
       res.redirect(`/prison-incentive-levels/view/${levelCode}`)
@@ -339,7 +339,7 @@ export default function routes(router: Router): Router {
         res.redirect(`/prison-incentive-levels/view/${levelCode}`)
       } catch (error) {
         logger.error('Failed to update prison incentive level', error)
-        // TODO: handle errors
+        req.flash('warning', `Incentive level was not added! ${error?.userMessage || ''}`)
         res.redirect('/prison-incentive-levels')
       }
     }),

--- a/server/routes/prisonIncentiveLevels.ts
+++ b/server/routes/prisonIncentiveLevels.ts
@@ -32,12 +32,16 @@ export default function routes(router: Router): Router {
       prisonIncentiveLevels.map(prisonIncentiveLevel => {
         return { ...prisonIncentiveLevel, levelRequired: requiredLevelCodes.has(prisonIncentiveLevel.levelCode) }
       })
+    const canRemoveLevel = prisonIncentiveLevelsWithRequiredFlag.some(
+      prisonIncentiveLevel => !prisonIncentiveLevel.levelRequired && !prisonIncentiveLevel.defaultOnAdmission,
+    )
 
     res.locals.breadcrumbs.addItems({ text: 'Incentive level settings' })
     res.render('pages/prisonIncentiveLevels.njk', {
       messages: req.flash(),
       prisonIncentiveLevels: prisonIncentiveLevelsWithRequiredFlag,
       canAddLevel,
+      canRemoveLevel,
       prisonName,
     })
   })

--- a/server/routes/prisonIncentiveLevels.ts
+++ b/server/routes/prisonIncentiveLevels.ts
@@ -102,6 +102,9 @@ export default function routes(router: Router): Router {
         if (!prisonIncentiveLevel.active) {
           throw BadRequest('Prison incentive level is already inactive')
         }
+        if (prisonIncentiveLevel.defaultOnAdmission) {
+          throw BadRequest('Default prison incentive level cannot be deactivated')
+        }
         if (incentiveLevel.required) {
           throw BadRequest('Incentive level is required globally')
         }
@@ -134,6 +137,9 @@ export default function routes(router: Router): Router {
       ])
       if (!prisonIncentiveLevel.active) {
         throw BadRequest('Prison incentive level is already inactive')
+      }
+      if (prisonIncentiveLevel.defaultOnAdmission) {
+        throw BadRequest('Default prison incentive level cannot be deactivated')
       }
       if (incentiveLevel.required) {
         throw BadRequest('Incentive level is required globally')

--- a/server/views/pages/prisonIncentiveLevels.njk
+++ b/server/views/pages/prisonIncentiveLevels.njk
@@ -26,26 +26,38 @@
       {% set rows = [] %}
 
       {% for prisonIncentiveLevel in prisonIncentiveLevels %}
-        {% set tags %}
+        {% set tags -%}
           {% if prisonIncentiveLevel.defaultOnAdmission %}
-            {{ govukTag({
-              html: "Default <span class='govuk-visually-hidden'>level for new prisoners</span>"
-            }) }}
+            {% set tagHtml %}
+              Default <span class="govuk-visually-hidden">level for new prisoners</span>
+            {% endset %}
+            {{ govukTag({ html: tagHtml }) }}
           {% endif %}
-        {% endset %}
+        {%- endset %}
 
-        {% set actions %}
+        {% set viewAction -%}
           <a href="/prison-incentive-levels/view/{{ prisonIncentiveLevel.levelCode }}">View settings</a>
-          {% if not prisonIncentiveLevel.levelRequired and not prisonIncentiveLevel.defaultOnAdmission %}
-            <a href="/prison-incentive-levels/remove/{{ prisonIncentiveLevel.levelCode }}" class="govuk-!-margin-left-4">Remove level</a>
-          {% endif %}
-        {% endset %}
+        {%- endset %}
 
-        {% set rows = (rows.push([
+        {% set removeAction -%}
+          {% if not prisonIncentiveLevel.levelRequired and not prisonIncentiveLevel.defaultOnAdmission %}
+            <a href="/prison-incentive-levels/remove/{{ prisonIncentiveLevel.levelCode }}">Remove level</a>
+          {% endif %}
+        {%- endset %}
+
+        {% set row = [
           { text: prisonIncentiveLevel.levelName },
           { html: tags },
-          { html: actions }
-        ]), rows) %}
+          { html: viewAction, classes: "govuk-!-text-align-right" }
+        ] %}
+
+        {% if canRemoveLevel %}
+          {% set row = (row.push(
+            { html: removeAction, classes: "govuk-!-text-align-right" }
+          ), row) %}
+        {% endif %}
+
+        {% set rows = (rows.push(row), rows) %}
       {% endfor %}
 
       {{ govukTable({

--- a/server/views/pages/prisonIncentiveLevels.njk
+++ b/server/views/pages/prisonIncentiveLevels.njk
@@ -36,7 +36,7 @@
 
         {% set actions %}
           <a href="/prison-incentive-levels/view/{{ prisonIncentiveLevel.levelCode }}">View settings</a>
-          {% if not prisonIncentiveLevel.levelRequired %}
+          {% if not prisonIncentiveLevel.levelRequired and not prisonIncentiveLevel.defaultOnAdmission %}
             <a href="/prison-incentive-levels/remove/{{ prisonIncentiveLevel.levelCode }}" class="govuk-!-margin-left-4">Remove level</a>
           {% endif %}
         {% endset %}

--- a/server/views/partials/prisonIncentiveLevelEditPartial.njk
+++ b/server/views/partials/prisonIncentiveLevelEditPartial.njk
@@ -2,8 +2,16 @@
 {% from "govuk/components/fieldset/macro.njk" import govukFieldset %}
 {% from "govuk/components/input/macro.njk" import govukInput %}
 
+{% set fieldId = "defaultOnAdmission" %}
+{% set field = form.getField(fieldId) %}
+{% if form.submitted %}
+  {% set defaultOnAdmission = field.value == "yes" %}
+{% else %}
+  {% set defaultOnAdmission = mustBeDefaultOnAdmission or prisonIncentiveLevel.defaultOnAdmission if prisonIncentiveLevel else false %}
+{% endif %}
 {{ govukCheckboxes({
-  name: "defaultOnAdmission",
+  attributes: { id: form.formId + "-" + fieldId },
+  name: fieldId,
   fieldset: {
     legend: {
       text: "Default incentive level",
@@ -14,9 +22,10 @@
     {
       value: "yes",
       text: "Make this the default level for new prisoners in your establishment",
-      checked: prisonIncentiveLevel.defaultOnAdmission if prisonIncentiveLevel else false
+      checked: defaultOnAdmission
     }
-  ]
+  ],
+  errorMessage: { text: field.error } if field.error else undefined
 }) }}
 
 <h2 class="govuk-heading-l govuk-!-margin-top-8">


### PR DESCRIPTION
Improves on #444 by
• adding integration tests to test end-to-end user journeys
• preventing actions that would result in no level being the default in a prison