### PR TITLE
Remove global incentive level descriptions

### DIFF
--- a/server/data/incentivesApi.ts
+++ b/server/data/incentivesApi.ts
@@ -4,7 +4,6 @@ import RestClient from './restClient'
 export interface IncentiveLevel {
   code: string
   name: string
-  description: string
   active: boolean
   required: boolean
 }

--- a/server/routes/forms/incentiveLevelForm.ts
+++ b/server/routes/forms/incentiveLevelForm.ts
@@ -3,7 +3,6 @@ import Form, { type BaseFormData } from './forms'
 export interface IncentiveLevelData extends BaseFormData {
   code?: string
   name: string
-  description: string
   availability: 'required' | 'active' | 'inactive'
 }
 

--- a/server/routes/incentiveLevels.ts
+++ b/server/routes/incentiveLevels.ts
@@ -123,7 +123,6 @@ export default function routes(router: Router): Router {
         try {
           const updatedIncentiveLevel = await incentivesApi.updateIncentiveLevel(levelCode, {
             name: form.getField('name').value,
-            description: form.getField('description').value || '',
             active,
             required,
           })
@@ -138,7 +137,6 @@ export default function routes(router: Router): Router {
           const createdIncentiveLevel = await incentivesApi.createIncentiveLevel({
             code: form.getField('code').value,
             name: form.getField('name').value,
-            description: form.getField('description').value || '',
             active,
             required,
           })

--- a/server/testData/incentivesApi.ts
+++ b/server/testData/incentivesApi.ts
@@ -1,12 +1,12 @@
 import type { IncentivesReviewsResponse, IncentiveLevel, PrisonIncentiveLevel } from '../data/incentivesApi'
 
 export const sampleIncentiveLevels: IncentiveLevel[] = [
-  { code: 'BAS', name: 'Basic', description: '', active: true, required: true },
-  { code: 'STD', name: 'Standard', description: '', active: true, required: true },
-  { code: 'ENH', name: 'Enhanced', description: '', active: true, required: true },
-  { code: 'EN2', name: 'Enhanced 2', description: '', active: true, required: false },
-  { code: 'EN3', name: 'Enhanced 3', description: '', active: true, required: false },
-  { code: 'ENT', name: 'Entry', description: '', active: false, required: false },
+  { code: 'BAS', name: 'Basic', active: true, required: true },
+  { code: 'STD', name: 'Standard', active: true, required: true },
+  { code: 'ENH', name: 'Enhanced', active: true, required: true },
+  { code: 'EN2', name: 'Enhanced 2', active: true, required: false },
+  { code: 'EN3', name: 'Enhanced 3', active: true, required: false },
+  { code: 'ENT', name: 'Entry', active: false, required: false },
 ]
 
 export const samplePrisonIncentiveLevels: PrisonIncentiveLevel[] = [

--- a/server/views/pages/incentiveLevel.njk
+++ b/server/views/pages/incentiveLevel.njk
@@ -40,10 +40,6 @@
             value: { text: incentiveLevel.name }
           },
           {
-            key: { text: "Description" },
-            value: { text: incentiveLevel.description }
-          },
-          {
             key: { text: "Availability" },
             value: { text: availability }
           }

--- a/server/views/pages/incentiveLevelForm.njk
+++ b/server/views/pages/incentiveLevelForm.njk
@@ -56,18 +56,6 @@
           errorMessage: { text: field.error } if field.error else undefined
         }) }}
 
-        {% set fieldId = "description" %}
-        {% set field = form.getField(fieldId) %}
-        {{ govukInput({
-          label: { text: "Description" },
-          classes: "govuk-!-width-two-thirds",
-          id: form.formId + "-" + fieldId,
-          name: fieldId,
-          value: field.value,
-          spellcheck: true,
-          errorMessage: { text: field.error } if field.error else undefined
-        }) }}
-
         {% set fieldId = "availability" %}
         {% set field = form.getField(fieldId) %}
         {{ govukRadios({

--- a/server/views/pages/prisonIncentiveLevelAddForm.njk
+++ b/server/views/pages/prisonIncentiveLevelAddForm.njk
@@ -22,9 +22,6 @@
         {% for incentiveLevel in availableUnusedIncentiveLevels %}
           {% set levelChoices = (levelChoices.push({
             text: incentiveLevel.name,
-            hint: {
-              text: incentiveLevel.description if incentiveLevel.description else undefined
-            },
             value: incentiveLevel.code
           }), levelChoices) %}
         {% endfor %}


### PR DESCRIPTION
Level descriptions are no longer needed for any admin screens.

Relates to [hmpps-incentives-api#420](https://github.com/ministryofjustice/hmpps-incentives-api/pull/420)