### PR TITLE
INC-1212: Handle api errors properly when incentive levels are being modified

### DIFF
--- a/integration_tests/e2e/prisonIncentiveLevels.cy.ts
+++ b/integration_tests/e2e/prisonIncentiveLevels.cy.ts
@@ -113,11 +113,11 @@ context('Prison incentive level management', () => {
 
     listPage.findTableLink(3, 'Remove level').click()
 
-    let deactivatePage = Page.verifyOnPage(PrisonIncentiveLevelDeactivateFormPage, 'Enhanced 2')
+    let deactivatePage = Page.verifyOnPage(PrisonIncentiveLevelDeactivateFormPage)
     deactivatePage.checkLastBreadcrumb()
 
     deactivatePage.form.submit() // empty form
-    Page.verifyOnPage(PrisonIncentiveLevelDeactivateFormPage, 'Enhanced 2')
+    Page.verifyOnPage(PrisonIncentiveLevelDeactivateFormPage)
     deactivatePage.errorSummaryTitle.should('contain.text', 'There is a problem')
 
     deactivatePage.confirmationRadios.eq(1).find('label').click()
@@ -128,7 +128,7 @@ context('Prison incentive level management', () => {
 
     listPage.findTableLink(3, 'Remove level').click()
 
-    deactivatePage = Page.verifyOnPage(PrisonIncentiveLevelDeactivateFormPage, 'Enhanced 2')
+    deactivatePage = Page.verifyOnPage(PrisonIncentiveLevelDeactivateFormPage)
     deactivatePage.confirmationRadios.eq(0).find('label').click()
     deactivatePage.form.submit() // form should now be valid
 

--- a/integration_tests/pages/page.ts
+++ b/integration_tests/pages/page.ts
@@ -5,7 +5,7 @@ export default abstract class Page {
     return new constructor(...args)
   }
 
-  constructor(private readonly title: string) {
+  constructor(protected readonly title: string) {
     this.checkOnPage()
   }
 

--- a/integration_tests/pages/prisonIncentiveLevels/prisonIncentiveLevel.ts
+++ b/integration_tests/pages/prisonIncentiveLevels/prisonIncentiveLevel.ts
@@ -6,7 +6,7 @@ export default class PrisonIncentiveLevelPage extends Page {
   }
 
   checkLastBreadcrumb() {
-    this.breadcrumbs.last().should('contain.text', `View settings for ${this.levelName}`)
+    this.breadcrumbs.last().should('contain.text', this.title)
   }
 
   get tables(): PageElement<HTMLTableElement> {

--- a/integration_tests/pages/prisonIncentiveLevels/prisonIncentiveLevelAddForm.ts
+++ b/integration_tests/pages/prisonIncentiveLevels/prisonIncentiveLevelAddForm.ts
@@ -6,7 +6,7 @@ export default class PrisonIncentiveLevelAddFormPage extends Page {
   }
 
   checkLastBreadcrumb() {
-    this.breadcrumbs.last().should('contain.text', 'Add a new incentive level')
+    this.breadcrumbs.last().should('contain.text', this.title)
   }
 
   get form(): PageElement<HTMLFormElement> {

--- a/integration_tests/pages/prisonIncentiveLevels/prisonIncentiveLevelDeactivateForm.ts
+++ b/integration_tests/pages/prisonIncentiveLevels/prisonIncentiveLevelDeactivateForm.ts
@@ -1,12 +1,12 @@
 import Page, { type PageElement } from '../page'
 
 export default class PrisonIncentiveLevelDeactivateFormPage extends Page {
-  constructor(private readonly levelName: string = 'Standard') {
-    super(`Are you sure you want to remove ${levelName}?`)
+  constructor() {
+    super('Remove an incentive level')
   }
 
   checkLastBreadcrumb() {
-    this.breadcrumbs.last().should('contain.text', `Are you sure you want to remove ${this.levelName}?`)
+    this.breadcrumbs.last().should('contain.text', 'Remove an incentive level')
   }
 
   get form(): PageElement<HTMLFormElement> {

--- a/integration_tests/pages/prisonIncentiveLevels/prisonIncentiveLevelDeactivateForm.ts
+++ b/integration_tests/pages/prisonIncentiveLevels/prisonIncentiveLevelDeactivateForm.ts
@@ -6,7 +6,7 @@ export default class PrisonIncentiveLevelDeactivateFormPage extends Page {
   }
 
   checkLastBreadcrumb() {
-    this.breadcrumbs.last().should('contain.text', 'Remove an incentive level')
+    this.breadcrumbs.last().should('contain.text', this.title)
   }
 
   get form(): PageElement<HTMLFormElement> {

--- a/integration_tests/pages/prisonIncentiveLevels/prisonIncentiveLevelEditForm.ts
+++ b/integration_tests/pages/prisonIncentiveLevels/prisonIncentiveLevelEditForm.ts
@@ -6,7 +6,7 @@ export default class PrisonIncentiveLevelEditFormPage extends Page {
   }
 
   checkLastBreadcrumb() {
-    this.breadcrumbs.last().should('contain.text', `Change settings for ${this.levelName}`)
+    this.breadcrumbs.last().should('contain.text', this.title)
   }
 
   get form(): PageElement<HTMLFormElement> {

--- a/integration_tests/pages/prisonIncentiveLevels/prisonIncentiveLevels.ts
+++ b/integration_tests/pages/prisonIncentiveLevels/prisonIncentiveLevels.ts
@@ -8,7 +8,7 @@ export default class PrisonIncentiveLevelsPage extends Page {
   }
 
   checkLastBreadcrumb() {
-    this.breadcrumbs.last().should('contain.text', 'Incentive level settings')
+    this.breadcrumbs.last().should('contain.text', this.title)
   }
 
   get table(): PageElement<HTMLTableElement> {

--- a/server/data/incentivesApi.ts
+++ b/server/data/incentivesApi.ts
@@ -1,5 +1,44 @@
+// eslint-disable-next-line max-classes-per-file
 import config from '../config'
 import RestClient from './restClient'
+
+/**
+ * Structure representing an error response from the incentives api
+ */
+export class ErrorResponse {
+  status: number
+
+  errorCode?: ErrorCode
+
+  userMessage?: string
+
+  developerMessage?: string
+
+  moreInfo?: string
+
+  static isErrorResponse(obj: object): obj is ErrorResponse {
+    // TODO: would be nice to make userMessage & developerMessage non-nullable in the api
+    return obj && 'status' in obj && typeof obj.status === 'number'
+  }
+}
+
+/**
+ * Unique codes to discriminate errors returned from the incentives api.
+ * Defined in uk.gov.justice.digital.hmpps.incentivesapi.config.ErrorResponse enumeration
+ * https://github.com/ministryofjustice/hmpps-incentives-api/blob/a82fbcb02cd146e52e3a498d0affd4832740d916/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/config/HmppsIncentivesApiExceptionHandler.kt#L265-L276
+ */
+export enum ErrorCode {
+  IncentiveLevelActiveIfRequired = 100,
+  IncentiveLevelActiveIfActiveInPrison = 101,
+  IncentiveLevelCodeNotUnique = 102,
+  IncentiveLevelReorderNeedsFullSet = 103,
+
+  PrisonIncentiveLevelActiveIfRequired = 200,
+  PrisonIncentiveLevelActiveIfDefault = 201,
+  PrisonIncentiveLevelActiveIfPrisonersExist = 202,
+  PrisonIncentiveLevelNotGloballyActive = 203,
+  PrisonIncentiveLevelDefaultRequired = 204,
+}
 
 export interface IncentiveLevel {
   code: string
@@ -107,6 +146,9 @@ export class IncentivesApi extends RestClient {
     return this.get({ path: `/incentive/levels/${encodeURIComponent(code)}` })
   }
 
+  /**
+   * @throws SanitisedError<ErrorResponse>
+   */
   createIncentiveLevel(data: IncentiveLevel): Promise<IncentiveLevel> {
     return this.post({
       path: '/incentive/levels',
@@ -114,6 +156,9 @@ export class IncentivesApi extends RestClient {
     })
   }
 
+  /**
+   * @throws SanitisedError<ErrorResponse>
+   */
   updateIncentiveLevel(levelCode: string, data: IncentiveLevelUpdate): Promise<IncentiveLevel> {
     return this.patch({
       path: `/incentive/levels/${encodeURIComponent(levelCode)}`,
@@ -121,6 +166,9 @@ export class IncentivesApi extends RestClient {
     })
   }
 
+  /**
+   * @throws SanitisedError<ErrorResponse>
+   */
   setIncentiveLevelOrder(levelCodes: string[]): Promise<IncentiveLevel[]> {
     return this.patch({
       path: `/incentive/level-order`,
@@ -138,6 +186,9 @@ export class IncentivesApi extends RestClient {
     })
   }
 
+  /**
+   * @throws SanitisedError<ErrorResponse>
+   */
   updatePrisonIncentiveLevel(
     prisonId: string,
     levelCode: string,

--- a/server/sanitisedError.test.ts
+++ b/server/sanitisedError.test.ts
@@ -1,4 +1,4 @@
-import sanitisedError, { UnsanitisedError } from './sanitisedError'
+import sanitisedError, { type UnsanitisedError } from './sanitisedError'
 
 describe('sanitised error', () => {
   it('it should omit the request headers from the error object ', () => {

--- a/server/sanitisedError.ts
+++ b/server/sanitisedError.ts
@@ -1,17 +1,17 @@
 import type { ResponseError } from 'superagent'
 
-interface SanitisedError {
+export interface SanitisedError<Data = unknown> {
   text?: string
   status?: number
   headers?: unknown
-  data?: unknown
+  data?: Data
   stack: string
   message: string
 }
 
 export type UnsanitisedError = ResponseError
 
-export default function sanitise(error: UnsanitisedError): SanitisedError {
+export default function sanitise<Data = unknown>(error: UnsanitisedError): SanitisedError<Data> {
   if (error.response) {
     return {
       text: error.response.text,

--- a/server/views/pages/prisonIncentiveLevelDeactivateForm.njk
+++ b/server/views/pages/prisonIncentiveLevelDeactivateForm.njk
@@ -3,7 +3,7 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 
-{% set pageTitle = applicationName + " – Are you sure you want to remove " + prisonIncentiveLevel.levelName + "?" %}
+{% set pageTitle = applicationName + " – Remove an incentive level" %}
 
 {% block content %}
   <div class="govuk-grid-row">
@@ -13,24 +13,32 @@
       {% include "../partials/formErrorSummary.njk" %}
 
       <h1 class="govuk-heading-xl" data-qa="prison-incentive-levels-deactivate">
-        Are you sure you want to remove {{ prisonIncentiveLevel.levelName }}?
+        Remove an incentive level
       </h1>
       <p>
-        This incentive level will no longer be available for use in your establishment.
-        Removal will not affect prisoners who are already on this level.
+        Removing an incentive level makes it unavailable for use in your establishment.
+      </p>
+      <p>
+        You should first check if there are any prisoners on this level.
+      </p>
+      <p>
+        Staff must review these prisoners and place them on an alternative level before this level can be removed.
       </p>
 
       <form id="form-{{ form.formId }}" method="post" novalidate>
 
         {% set fieldId = "confirmation" %}
         {% set field = form.getField(fieldId) %}
+        {% set fieldLabel %}
+          Do you want to remove {{ prisonIncentiveLevel.levelName }}?
+        {% endset %}
         {{ govukRadios({
           attributes: { id: form.formId + "-" + fieldId },
           name: fieldId,
           fieldset: {
             legend: {
-              text: "Remove this level?",
-              classes: "govuk-visually-hidden"
+              html: fieldLabel,
+              classes: "govuk-fieldset__legend--m"
             }
           },
           items: [

--- a/server/views/partials/messages.njk
+++ b/server/views/partials/messages.njk
@@ -4,7 +4,7 @@
   {% for message in messages %}
     {{ mojBanner({
       type: messageType,
-      text: message
+      html: message | escape | nl2br
     }) }}
   {% endfor %}
 {% endfor %}


### PR DESCRIPTION
…and show a specific custom message when a level cannot be deactivated  because there are prisoners on it.

Turns out that api errors were incorrectly handled before: the error thrown was not directly what the api returned but wrapped inside `SanitisedError`