### PR TITLE
Improve accessibility of tables by adding hidden captions

### DIFF
--- a/server/views/pages/reviewsTable.njk
+++ b/server/views/pages/reviewsTable.njk
@@ -37,15 +37,17 @@
   <p>Review dates are calculated according to national incentives policy.</p>
   <p>Your local policy may require more frequent reviews.</p>
 
-  <ul class="govuk-tabs__list govuk-!-margin-top-7">
-    {% for level in levels %}
-      <li class="govuk-tabs__list-item {% if level.levelCode == selectedLevelCode %}govuk-tabs__list-item--selected{% endif %}">
-        <a class="govuk-tabs__tab" href="?level={{ level.levelCode }}&amp;sort={{ sort }}&amp;order={{ order }}" data-ga-category="Reviews table > Clicked on incentive level tab" data-ga-action="{{ level.levelName }}">
-          {{ level.levelName }} ({{ level.reviewCount }})
-        </a>
-      </li>
-    {% endfor %}
-  </ul>
+  <nav>
+    <ul class="govuk-tabs__list govuk-!-margin-top-7">
+      {% for level in levels %}
+        <li class="govuk-tabs__list-item {% if level.levelCode == selectedLevelCode %}govuk-tabs__list-item--selected{% endif %}">
+          <a class="govuk-tabs__tab" href="?level={{ level.levelCode }}&amp;sort={{ sort }}&amp;order={{ order }}" data-ga-category="Reviews table > Clicked on incentive level tab" data-ga-action="{{ level.levelName }}">
+            {{ level.levelName }} ({{ level.reviewCount }})
+          </a>
+        </li>
+      {% endfor %}
+    </ul>
+  </nav>
 
   {% set tableRows = [] %}
   {% for review in reviews %}
@@ -118,8 +120,13 @@
     </p>
   {%- endset %}
 
+  {% set caption -%}
+    Incentive level review details for {{ locationDescription }}
+  {%- endset %}
   <div class="app-reviews-container">
     {{ govukTable({
+      caption: caption,
+      captionClasses: "govuk-visually-hidden",
       classes: "app-reviews-table",
       head: tableHead,
       rows: tableRows if tableRows.length > 0 else [[{

--- a/server/views/partials/about-analytics/appendix.njk
+++ b/server/views/partials/about-analytics/appendix.njk
@@ -8,7 +8,7 @@
   Behaviour entries
 </h3>
 {{ govukTable({
-  caption: "",
+  caption: "Behaviour entry codes",
   captionClasses: "govuk-visually-hidden",
   classes: "app-table--2-even-columns",
   firstCellIsHeader: true,
@@ -31,7 +31,7 @@
   Incentive levels
 </h3>
 {{ govukTable({
-  caption: "",
+  caption: "Incentive level codes",
   captionClasses: "govuk-visually-hidden",
   classes: "app-table--2-even-columns",
   firstCellIsHeader: true,
@@ -71,7 +71,7 @@
   Protected characteristics
 </h3>
 {{ govukTable({
-  caption: "",
+  caption: "Religion codes",
   captionClasses: "govuk-visually-hidden",
   classes: "app-table--3-even-columns",
   firstCellIsHeader: true,
@@ -124,7 +124,7 @@
   ]
 }) }}
 {{ govukTable({
-  caption: "",
+  caption: "Sexual orientation codes",
   captionClasses: "govuk-visually-hidden",
   classes: "app-table--2-even-columns",
   firstCellIsHeader: true,
@@ -156,7 +156,7 @@
   ]
 }) }}
 {{ govukTable({
-  caption: "",
+  caption: "Disability codes",
   captionClasses: "govuk-visually-hidden",
   classes: "app-table--2-even-columns",
   firstCellIsHeader: true,
@@ -184,7 +184,7 @@
   Regional benchmark groups
 </h3>
 {{ govukTable({
-  caption: "",
+  caption: "Region codes",
   captionClasses: "govuk-visually-hidden",
   classes: "app-table--2-even-columns",
   firstCellIsHeader: true,


### PR DESCRIPTION
Previous DAC audits had asked for tables to have captions so might as well add screen-reader-only versions