### PR TITLE
Reverse attempt to get renovate to ignore npm engine

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -19,10 +19,6 @@
       "allowedVersions": "^18"
     },
     {
-      "matchDepNames": ["npm"],
-      "allowedVersions": "^9"
-    },
-    {
       "matchPackageNames": ["typescript", "govuk-frontend"],
       "rangeStrategy": "bump",
       "stabilityDays": 0
@@ -41,7 +37,7 @@
     {
       "matchDatasources": ["orb"],
       "matchPackageNames": ["cimg/node"],
-      "allowedVersions": "18.15-browsers"
+      "allowedVersions": "18.16-browsers"
     },
     {
       "matchDatasources": ["orb"],


### PR DESCRIPTION
Clearly didn't help because #457 appeared
Reverting: 4b90b5017cd19d47434a5c7128ff0e781c6e5e4e