### PR TITLE
INC-1238: Show location-based tiles on home page only when appropriate

### DIFF
--- a/integration_tests/e2e/aboutNationalPolicy.cy.ts
+++ b/integration_tests/e2e/aboutNationalPolicy.cy.ts
@@ -7,6 +7,7 @@ context('About National policy page', () => {
     cy.task('reset')
     cy.task('stubSignIn')
     cy.task('stubAuthUser')
+    cy.task('stubPrisonApiLocations')
 
     cy.signIn()
     const homePage = Page.verifyOnPage(HomePage)

--- a/integration_tests/e2e/analytics/behaviourEntries.cy.ts
+++ b/integration_tests/e2e/analytics/behaviourEntries.cy.ts
@@ -16,6 +16,7 @@ context('Analytics section > Behaviour entries page', () => {
     cy.task('reset')
     cy.task('stubSignIn')
     cy.task('stubAuthUser')
+    cy.task('stubPrisonApiLocations')
     cy.task('stubCreateZendeskTicket')
 
     cy.signIn()
@@ -121,6 +122,7 @@ context('Pgd Region selection > National > Analytics section > Behaviour entries
     cy.task('reset')
     cy.task('stubSignIn')
     cy.task('stubAuthUser')
+    cy.task('stubPrisonApiLocations')
 
     cy.signIn()
     const homePage = Page.verifyOnPage(HomePage)
@@ -221,6 +223,7 @@ context('Pgd Region selection > LTHS > Analytics section > Behaviour entries pag
     cy.task('reset')
     cy.task('stubSignIn')
     cy.task('stubAuthUser')
+    cy.task('stubPrisonApiLocations')
 
     cy.signIn()
     const homePage = Page.verifyOnPage(HomePage)

--- a/integration_tests/e2e/analytics/incentiveLevels.cy.ts
+++ b/integration_tests/e2e/analytics/incentiveLevels.cy.ts
@@ -15,6 +15,7 @@ context('Analytics section > Incentive levels page', () => {
     cy.task('reset')
     cy.task('stubSignIn')
     cy.task('stubAuthUser')
+    cy.task('stubPrisonApiLocations')
     cy.task('stubCreateZendeskTicket')
 
     cy.signIn()
@@ -94,6 +95,7 @@ context('Pgd Region selection > National > Analytics section > Incentive levels 
     cy.task('reset')
     cy.task('stubSignIn')
     cy.task('stubAuthUser')
+    cy.task('stubPrisonApiLocations')
 
     cy.signIn()
     const homePage = Page.verifyOnPage(HomePage)
@@ -175,6 +177,7 @@ context('Pgd Region selection > LTHS > Analytics section > Incentive levels page
     cy.task('reset')
     cy.task('stubSignIn')
     cy.task('stubAuthUser')
+    cy.task('stubPrisonApiLocations')
 
     cy.signIn()
     const homePage = Page.verifyOnPage(HomePage)

--- a/integration_tests/e2e/analytics/pgdRegionSelection.cy.ts
+++ b/integration_tests/e2e/analytics/pgdRegionSelection.cy.ts
@@ -8,6 +8,7 @@ context('Prison group selection', () => {
     cy.task('reset')
     cy.task('stubSignIn')
     cy.task('stubAuthUser')
+    cy.task('stubPrisonApiLocations')
 
     cy.signIn()
     const homePage = Page.verifyOnPage(HomePage)

--- a/integration_tests/e2e/analytics/protectedCharacteristics.cy.ts
+++ b/integration_tests/e2e/analytics/protectedCharacteristics.cy.ts
@@ -38,6 +38,7 @@ context('Analytics section > Protected characteristics page', () => {
     cy.task('reset')
     cy.task('stubSignIn')
     cy.task('stubAuthUser')
+    cy.task('stubPrisonApiLocations')
     cy.task('stubCreateZendeskTicket')
 
     cy.signIn()
@@ -225,6 +226,7 @@ context('Pgd Region selection > National > Analytics section > Protected charact
     cy.task('reset')
     cy.task('stubSignIn')
     cy.task('stubAuthUser')
+    cy.task('stubPrisonApiLocations')
 
     cy.signIn()
     const homePage = Page.verifyOnPage(HomePage)
@@ -385,6 +387,7 @@ context('Pgd Region selection > LTHS > Analytics section > Protected characteris
     cy.task('reset')
     cy.task('stubSignIn')
     cy.task('stubAuthUser')
+    cy.task('stubPrisonApiLocations')
 
     cy.signIn()
     const homePage = Page.verifyOnPage(HomePage)

--- a/integration_tests/e2e/prisonIncentiveLevels.cy.ts
+++ b/integration_tests/e2e/prisonIncentiveLevels.cy.ts
@@ -15,6 +15,7 @@ context('Prison incentive level management', () => {
     cy.task('reset')
     cy.task('stubSignIn', { roles })
     cy.task('stubAuthUser', { roles })
+    cy.task('stubPrisonApiLocations')
     cy.task('stubIncentiveLevels')
     cy.task('stubIncentiveLevel')
     cy.task('stubPrisonIncentiveLevels')

--- a/integration_tests/e2e/prisonerImages.cy.ts
+++ b/integration_tests/e2e/prisonerImages.cy.ts
@@ -7,6 +7,7 @@ context('Getting a prisoner image', () => {
   context('when authenticated', () => {
     beforeEach(() => {
       cy.task('stubAuthUser')
+      cy.task('stubPrisonApiLocations')
       cy.task('stubPrisonApiImages')
 
       cy.signIn()

--- a/server/data/prisonApi.ts
+++ b/server/data/prisonApi.ts
@@ -25,7 +25,7 @@ class PrisonApi extends RestClient {
   }
 
   getUserLocations(): Promise<Array<Location>> {
-    return this.get<Array<Location>>({ path: `/api/users/me/locations` }).then(locations => {
+    return this.get<Array<Location>>({ path: '/api/users/me/locations' }).then(locations => {
       return locations.filter(location => {
         return location.currentOccupancy > 0
       })

--- a/server/routes/selectLocation.ts
+++ b/server/routes/selectLocation.ts
@@ -10,7 +10,7 @@ export default function routes(router: Router): Router {
 
   get('/', async (req, res) => {
     const prisonApi = new PrisonApi(res.locals.user.token)
-    const locations: Array<Location> = await prisonApi.getUserLocations()
+    const locations = await prisonApi.getUserLocations()
 
     const options = locations.map((location: Location) => ({
       value: location.locationPrefix,

--- a/server/testData/nomisIUserRolesApi.ts
+++ b/server/testData/nomisIUserRolesApi.ts
@@ -1,4 +1,4 @@
-import { UserCaseload } from '../data/nomisUserRolesApi'
+import type { UserCaseload } from '../data/nomisUserRolesApi'
 
 function getSingleCaseload(): UserCaseload {
   return {

--- a/server/testData/prisonApi.ts
+++ b/server/testData/prisonApi.ts
@@ -1,4 +1,4 @@
-import { Location } from '../data/prisonApi'
+import type { Location } from '../data/prisonApi'
 
 function getTestLocation({
   agencyId = 'MDI',

--- a/server/views/pages/home.njk
+++ b/server/views/pages/home.njk
@@ -10,54 +10,50 @@
     {{ applicationName }}
   </h1>
 
-  <h2 class="govuk-heading-m govuk-!-margin-bottom-4">
-    Incentive levels by prisoner
-  </h2>
-  <ul class="govuk-grid-row card-group">
-    <li class="govuk-grid-column-one-third card-group__item">
+  {% if canViewLocationBasedTiles %}
+    <h2 class="govuk-heading-m govuk-!-margin-bottom-4">
+      Incentive levels by prisoner
+    </h2>
+    <ul class="govuk-grid-row card-group">
+      <li class="govuk-grid-column-one-third card-group__item">
+        {{ card({
+          href: "/select-location",
+          clickable: "true",
+          heading: "Manage incentive reviews",
+          description: "See and record incentive levels, recent behaviour entries and overdue reviews for prisoners in your residential location.",
+          id: "incentive-information"
+        }) }}
+      </li>
 
-      {% set cardHeading = "Manage incentive reviews" %}
-      {% set cardDescription = "See and record incentive levels, recent behaviour entries and overdue reviews for prisoners in your residential location." %}
-
-      {{ card({
-        href: "/select-location",
-        clickable: "true",
-        heading: cardHeading,
-        description: cardDescription,
-        id: "incentive-information"
-      }) }}
-
-    </li>
-
-    <li class="govuk-grid-column-one-third card-group__item">
-      {{ card({
-        href: "/about-national-policy",
-        clickable: "true",
-        heading: "National policy: frequency of reviews",
-        description: "Summary of the national policy guidelines used to calculate incentive review dates for prisoners on each level.",
-        id: "about-national-policy"
-      }) }}
-    </li>
-  </ul>
+      <li class="govuk-grid-column-one-third card-group__item">
+        {{ card({
+          href: "/about-national-policy",
+          clickable: "true",
+          heading: "National policy: frequency of reviews",
+          description: "Summary of the national policy guidelines used to calculate incentive review dates for prisoners on each level.",
+          id: "about-national-policy"
+        }) }}
+      </li>
+    </ul>
+  {% endif %}
 
   <h2 class="govuk-heading-m govuk-!-margin-bottom-4">
     Data visualisations
   </h2>
   <ul class="govuk-grid-row card-group">
+    {% if canViewLocationBasedTiles %}
+      <li class="govuk-grid-column-one-third card-group__item">
+        {{ card({
+          href: "/analytics/incentive-levels",
+          clickable: "true",
+          heading: "Incentive levels and behaviour entry charts",
+          description: "Data visualisation for incentive levels and behaviour entries at establishment level, including protected characteristics.",
+          id: "incentive-analytics"
+        }) }}
+      </li>
+    {% endif %}
+
     <li class="govuk-grid-column-one-third card-group__item">
-
-      {{ card({
-        href: "/analytics/incentive-levels",
-        clickable: "true",
-        heading: "Incentive levels and behaviour entry charts",
-        description: "Data visualisation for incentive levels and behaviour entries at establishment level, including protected characteristics.",
-        id: "incentive-analytics"
-      }) }}
-
-    </li>
-
-    <li class="govuk-grid-column-one-third card-group__item">
-
       {{ card({
         href: "/analytics/select-pgd-region",
         clickable: "true",
@@ -65,7 +61,6 @@
         description: "Data visualisation for incentive levels, behaviour entries and protected characteristics prison group and national level.",
         id: "select-pgd-region"
       }) }}
-
     </li>
 
     <li class="govuk-grid-column-one-third card-group__item">


### PR DESCRIPTION
There exist users with case loads that aren’t real locations so it does not make sense to show them sections of the site that only work in prisons.

Such users are:
• LSAs when using their special account (with `CADM_I` role)
• central admins who are never in a prison

The former group can now only see the prison-group analytics charts.
The latter group can now only see the prison-group analytics charts and global incentive level admin section.

---

Effectively:
- all users can see the prison-group analytics charts and about page for visualisations
  - central admins, non-prison-based users, with `MAINTAIN_INCENTIVE_LEVELS` role also see global incentive level admin section
  - all prison-based users also see incentive reviews sections and all analytics charts
    - LSAs, using their normal prison-based account, with `MAINTAIN_PRISON_IEP_LEVELS` role also see prison incentive level admin section

---
Relates to: [DPS#2431](https://github.com/ministryofjustice/digital-prison-services/pull/2431)