### PR TITLE
INC-1243: Enhance admin section to manage incentive levels globally

### DIFF
--- a/assets/scss/components/_incentive-levels.scss
+++ b/assets/scss/components/_incentive-levels.scss
@@ -1,15 +1,3 @@
-// TODO: remove once incentive level management is designed
-.app-incentive-levels-list {
-  @include govuk-media-query($from: tablet) {
-    .govuk-summary-list__key {
-      width: 20%;
-    }
-    .govuk-summary-list__actions {
-      width: 30%;
-    }
-  }
-}
-
 .app-incentive-levels--two-column-table {
   .govuk-table__cell {
     @extend .govuk-\!-width-one-half;

--- a/integration_tests/e2e/incentiveLevels.cy.ts
+++ b/integration_tests/e2e/incentiveLevels.cy.ts
@@ -1,8 +1,10 @@
 import type { UserRole } from '../../server/data/hmppsAuthClient'
 import { sampleIncentiveLevels } from '../../server/testData/incentivesApi'
+import type { IncentiveLevel } from '../../server/data/incentivesApi'
 import Page from '../pages/page'
 import HomePage from '../pages/home'
 import IncentiveLevelsPage from '../pages/incentiveLevels/incentiveLevels'
+import IncentiveLevelCreateFormPage from '../pages/incentiveLevels/incentiveLevelCreateForm'
 import IncentiveLevelStatusFormPage from '../pages/incentiveLevels/incentiveLevelStatusForm'
 
 context('Incentive level management', () => {
@@ -35,6 +37,39 @@ context('Incentive level management', () => {
     )
     listPage.contentsOfTable.its('Standard').its('status').should('contain', 'Active')
     listPage.contentsOfTable.its('Entry').its('status').should('contain', 'Inactive')
+  })
+
+  it('should allow creating a new level', () => {
+    const enhanced4: IncentiveLevel = { name: 'Enhanced 4', code: 'EN4', active: true, required: false }
+    cy.task('stubIncentiveLevel', { incentiveLevel: enhanced4 })
+    cy.task('stubCreateIncentiveLevel', { incentiveLevel: enhanced4 })
+    cy.task('stubPatchIncentiveLevel', { incentiveLevel: enhanced4 })
+
+    const homePage = Page.verifyOnPage(HomePage)
+    homePage.manageIncentiveLevelsLink().click()
+
+    let listPage = Page.verifyOnPage(IncentiveLevelsPage)
+    listPage.createLink.click()
+
+    const createPage = Page.verifyOnPage(IncentiveLevelCreateFormPage)
+    createPage.checkLastBreadcrumb()
+
+    createPage.form.submit() // empty form
+    Page.verifyOnPage(IncentiveLevelCreateFormPage)
+    createPage.errorSummaryTitle.should('contain.text', 'There is a problem')
+
+    createPage.getInputField('name').type('Enhanced 4')
+    createPage.getInputField('code').type('EN4')
+    createPage.form.submit() // form should now be valid
+
+    cy.task('stubIncentiveLevels', { incentiveLevels: [...sampleIncentiveLevels, enhanced4] })
+
+    const statusPage = Page.verifyOnPage(IncentiveLevelStatusFormPage)
+    statusPage.messages.should('not.exist')
+    statusPage.form.submit()
+
+    listPage = Page.verifyOnPage(IncentiveLevelsPage)
+    listPage.messages.should('contain.text', 'Incentive level status was saved').should('contain.text', 'Enhanced 4')
   })
 
   it('should allow changing the status of a non-required level', () => {

--- a/integration_tests/e2e/incentiveLevels.cy.ts
+++ b/integration_tests/e2e/incentiveLevels.cy.ts
@@ -1,7 +1,9 @@
 import type { UserRole } from '../../server/data/hmppsAuthClient'
+import { sampleIncentiveLevels } from '../../server/testData/incentivesApi'
 import Page from '../pages/page'
 import HomePage from '../pages/home'
 import IncentiveLevelsPage from '../pages/incentiveLevels/incentiveLevels'
+import IncentiveLevelStatusFormPage from '../pages/incentiveLevels/incentiveLevelStatusForm'
 
 context('Incentive level management', () => {
   beforeEach(() => {
@@ -33,5 +35,30 @@ context('Incentive level management', () => {
     )
     listPage.contentsOfTable.its('Standard').its('status').should('contain', 'Active')
     listPage.contentsOfTable.its('Entry').its('status').should('contain', 'Inactive')
+  })
+
+  it('should allow changing the status of a non-required level', () => {
+    const enhanced2 = sampleIncentiveLevels[3]
+    cy.task('stubIncentiveLevel', { incentiveLevel: enhanced2 })
+    cy.task('stubPatchIncentiveLevel', { incentiveLevel: { ...enhanced2, active: false } })
+
+    const homePage = Page.verifyOnPage(HomePage)
+    homePage.manageIncentiveLevelsLink().click()
+
+    let listPage = Page.verifyOnPage(IncentiveLevelsPage)
+    listPage.contentsOfTable.its('Basic').its('changeStatus').should('be.empty')
+    listPage.contentsOfTable.its('Standard').its('changeStatus').should('be.empty')
+    listPage.contentsOfTable.its('Enhanced').its('changeStatus').should('be.empty')
+
+    listPage.findTableLink(4, 'Change status').click()
+
+    const statusPage = Page.verifyOnPage(IncentiveLevelStatusFormPage)
+    statusPage.checkLastBreadcrumb()
+
+    statusPage.statusRadios.eq(1).find('label').click()
+    statusPage.form.submit()
+
+    listPage = Page.verifyOnPage(IncentiveLevelsPage)
+    listPage.messages.should('contain.text', 'Incentive level status was saved').should('contain.text', 'Enhanced 2')
   })
 })

--- a/integration_tests/e2e/incentiveLevels.cy.ts
+++ b/integration_tests/e2e/incentiveLevels.cy.ts
@@ -1,0 +1,37 @@
+import type { UserRole } from '../../server/data/hmppsAuthClient'
+import Page from '../pages/page'
+import HomePage from '../pages/home'
+import IncentiveLevelsPage from '../pages/incentiveLevels/incentiveLevels'
+
+context('Incentive level management', () => {
+  beforeEach(() => {
+    const roles: UserRole[] = [{ roleCode: 'ROLE_MAINTAIN_INCENTIVE_LEVELS' }]
+    cy.task('reset')
+    cy.task('stubSignIn', { roles })
+    cy.task('stubAuthUser', { roles })
+    cy.task('stubPrisonApiLocations')
+    cy.task('stubIncentiveLevels', { inactive: true })
+    cy.task('stubIncentiveLevel')
+
+    cy.signIn()
+  })
+
+  it('shows list of levels and details of a level', () => {
+    const homePage = Page.verifyOnPage(HomePage)
+    homePage.manageIncentiveLevelsLink().click()
+
+    const listPage = Page.verifyOnPage(IncentiveLevelsPage)
+    listPage.checkLastBreadcrumb()
+    listPage.contentsOfTable.should(
+      'have.all.key',
+      'Basic',
+      'Standard',
+      'Enhanced',
+      'Enhanced 2',
+      'Enhanced 3',
+      'Entry',
+    )
+    listPage.contentsOfTable.its('Standard').its('status').should('contain', 'Active')
+    listPage.contentsOfTable.its('Entry').its('status').should('contain', 'Inactive')
+  })
+})

--- a/integration_tests/e2e/prisonIncentiveLevels.cy.ts
+++ b/integration_tests/e2e/prisonIncentiveLevels.cy.ts
@@ -1,7 +1,7 @@
-import Page from '../pages/page'
 import type { UserRole } from '../../server/data/hmppsAuthClient'
 import type { PrisonIncentiveLevel } from '../../server/data/incentivesApi'
 import { sampleIncentiveLevels, samplePrisonIncentiveLevels } from '../../server/testData/incentivesApi'
+import Page from '../pages/page'
 import HomePage from '../pages/home'
 import PrisonIncentiveLevelPage from '../pages/prisonIncentiveLevels/prisonIncentiveLevel'
 import PrisonIncentiveLevelAddFormPage from '../pages/prisonIncentiveLevels/prisonIncentiveLevelAddForm'

--- a/integration_tests/mockApis/incentivesApi.ts
+++ b/integration_tests/mockApis/incentivesApi.ts
@@ -68,6 +68,22 @@ export default {
     })
   },
 
+  stubPatchIncentiveLevel: (options: { incentiveLevel: IncentiveLevel }): SuperAgentRequest => {
+    const { incentiveLevel } = options
+
+    return stubFor({
+      request: {
+        method: 'PATCH',
+        urlPattern: `/incentivesApi/incentive/levels/${incentiveLevel.code}`,
+      },
+      response: {
+        status: 200,
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+        jsonBody: incentiveLevel,
+      },
+    })
+  },
+
   stubPrisonIncentiveLevels: (
     options: { prisonId: string } & ({ inactive: boolean } | { prisonIncentiveLevels: PrisonIncentiveLevel[] }) = {
       prisonId: 'MDI',

--- a/integration_tests/mockApis/incentivesApi.ts
+++ b/integration_tests/mockApis/incentivesApi.ts
@@ -68,6 +68,22 @@ export default {
     })
   },
 
+  stubCreateIncentiveLevel: (options: { incentiveLevel: IncentiveLevel }): SuperAgentRequest => {
+    const { incentiveLevel } = options
+
+    return stubFor({
+      request: {
+        method: 'POST',
+        urlPattern: '/incentivesApi/incentive/levels',
+      },
+      response: {
+        status: 201,
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+        jsonBody: incentiveLevel,
+      },
+    })
+  },
+
   stubPatchIncentiveLevel: (options: { incentiveLevel: IncentiveLevel }): SuperAgentRequest => {
     const { incentiveLevel } = options
 

--- a/integration_tests/mockApis/incentivesApi.ts
+++ b/integration_tests/mockApis/incentivesApi.ts
@@ -24,10 +24,14 @@ export default {
       inactive: false,
     },
   ): SuperAgentRequest => {
+    let urlPattern = '/incentivesApi/incentive/levels'
     let incentiveLevels: IncentiveLevel[]
     if ('incentiveLevels' in options) {
       incentiveLevels = options.incentiveLevels
     } else {
+      if (options.inactive) {
+        urlPattern += '\\?with-inactive=true'
+      }
       incentiveLevels = options.inactive
         ? sampleIncentiveLevels
         : sampleIncentiveLevels.filter(incentiveLevel => incentiveLevel.active)
@@ -36,7 +40,7 @@ export default {
     return stubFor({
       request: {
         method: 'GET',
-        urlPattern: '/incentivesApi/incentive/levels',
+        urlPattern,
       },
       response: {
         status: 200,

--- a/integration_tests/pages/incentiveLevels/incentiveLevelCreateForm.ts
+++ b/integration_tests/pages/incentiveLevels/incentiveLevelCreateForm.ts
@@ -1,0 +1,19 @@
+import Page, { type PageElement } from '../page'
+
+export default class IncentiveLevelCreateFormPage extends Page {
+  constructor() {
+    super('Create a new incentive level')
+  }
+
+  checkLastBreadcrumb() {
+    this.breadcrumbs.last().should('contain.text', this.title)
+  }
+
+  get form(): PageElement<HTMLFormElement> {
+    return cy.get('#form-incentiveLevelCreateForm')
+  }
+
+  getInputField(name: string): PageElement<HTMLInputElement> {
+    return this.form.find(`[name=${name}]`)
+  }
+}

--- a/integration_tests/pages/incentiveLevels/incentiveLevelStatusForm.ts
+++ b/integration_tests/pages/incentiveLevels/incentiveLevelStatusForm.ts
@@ -1,0 +1,19 @@
+import Page, { type PageElement } from '../page'
+
+export default class IncentiveLevelStatusFormPage extends Page {
+  constructor() {
+    super('Select incentive level status')
+  }
+
+  checkLastBreadcrumb() {
+    this.breadcrumbs.last().should('contain.text', this.title)
+  }
+
+  get form(): PageElement<HTMLFormElement> {
+    return cy.get('#form-incentiveLevelStatusForm')
+  }
+
+  get statusRadios(): PageElement<HTMLDivElement> {
+    return this.form.find('.govuk-radios__item')
+  }
+}

--- a/integration_tests/pages/incentiveLevels/incentiveLevels.ts
+++ b/integration_tests/pages/incentiveLevels/incentiveLevels.ts
@@ -1,18 +1,18 @@
 import Page, { type PageElement } from '../page'
 
 type TableRowContents = {
-  tags: string
-  viewAction: string
-  removeAction: string | undefined
+  code: string
+  status: string
+  changeStatus: string | undefined
 }
 
-export default class PrisonIncentiveLevelsPage extends Page {
+export default class IncentiveLevelsPage extends Page {
   constructor() {
-    super('Incentive level settings')
+    super('Global incentive level admin')
   }
 
   checkLastBreadcrumb() {
-    this.breadcrumbs.last().should('contain.text', this.title)
+    this.breadcrumbs.last().should('contain.text', 'Global incentive level admin')
   }
 
   get table(): PageElement<HTMLTableElement> {
@@ -22,18 +22,17 @@ export default class PrisonIncentiveLevelsPage extends Page {
   get contentsOfTable(): Cypress.Chainable<Record<string, TableRowContents>> {
     return this.table.then($table => {
       const contentsOfTable: [string, TableRowContents][] = []
-      const rows = $table[0].getElementsByTagName('tr')
+      const rows = $table.find('tbody')[0].getElementsByTagName('tr')
       for (let index = 0; index < rows.length; index += 1) {
         const row = rows[index]
-        const levelCell = row.getElementsByTagName('th')[0]
         const cells = row.getElementsByTagName('td')
-        const [tagCell, viewCell, removeCell] = [cells[0], cells[1], cells[2]]
+        const [nameCell, codeCell, statusCell, changeStatusCell] = [cells[0], cells[1], cells[2], cells[3]]
         const contents: TableRowContents = {
-          tags: tagCell.textContent.trim(),
-          viewAction: viewCell.textContent.trim(),
-          removeAction: removeCell?.textContent?.trim(),
+          code: codeCell.textContent.trim(),
+          status: statusCell.textContent.trim(),
+          changeStatus: changeStatusCell?.textContent?.trim(),
         }
-        contentsOfTable.push([levelCell.textContent.trim(), contents])
+        contentsOfTable.push([nameCell.textContent.trim(), contents])
       }
       return cy.wrap(Object.fromEntries(contentsOfTable))
     })
@@ -43,7 +42,7 @@ export default class PrisonIncentiveLevelsPage extends Page {
     return this.table.find('tr').eq(row).scrollIntoView().find(`a:contains(${text})`)
   }
 
-  get addLink(): PageElement<HTMLAnchorElement> {
-    return cy.get('a:contains(Add)')
+  get createLink(): PageElement<HTMLAnchorElement> {
+    return cy.get('a:contains(Create)')
   }
 }

--- a/integration_tests/pages/incentiveLevels/incentiveLevels.ts
+++ b/integration_tests/pages/incentiveLevels/incentiveLevels.ts
@@ -12,7 +12,7 @@ export default class IncentiveLevelsPage extends Page {
   }
 
   checkLastBreadcrumb() {
-    this.breadcrumbs.last().should('contain.text', 'Global incentive level admin')
+    this.breadcrumbs.last().should('contain.text', this.title)
   }
 
   get table(): PageElement<HTMLTableElement> {

--- a/integration_tests/plugins/index.ts
+++ b/integration_tests/plugins/index.ts
@@ -22,6 +22,7 @@ export default (on: (string, Record) => void): void => {
 
     stubIncentiveLevels: incentivesApi.stubIncentiveLevels,
     stubIncentiveLevel: incentivesApi.stubIncentiveLevel,
+    stubPatchIncentiveLevel: incentivesApi.stubPatchIncentiveLevel,
     stubPrisonIncentiveLevels: incentivesApi.stubPrisonIncentiveLevels,
     stubPrisonIncentiveLevel: incentivesApi.stubPrisonIncentiveLevel,
     stubPatchPrisonIncentiveLevel: incentivesApi.stubPatchPrisonIncentiveLevel,

--- a/integration_tests/plugins/index.ts
+++ b/integration_tests/plugins/index.ts
@@ -22,6 +22,7 @@ export default (on: (string, Record) => void): void => {
 
     stubIncentiveLevels: incentivesApi.stubIncentiveLevels,
     stubIncentiveLevel: incentivesApi.stubIncentiveLevel,
+    stubCreateIncentiveLevel: incentivesApi.stubCreateIncentiveLevel,
     stubPatchIncentiveLevel: incentivesApi.stubPatchIncentiveLevel,
     stubPrisonIncentiveLevels: incentivesApi.stubPrisonIncentiveLevels,
     stubPrisonIncentiveLevel: incentivesApi.stubPrisonIncentiveLevel,

--- a/server/data/prisonApi.ts
+++ b/server/data/prisonApi.ts
@@ -1,7 +1,7 @@
 import config from '../config'
 import RestClient from './restClient'
 
-interface Location {
+export interface Location {
   locationId: number
   locationType: string
   description: string
@@ -12,7 +12,14 @@ interface Location {
   userDescription?: string
 }
 
-class PrisonApi extends RestClient {
+export interface Agency {
+  agencyId: string
+  description: string
+  agencyType: string
+  active: boolean
+}
+
+export class PrisonApi extends RestClient {
   constructor(token: string) {
     super('HMPPS Prison API', config.apis.hmppsPrisonApi, token)
   }
@@ -31,6 +38,8 @@ class PrisonApi extends RestClient {
       })
     })
   }
-}
 
-export { PrisonApi, Location }
+  getAgency(agencyId: string, activeOnly = true): Promise<Agency> {
+    return this.get<Agency>({ path: `/api/agencies/${encodeURIComponent(agencyId)}?activeOnly=${Boolean(activeOnly)}` })
+  }
+}

--- a/server/routes/forms/incentiveLevelCreateForm.test.ts
+++ b/server/routes/forms/incentiveLevelCreateForm.test.ts
@@ -1,0 +1,44 @@
+import IncentiveLevelCreateForm, { type IncentiveLevelCreateData } from './incentiveLevelCreateForm'
+
+describe('IncentiveLevelCreateForm', () => {
+  const formId = 'test-form-1' as const
+
+  const validData: Partial<IncentiveLevelCreateData>[] = [
+    {
+      name: 'Standard',
+      code: 'STD',
+    },
+    {
+      name: 'Enhanced 4',
+      code: 'EN4',
+    },
+  ]
+  it.each(validData)('with valid data', testCase => {
+    const form = new IncentiveLevelCreateForm(formId)
+    form.submit({ formId, ...testCase })
+    expect(form.hasErrors).toBeFalsy()
+  })
+
+  const invalidData: [string, unknown][] = [
+    ['empty submission', {}],
+    [
+      'blank name',
+      {
+        name: '',
+        code: 'ABC',
+      },
+    ],
+    [
+      'blank code',
+      {
+        name: 'Standard',
+        code: '',
+      },
+    ],
+  ]
+  it.each(invalidData)('with invalid data: %s', (_, testCase: unknown) => {
+    const form = new IncentiveLevelCreateForm(formId)
+    form.submit({ formId, ...(testCase as Partial<IncentiveLevelCreateData>) })
+    expect(form.hasErrors).toBeTruthy()
+  })
+})

--- a/server/routes/forms/incentiveLevelCreateForm.test.ts
+++ b/server/routes/forms/incentiveLevelCreateForm.test.ts
@@ -35,6 +35,27 @@ describe('IncentiveLevelCreateForm', () => {
         code: '',
       },
     ],
+    [
+      'short code',
+      {
+        name: 'Standard',
+        code: 'st',
+      },
+    ],
+    [
+      'long code',
+      {
+        name: 'Standard',
+        code: 'Standard',
+      },
+    ],
+    [
+      'code with invalid characters',
+      {
+        name: 'Enhanced 4',
+        code: 'E 4',
+      },
+    ],
   ]
   it.each(invalidData)('with invalid data: %s', (_, testCase: unknown) => {
     const form = new IncentiveLevelCreateForm(formId)

--- a/server/routes/forms/incentiveLevelCreateForm.ts
+++ b/server/routes/forms/incentiveLevelCreateForm.ts
@@ -10,8 +10,12 @@ export default class IncentiveLevelCreateForm extends Form<IncentiveLevelCreateD
     if (!this.data.name || this.data.name.length < 1) {
       this.addError('name', 'The level’s name is required')
     }
-    if (!this.data.code || this.data.code.length < 1) {
-      this.addError('name', 'The level’s code is required')
+    // TODO: add max length limit to `name` & error message once determined
+    //       NOMIS has hard limit of 40, incentives DB is 30
+
+    const codeRE = /^[A-Za-z0-9]{3}$/
+    if (!codeRE.test(this.data.code)) {
+      this.addError('code', 'The level’s code must be 3 letters or numbers')
     }
   }
 }

--- a/server/routes/forms/incentiveLevelCreateForm.ts
+++ b/server/routes/forms/incentiveLevelCreateForm.ts
@@ -1,0 +1,17 @@
+import Form, { type BaseFormData } from './forms'
+
+export interface IncentiveLevelCreateData extends BaseFormData {
+  name: string
+  code: string
+}
+
+export default class IncentiveLevelCreateForm extends Form<IncentiveLevelCreateData> {
+  protected validate(): void {
+    if (!this.data.name || this.data.name.length < 1) {
+      this.addError('name', 'The level’s name is required')
+    }
+    if (!this.data.code || this.data.code.length < 1) {
+      this.addError('name', 'The level’s code is required')
+    }
+  }
+}

--- a/server/routes/forms/incentiveLevelEditForm.test.ts
+++ b/server/routes/forms/incentiveLevelEditForm.test.ts
@@ -1,15 +1,15 @@
-import IncentiveLevelForm, { type IncentiveLevelData } from './incentiveLevelForm'
+import IncentiveLevelEditForm, { type IncentiveLevelEditData } from './incentiveLevelEditForm'
 
-describe('IncentiveLevelForm', () => {
+describe('IncentiveLevelEditForm', () => {
   const formId = 'test-form-1' as const
 
-  const validData: Partial<IncentiveLevelData>[] = [
+  const validData: Partial<IncentiveLevelEditData>[] = [
     { name: 'Standard', availability: 'required' },
     { name: 'Basic', availability: 'active' },
     { name: 'Entry', availability: 'inactive' },
   ]
-  it.each(validData)('with valid data', (testCase: Partial<IncentiveLevelData>) => {
-    const form = new IncentiveLevelForm(formId)
+  it.each(validData)('with valid data', (testCase: Partial<IncentiveLevelEditData>) => {
+    const form = new IncentiveLevelEditForm(formId)
     form.submit({ formId, ...testCase })
     expect(form.hasErrors).toBeFalsy()
   })
@@ -21,8 +21,8 @@ describe('IncentiveLevelForm', () => {
     { name: 'Basic', availability: 'none' },
   ]
   it.each(invalidData)('with invalid data', (testCase: unknown) => {
-    const form = new IncentiveLevelForm(formId)
-    form.submit({ formId, ...(testCase as Partial<IncentiveLevelData>) })
+    const form = new IncentiveLevelEditForm(formId)
+    form.submit({ formId, ...(testCase as Partial<IncentiveLevelEditData>) })
     expect(form.hasErrors).toBeTruthy()
   })
 })

--- a/server/routes/forms/incentiveLevelEditForm.ts
+++ b/server/routes/forms/incentiveLevelEditForm.ts
@@ -1,11 +1,11 @@
 import Form, { type BaseFormData } from './forms'
 
-export interface IncentiveLevelData extends BaseFormData {
+export interface IncentiveLevelEditData extends BaseFormData {
   name: string
   availability: 'required' | 'active' | 'inactive'
 }
 
-export default class IncentiveLevelForm extends Form<IncentiveLevelData> {
+export default class IncentiveLevelEditForm extends Form<IncentiveLevelEditData> {
   protected validate(): void {
     if (!this.data.name || this.data.name.length < 1) {
       this.addError('name', 'The level’s name is required')

--- a/server/routes/forms/incentiveLevelForm.test.ts
+++ b/server/routes/forms/incentiveLevelForm.test.ts
@@ -5,8 +5,8 @@ describe('IncentiveLevelForm', () => {
 
   const validData: Partial<IncentiveLevelData>[] = [
     { name: 'Standard', availability: 'required' },
-    { code: 'BAS', name: 'Basic', availability: 'active' },
-    { code: 'ENT', name: 'Entry', availability: 'inactive' },
+    { name: 'Basic', availability: 'active' },
+    { name: 'Entry', availability: 'inactive' },
   ]
   it.each(validData)('with valid data', (testCase: Partial<IncentiveLevelData>) => {
     const form = new IncentiveLevelForm(formId)
@@ -17,9 +17,8 @@ describe('IncentiveLevelForm', () => {
   const invalidData: unknown[] = [
     {},
     { name: 'Standard' },
-    { code: '', name: 'Standard', availability: 'required' },
-    { code: 'BAS', name: '', availability: 'required' },
-    { code: 'BAS', name: 'Basic', availability: 'none' },
+    { name: '', availability: 'required' },
+    { name: 'Basic', availability: 'none' },
   ]
   it.each(invalidData)('with invalid data', (testCase: unknown) => {
     const form = new IncentiveLevelForm(formId)

--- a/server/routes/forms/incentiveLevelForm.ts
+++ b/server/routes/forms/incentiveLevelForm.ts
@@ -1,16 +1,12 @@
 import Form, { type BaseFormData } from './forms'
 
 export interface IncentiveLevelData extends BaseFormData {
-  code?: string
   name: string
   availability: 'required' | 'active' | 'inactive'
 }
 
 export default class IncentiveLevelForm extends Form<IncentiveLevelData> {
   protected validate(): void {
-    if (typeof this.data.code !== 'undefined' && this.data.code.length < 1) {
-      this.addError('code', 'The level’s code is required')
-    }
     if (!this.data.name || this.data.name.length < 1) {
       this.addError('name', 'The level’s name is required')
     }

--- a/server/routes/forms/incentiveLevelReorderForm.test.ts
+++ b/server/routes/forms/incentiveLevelReorderForm.test.ts
@@ -1,0 +1,27 @@
+import IncentiveLevelReorderForm, { type IncentiveLevelReorderData } from './incentiveLevelReorderForm'
+
+describe('IncentiveLevelReorderForm', () => {
+  const formId = 'test-form-1' as const
+
+  const validData: Partial<IncentiveLevelReorderData>[] = [
+    { code: 'ENT', direction: 'up' },
+    { code: 'EN3', direction: 'down' },
+  ]
+  it.each(validData)('with valid data', (testCase: Partial<IncentiveLevelReorderData>) => {
+    const form = new IncentiveLevelReorderForm(formId)
+    form.submit({ formId, ...testCase })
+    expect(form.hasErrors).toBeFalsy()
+  })
+
+  const invalidData: unknown[] = [
+    {},
+    { code: 'ENT' },
+    { code: '', direction: 'up' },
+    { code: 'ENT', direction: 'higher' },
+  ]
+  it.each(invalidData)('with invalid data', (testCase: unknown) => {
+    const form = new IncentiveLevelReorderForm(formId)
+    form.submit({ formId, ...(testCase as Partial<IncentiveLevelReorderData>) })
+    expect(form.hasErrors).toBeTruthy()
+  })
+})

--- a/server/routes/forms/incentiveLevelReorderForm.ts
+++ b/server/routes/forms/incentiveLevelReorderForm.ts
@@ -1,0 +1,17 @@
+import Form, { type BaseFormData } from './forms'
+
+export interface IncentiveLevelReorderData extends BaseFormData {
+  code: string
+  direction: 'up' | 'down'
+}
+
+export default class IncentiveLevelReorderForm extends Form<IncentiveLevelReorderData> {
+  protected validate(): void {
+    if (!this.data.code || this.data.code.length < 1) {
+      this.addError('code', 'The level’s code is required')
+    }
+    if (!['up', 'down'].includes(this.data.direction)) {
+      this.addError('direction', 'Direction must be chosen')
+    }
+  }
+}

--- a/server/routes/forms/incentiveLevelReorderForm.ts
+++ b/server/routes/forms/incentiveLevelReorderForm.ts
@@ -1,3 +1,4 @@
+import type { IncentiveLevel } from '../../data/incentivesApi'
 import Form, { type BaseFormData } from './forms'
 
 export interface IncentiveLevelReorderData extends BaseFormData {
@@ -13,5 +14,31 @@ export default class IncentiveLevelReorderForm extends Form<IncentiveLevelReorde
     if (!['up', 'down'].includes(this.data.direction)) {
       this.addError('direction', 'Direction must be chosen')
     }
+  }
+
+  /** @throws Error */
+  reorderIncentiveLevels(incentiveLevels: IncentiveLevel[]): string[] {
+    const incentiveLevelCodes = incentiveLevels.map(incentiveLevel => incentiveLevel.code)
+
+    const levelCode = this.getField('code').value
+    const moveDirection = this.getField('direction').value
+
+    const previousIndex = incentiveLevelCodes.findIndex(incentiveLevelCode => incentiveLevelCode === levelCode)
+    if (typeof previousIndex !== 'number' || previousIndex < 0) {
+      throw new Error('Cannot find level to move!')
+    }
+    const newIndex = moveDirection === 'up' ? previousIndex - 1 : previousIndex + 1
+    if (newIndex < 0) {
+      throw new Error('Cannot move first incentive level up!')
+    }
+    if (newIndex >= incentiveLevelCodes.length) {
+      throw new Error('Cannot move last incentive level down!')
+    }
+    const level1 = incentiveLevelCodes[previousIndex]
+    const level2 = incentiveLevelCodes[newIndex]
+    incentiveLevelCodes[newIndex] = level1
+    incentiveLevelCodes[previousIndex] = level2
+
+    return incentiveLevelCodes
   }
 }

--- a/server/routes/forms/incentiveLevelStatusForm.test.ts
+++ b/server/routes/forms/incentiveLevelStatusForm.test.ts
@@ -1,0 +1,19 @@
+import IncentiveLevelStatusForm from './incentiveLevelStatusForm'
+
+describe('IncentiveLevelStatusForm', () => {
+  const formId = 'test-form-1' as const
+
+  it.each(['active', 'inactive'])('with valid data: %s', (status: 'active' | 'inactive') => {
+    const form = new IncentiveLevelStatusForm(formId)
+    form.submit({ formId, status })
+    expect(form.hasErrors).toBeFalsy()
+  })
+
+  it.each([undefined, null, '', 'ACTIVE', 'required'])('with invalid data: %s', (status: unknown) => {
+    const form = new IncentiveLevelStatusForm(formId)
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    form.submit({ formId, status })
+    expect(form.hasErrors).toBeTruthy()
+  })
+})

--- a/server/routes/forms/incentiveLevelStatusForm.ts
+++ b/server/routes/forms/incentiveLevelStatusForm.ts
@@ -1,0 +1,13 @@
+import Form, { type BaseFormData } from './forms'
+
+export interface IncentiveLevelStatusData extends BaseFormData {
+  status: 'active' | 'inactive'
+}
+
+export default class IncentiveLevelStatusForm extends Form<IncentiveLevelStatusData> {
+  protected validate(): void {
+    if (!['active', 'inactive'].includes(this.data.status)) {
+      this.addError('status', 'Select an option')
+    }
+  }
+}

--- a/server/routes/home.ts
+++ b/server/routes/home.ts
@@ -75,7 +75,7 @@ export default function routes(router: Router): Router {
         return
       }
       if (!req.body.formId || req.body.formId !== formId) {
-        logger.error(`Form posted with incorrect formId=${req.body.formId} when only ${formId} are allowed`)
+        logger.error(`Form posted with incorrect formId=${req.body.formId} when only ${formId} is allowed`)
         next(new BadRequest())
         return
       }

--- a/server/routes/incentiveLevels.test.ts
+++ b/server/routes/incentiveLevels.test.ts
@@ -8,7 +8,7 @@ import createUserToken from './testutils/createUserToken'
 import { sampleIncentiveLevels } from '../testData/incentivesApi'
 import { IncentivesApi, type ErrorResponse } from '../data/incentivesApi'
 import type { SanitisedError } from '../sanitisedError'
-import type { IncentiveLevelData } from './forms/incentiveLevelForm'
+import type { IncentiveLevelEditData } from './forms/incentiveLevelEditForm'
 import type { IncentiveLevelStatusData } from './forms/incentiveLevelStatusForm'
 
 jest.mock('../data/hmppsAuthClient')
@@ -57,7 +57,7 @@ describe('Incentive level management', () => {
   it.each([
     ['/incentive-levels', 'incentive-levels-list'],
     ['/incentive-levels/view/STD', 'incentive-levels-detail'],
-    ['/incentive-levels/edit/STD', 'incentive-levels-form'],
+    ['/incentive-levels/edit/STD', 'incentive-levels-edit'],
     ['/incentive-levels/status/STD', 'incentive-levels-status'],
   ])('should be accessible with necessary role: %s', (url: string, expectedPage: string) => {
     return request(app)
@@ -450,7 +450,7 @@ describe('Incentive level management', () => {
     type SuccessTestCase = {
       scenario: string
       name: string
-      availability: IncentiveLevelData['availability']
+      availability: IncentiveLevelEditData['availability']
     }
     const successTestCases: SuccessTestCase[] = [
       {
@@ -484,7 +484,7 @@ describe('Incentive level management', () => {
         required: expectedRequired,
       })
 
-      const form: IncentiveLevelData = {
+      const form: IncentiveLevelEditData = {
         formId: 'incentiveLevelEditForm',
         name,
         availability,
@@ -562,7 +562,7 @@ describe('Incentive level management', () => {
       }
       incentivesApi.updateIncentiveLevel.mockRejectedValue(error)
 
-      const validForm: IncentiveLevelData = {
+      const validForm: IncentiveLevelEditData = {
         formId: 'incentiveLevelEditForm',
         name: 'Standard',
         availability: 'required',

--- a/server/routes/incentiveLevels.test.ts
+++ b/server/routes/incentiveLevels.test.ts
@@ -209,6 +209,7 @@ describe('Incentive level management', () => {
     })
   })
 
+  // NB: Only for super-admin use; not linked to
   describe('details of a level', () => {
     type TestCase = {
       scenario: string
@@ -472,6 +473,7 @@ describe('Incentive level management', () => {
     })
   })
 
+  // NB: Only for super-admin use; not linked to
   describe('editing a level', () => {
     type PrefillTestCase = {
       scenario: string
@@ -860,6 +862,7 @@ describe('Incentive level management', () => {
     })
   })
 
+  // NB: Only for super-admin use; not linked to
   describe('reordering levels', () => {
     type SuccessTestCase = {
       scenario: string

--- a/server/routes/incentiveLevels.test.ts
+++ b/server/routes/incentiveLevels.test.ts
@@ -7,7 +7,8 @@ import { appWithAllRoutes } from './testutils/appSetup'
 import createUserToken from './testutils/createUserToken'
 import { sampleIncentiveLevels } from '../testData/incentivesApi'
 import { IncentivesApi, type ErrorResponse } from '../data/incentivesApi'
-import { SanitisedError } from '../sanitisedError'
+import type { SanitisedError } from '../sanitisedError'
+import type { IncentiveLevelData } from './forms/incentiveLevelForm'
 
 jest.mock('../data/hmppsAuthClient')
 jest.mock('../data/incentivesApi', () => {
@@ -37,7 +38,7 @@ const tokenWithMissingRole = createUserToken([])
 const tokenWithNecessaryRole = createUserToken(['ROLE_MAINTAIN_INCENTIVE_LEVELS'])
 
 describe('Incentive level management', () => {
-  it.each(['/incentive-levels', '/incentive-levels/view/STD'])(
+  it.each(['/incentive-levels', '/incentive-levels/view/STD', '/incentive-levels/edit/STD'])(
     'should not be accessible without correct role: %s',
     (url: string) => {
       return request(app)
@@ -53,6 +54,7 @@ describe('Incentive level management', () => {
   it.each([
     ['/incentive-levels', 'incentive-levels-list'],
     ['/incentive-levels/view/STD', 'incentive-levels-detail'],
+    ['/incentive-levels/edit/STD', 'incentive-levels-form'],
   ])('should be accessible with necessary role: %s', (url: string, expectedPage: string) => {
     return request(app)
       .get(url)
@@ -166,6 +168,15 @@ describe('Incentive level management', () => {
           expect(res.text).not.toContain('/incentive-levels/view/')
         })
     })
+
+    it('should not show links to edit level details', () => {
+      return request(app)
+        .get('/incentive-levels')
+        .set('authorization', `bearer ${tokenWithNecessaryRole}`)
+        .expect(res => {
+          expect(res.text).not.toContain('/incentive-levels/edit/')
+        })
+    })
   })
 
   describe('details of a level', () => {
@@ -235,6 +246,199 @@ describe('Incentive level management', () => {
 
       return request(app)
         .get('/incentive-levels/view/ABC')
+        .set('authorization', `bearer ${tokenWithNecessaryRole}`)
+        .expect(404)
+    })
+  })
+
+  describe('editing a level', () => {
+    type PrefillTestCase = {
+      scenario: string
+      sampleIncentiveLevelIndex: number
+      expectedAvailability: string
+    }
+    const prefillTestCases: PrefillTestCase[] = [
+      {
+        scenario: 'a required level',
+        sampleIncentiveLevelIndex: 1,
+        expectedAvailability: 'required',
+      },
+      {
+        scenario: 'a non-required level',
+        sampleIncentiveLevelIndex: 3,
+        expectedAvailability: 'active',
+      },
+      {
+        scenario: 'an inactive level',
+        sampleIncentiveLevelIndex: 5,
+        expectedAvailability: 'inactive',
+      },
+    ]
+    it.each(prefillTestCases)(
+      'should prefill form with details of $scenario',
+      ({ sampleIncentiveLevelIndex, expectedAvailability }: PrefillTestCase) => {
+        const $ = jquery(new JSDOM().window) as unknown as typeof jquery
+
+        const incentiveLevel = sampleIncentiveLevels[sampleIncentiveLevelIndex]
+        incentivesApi.getIncentiveLevel.mockResolvedValue(incentiveLevel)
+
+        return request(app)
+          .get('/incentive-levels/edit/STD')
+          .set('authorization', `bearer ${tokenWithNecessaryRole}`)
+          .expect(res => {
+            const $body = $(res.text)
+            const $form = $body.find('form')
+            const formValues = Object.fromEntries($form.serializeArray().map(pair => [pair.name, pair.value]))
+            expect(formValues).toHaveProperty('name', incentiveLevel.name)
+            expect(formValues).toHaveProperty('availability', expectedAvailability)
+          })
+      },
+    )
+
+    type SuccessTestCase = {
+      scenario: string
+      name: string
+      availability: IncentiveLevelData['availability']
+    }
+    const successTestCases: SuccessTestCase[] = [
+      {
+        scenario: 'no change',
+        name: 'Standard',
+        availability: 'required',
+      },
+      {
+        scenario: 'a name change',
+        name: 'Silver',
+        availability: 'required',
+      },
+      {
+        scenario: 'it becoming inactive',
+        name: 'Standard',
+        availability: 'inactive',
+      },
+      {
+        scenario: 'it becoming not required',
+        name: 'Standard',
+        availability: 'active',
+      },
+    ]
+    it.each(successTestCases)('should allow saving level details with $scenario', ({ name, availability }) => {
+      const expectedActive = availability !== 'inactive'
+      const expectedRequired = availability === 'required'
+      incentivesApi.updateIncentiveLevel.mockResolvedValue({
+        ...sampleIncentiveLevels[1],
+        name,
+        active: expectedActive,
+        required: expectedRequired,
+      })
+
+      const form: IncentiveLevelData = {
+        formId: 'incentiveLevelEditForm',
+        name,
+        availability,
+      }
+
+      return request(app)
+        .post('/incentive-levels/edit/STD')
+        .set('authorization', `bearer ${tokenWithNecessaryRole}`)
+        .send(form)
+        .expect(res => {
+          expect(res.redirect).toBeTruthy()
+          expect(res.headers.location).toBe('/incentive-levels/view/STD')
+
+          expect(incentivesApi.updateIncentiveLevel).toHaveBeenCalledWith('STD', {
+            name,
+            active: expectedActive,
+            required: expectedRequired,
+          })
+        })
+    })
+
+    type FailureTestCase = {
+      scenario: string
+      errorMessage: string
+      name?: unknown
+      availability?: unknown
+    }
+    const failureTestCases: FailureTestCase[] = [
+      {
+        scenario: 'form is empty',
+        errorMessage: 'There is a problem',
+      },
+      {
+        scenario: 'name is missing',
+        errorMessage: 'The level’s name is required',
+        name: '',
+        availability: 'required',
+      },
+      {
+        scenario: 'the availability is not chosen',
+        errorMessage: 'Availability must be chosen',
+        name: 'Standard',
+        availability: '',
+      },
+      {
+        scenario: 'the availability is invalid',
+        errorMessage: 'Availability must be chosen',
+        name: 'Standard',
+        availability: 'none',
+      },
+    ]
+    it.each(failureTestCases)('should show errors when $scenario', ({ errorMessage, name, availability }) => {
+      const $ = jquery(new JSDOM().window) as unknown as typeof jquery
+
+      return request(app)
+        .post('/incentive-levels/edit/STD')
+        .set('authorization', `bearer ${tokenWithNecessaryRole}`)
+        .send({ formId: 'incentiveLevelEditForm', name, availability })
+        .expect(res => {
+          const $body = $(res.text)
+
+          const errorSummary = $body.find('.govuk-error-summary')
+          expect(errorSummary.length).toEqual(1)
+          expect(errorSummary.text()).toContain(errorMessage)
+
+          expect(incentivesApi.updateIncentiveLevel).not.toHaveBeenCalled()
+        })
+    })
+
+    it('should show error message returned by api', () => {
+      const error: SanitisedError<ErrorResponse> = {
+        status: 500,
+        message: 'Internal Server Error',
+        stack: 'Internal Server Error',
+      }
+      incentivesApi.updateIncentiveLevel.mockRejectedValue(error)
+
+      const validForm: IncentiveLevelData = {
+        formId: 'incentiveLevelEditForm',
+        name: 'Standard',
+        availability: 'required',
+      }
+
+      return request(app)
+        .post('/incentive-levels/edit/STD')
+        .set('authorization', `bearer ${tokenWithNecessaryRole}`)
+        .send(validForm)
+        .redirects(1)
+        .expect(res => {
+          expect(res.text).toContain('Incentive level details were not saved!')
+          expect(res.text).not.toContain('Internal Server Error')
+
+          expect(incentivesApi.updateIncentiveLevel).toHaveBeenCalled()
+        })
+    })
+
+    it('should 404 if level does not exist', () => {
+      const error: SanitisedError<ErrorResponse> = {
+        status: 404,
+        message: 'Not Found',
+        stack: 'Not Found',
+      }
+      incentivesApi.getIncentiveLevel.mockRejectedValue(error)
+
+      return request(app)
+        .get('/incentive-levels/edit/ABC')
         .set('authorization', `bearer ${tokenWithNecessaryRole}`)
         .expect(404)
     })

--- a/server/routes/incentiveLevels.ts
+++ b/server/routes/incentiveLevels.ts
@@ -270,9 +270,14 @@ export default function routes(router: Router): Router {
         let message = 'Incentive level was not created!'
         const errorResponse = (error as SanitisedError<ErrorResponse>).data
         if (ErrorResponse.isErrorResponse(errorResponse)) {
-          const userMessage = errorResponse.userMessage?.trim() || ''
-          if (userMessage.length > 0) {
-            message = `${message}\n\n${userMessage}`
+          if (errorResponse.errorCode === ErrorCode.IncentiveLevelCodeNotUnique) {
+            message =
+              'Incentive level was not created because the code must be unique. Go back and try a different code.'
+          } else {
+            const userMessage = errorResponse.userMessage?.trim() || ''
+            if (userMessage.length > 0) {
+              message = `${message}\n\n${userMessage}`
+            }
           }
         }
         req.flash('warning', message)

--- a/server/routes/incentiveLevels.ts
+++ b/server/routes/incentiveLevels.ts
@@ -49,7 +49,7 @@ export default function routes(router: Router): Router {
         return
       }
       if (!req.body.formId || req.body.formId !== formId) {
-        logger.error(`Form posted with incorrect formId=${req.body.formId} when only ${formId} are allowed`)
+        logger.error(`Form posted with incorrect formId=${req.body.formId} when only ${formId} is allowed`)
         next(new BadRequest())
         return
       }

--- a/server/routes/incentiveLevels.ts
+++ b/server/routes/incentiveLevels.ts
@@ -17,6 +17,9 @@ export const manageIncentiveLevelsRole = 'ROLE_MAINTAIN_INCENTIVE_LEVELS'
 export default function routes(router: Router): Router {
   const get = (path: string, handler: RequestHandler) => router.get(path, asyncMiddleware(handler))
 
+  /*
+   * List of all incentive levels that exist globally, whether in use or historic
+   */
   get('/', async (req, res) => {
     const incentivesApi = new IncentivesApi(res.locals.user.token)
 
@@ -27,6 +30,10 @@ export default function routes(router: Router): Router {
     res.render('pages/incentiveLevels.njk', { messages: req.flash(), incentiveLevels, canChangeStatus })
   })
 
+  /*
+   * Detail view of a specific incentive level
+   * NB: Only for super-admin use; not linked to
+   */
   get('/view/:levelCode', async (req, res) => {
     const incentivesApi = new IncentivesApi(res.locals.user.token)
 
@@ -40,6 +47,9 @@ export default function routes(router: Router): Router {
     res.render('pages/incentiveLevel.njk', { messages: req.flash(), incentiveLevel })
   })
 
+  /*
+   * Set whether an incentive level is active, i.e. available for prisons to use
+   */
   const statusFormId = 'incentiveLevelStatusForm' as const
   router.all(
     ['/status/:levelCode'],
@@ -123,6 +133,10 @@ export default function routes(router: Router): Router {
     }),
   )
 
+  /*
+   * Edit any of an existing incentive level’s details
+   * NB: Only for super-admin use; not linked to
+   */
   const editFormId = 'incentiveLevelEditForm' as const
   router.all(
     ['/edit/:levelCode'],
@@ -230,6 +244,9 @@ export default function routes(router: Router): Router {
     }),
   )
 
+  /*
+   * Create a new incentive level which is automatically active but not required
+   */
   const createFormId = 'incentiveLevelCreateForm' as const
   router.all(
     ['/add'],
@@ -299,6 +316,10 @@ export default function routes(router: Router): Router {
     }),
   )
 
+  /*
+   * Change the order of incentive levels
+   * NB: Only for super-admin use; not linked to
+   */
   const reorderFormId = 'incentiveLevelReorderForm' as const
   router.all(
     ['/reorder'],

--- a/server/routes/incentiveLevels.ts
+++ b/server/routes/incentiveLevels.ts
@@ -16,9 +16,10 @@ export default function routes(router: Router): Router {
     const incentivesApi = new IncentivesApi(res.locals.user.token)
 
     const incentiveLevels = await incentivesApi.getIncentiveLevels(true)
+    const canChangeStatus = incentiveLevels.some(incentiveLevel => !incentiveLevel.required)
 
     res.locals.breadcrumbs.addItems({ text: 'Global incentive level admin' })
-    res.render('pages/incentiveLevels.njk', { messages: req.flash(), incentiveLevels })
+    res.render('pages/incentiveLevels.njk', { messages: req.flash(), incentiveLevels, canChangeStatus })
   })
 
   get('/view/:levelCode', async (req, res) => {

--- a/server/routes/incentiveLevels.ts
+++ b/server/routes/incentiveLevels.ts
@@ -17,7 +17,7 @@ export default function routes(router: Router): Router {
 
     const incentiveLevels = await incentivesApi.getIncentiveLevels(true)
 
-    res.locals.breadcrumbs.addItems({ text: 'Manage levels' })
+    res.locals.breadcrumbs.addItems({ text: 'Global incentive level admin' })
     res.render('pages/incentiveLevels.njk', { messages: req.flash(), incentiveLevels })
   })
 
@@ -27,7 +27,10 @@ export default function routes(router: Router): Router {
     const { levelCode } = req.params
     const incentiveLevel = await incentivesApi.getIncentiveLevel(levelCode)
 
-    res.locals.breadcrumbs.addItems({ text: 'Manage levels', href: '/incentive-levels' }, { text: incentiveLevel.name })
+    res.locals.breadcrumbs.addItems(
+      { text: 'Global incentive level admin', href: '/incentive-levels' },
+      { text: incentiveLevel.name },
+    )
     res.render('pages/incentiveLevel.njk', { messages: req.flash(), incentiveLevel })
   })
 
@@ -176,8 +179,8 @@ export default function routes(router: Router): Router {
       }
 
       res.locals.breadcrumbs.addItems(
-        { text: 'Manage levels', href: '/incentive-levels' },
-        { text: incentiveLevel ? incentiveLevel.name : 'Add new level' },
+        { text: 'Global incentive level admin', href: '/incentive-levels' },
+        { text: incentiveLevel ? 'Change incentive level details' : 'Create a new incentive level' },
       )
       res.render('pages/incentiveLevelForm.njk', {
         messages: req.flash(),

--- a/server/routes/incentiveLevels.ts
+++ b/server/routes/incentiveLevels.ts
@@ -30,7 +30,7 @@ export default function routes(router: Router): Router {
 
     res.locals.breadcrumbs.addItems(
       { text: 'Global incentive level admin', href: '/incentive-levels' },
-      { text: incentiveLevel.name },
+      { text: `View details for ${incentiveLevel.name}` },
     )
     res.render('pages/incentiveLevel.njk', { messages: req.flash(), incentiveLevel })
   })

--- a/server/routes/incentiveLevels.ts
+++ b/server/routes/incentiveLevels.ts
@@ -6,7 +6,7 @@ import type { SanitisedError } from '../sanitisedError'
 import asyncMiddleware from '../middleware/asyncMiddleware'
 import { IncentivesApi, ErrorResponse } from '../data/incentivesApi'
 import { requireGetOrPost } from './forms/forms'
-import IncentiveLevelForm from './forms/incentiveLevelForm'
+import IncentiveLevelEditForm from './forms/incentiveLevelEditForm'
 import IncentiveLevelStatusForm from './forms/incentiveLevelStatusForm'
 
 export const manageIncentiveLevelsRole = 'ROLE_MAINTAIN_INCENTIVE_LEVELS'
@@ -115,21 +115,21 @@ export default function routes(router: Router): Router {
     }),
   )
 
-  const formId = 'incentiveLevelEditForm' as const
+  const editFormId = 'incentiveLevelEditForm' as const
   router.all(
     ['/edit/:levelCode'],
     requireGetOrPost,
     asyncMiddleware(async (req: Request, res: Response, next: NextFunction) => {
-      const form = new IncentiveLevelForm(formId)
+      const form = new IncentiveLevelEditForm(editFormId)
       res.locals.forms = res.locals.forms || {}
-      res.locals.forms[formId] = form
+      res.locals.forms[editFormId] = form
 
       if (req.method !== 'POST') {
         next()
         return
       }
-      if (!req.body.formId || req.body.formId !== formId) {
-        logger.error(`Form posted with incorrect formId=${req.body.formId} when only ${formId} is allowed`)
+      if (!req.body.formId || req.body.formId !== editFormId) {
+        logger.error(`Form posted with incorrect formId=${req.body.formId} when only ${editFormId} is allowed`)
         next(new BadRequest())
         return
       }
@@ -188,7 +188,7 @@ export default function routes(router: Router): Router {
       const { levelCode } = req.params
       const incentiveLevel = await incentivesApi.getIncentiveLevel(levelCode)
 
-      const form: IncentiveLevelForm = res.locals.forms[formId]
+      const form: IncentiveLevelEditForm = res.locals.forms[editFormId]
       if (!form.submitted) {
         let availability
         if (incentiveLevel.required) {
@@ -199,7 +199,7 @@ export default function routes(router: Router): Router {
           availability = 'inactive' as const
         }
         form.submit({
-          formId,
+          formId: editFormId,
           name: incentiveLevel.name,
           availability,
         })
@@ -209,7 +209,7 @@ export default function routes(router: Router): Router {
         { text: 'Global incentive level admin', href: '/incentive-levels' },
         { text: `Change details for ${incentiveLevel.name}` },
       )
-      res.render('pages/incentiveLevelForm.njk', {
+      res.render('pages/incentiveLevelEditForm.njk', {
         messages: req.flash(),
         form,
         incentiveLevel,

--- a/server/testData/prisonApi.ts
+++ b/server/testData/prisonApi.ts
@@ -1,6 +1,21 @@
-import type { Location } from '../data/prisonApi'
+import type { Agency, Location } from '../data/prisonApi'
 
-function getTestLocation({
+export const sampleAgencies: Record<string, Agency> = {
+  MDI: {
+    agencyId: 'MDI',
+    description: 'Moorland (HMP & YOI)',
+    agencyType: 'INST',
+    active: true,
+  },
+  WRI: {
+    agencyId: 'WRI',
+    description: 'Whitemoor (HMP & YOI)',
+    agencyType: 'INST',
+    active: true,
+  },
+}
+
+export function getTestLocation({
   agencyId = 'MDI',
   locationId = 2,
   locationPrefix = 'MDI-2',
@@ -22,6 +37,3 @@ function getTestLocation({
     operationalCapacity: 200,
   }
 }
-
-// eslint-disable-next-line import/prefer-default-export
-export { getTestLocation }

--- a/server/views/pages/home.njk
+++ b/server/views/pages/home.njk
@@ -84,8 +84,8 @@
           {{ card({
             href: "/incentive-levels",
             clickable: "true",
-            heading: "Manage incentive levels in all prisons",
-            description: "Add and remove incentive levels which are available for all establishments to use.",
+            heading: "Global incentive level admin",
+            description: "Create and change the status of incentive levels across all establishments.",
             id: "manage-incentive-levels"
           }) }}
         </li>

--- a/server/views/pages/incentiveLevel.njk
+++ b/server/views/pages/incentiveLevel.njk
@@ -1,10 +1,9 @@
 {% extends "../partials/layout.njk" %}
 
-{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 
-{% set pageTitle = applicationName + " – " + incentiveLevel.name %}
+{% set pageTitle = applicationName + " – View details for " + incentiveLevel.name %}
 
 {% block content %}
   <div class="govuk-grid-row">
@@ -13,23 +12,19 @@
       {% include "../partials/messages.njk" %}
 
       <h1 class="govuk-heading-xl" data-qa="incentive-levels-detail">
-        {{ incentiveLevel.name }}
+        View details for {{ incentiveLevel.name }}
       </h1>
 
-      {{ govukBackLink({
-        text: "Back",
-        href: "/incentive-levels"
-      }) }}
-
       {% if incentiveLevel.required %}
-        {% set availability = "Required in all prisons" %}
+        {% set availability = "Mandatory in all prisons" %}
       {% elif incentiveLevel.active %}
         {% set availability = "Available for prisons to use" %}
       {% else %}
-        {% set availability = "Disabled" %}
+        {% set availability = "Not available for prisons to use" %}
       {% endif %}
 
       {{ govukSummaryList({
+        attributes: { "data-qa": "incentive-level-summary-list" },
         rows: [
           {
             key: { text: "Code" },
@@ -46,7 +41,7 @@
         ]
       }) }}
 
-      <div class="govuk-button-group">
+      <div class="govuk-button-group govuk-!-margin-top-8">
         {{ govukButton({
           text: "Edit details",
           element: "a",

--- a/server/views/pages/incentiveLevel.njk
+++ b/server/views/pages/incentiveLevel.njk
@@ -52,25 +52,6 @@
           element: "a",
           href: "/incentive-levels/edit/" + incentiveLevel.code
         }) }}
-
-        {% if not incentiveLevel.active %}
-
-          {{ govukButton({
-            text: "Allow prisons to use this level",
-            element: "a",
-            href: "/incentive-levels/activate/" + incentiveLevel.code
-          }) }}
-
-        {% elif not incentiveLevel.required %}
-
-          {{ govukButton({
-            text: "Disable this level",
-            classes: "govuk-button--warning",
-            element: "a",
-            href: "/incentive-levels/deactivate/" + incentiveLevel.code
-          }) }}
-
-        {% endif %}
       </div>
 
     </div>

--- a/server/views/pages/incentiveLevel.njk
+++ b/server/views/pages/incentiveLevel.njk
@@ -4,7 +4,7 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 
-{% set pageTitle = applicationName + " – " + incentiveLevel.name + " level" %}
+{% set pageTitle = applicationName + " – " + incentiveLevel.name %}
 
 {% block content %}
   <div class="govuk-grid-row">
@@ -13,7 +13,7 @@
       {% include "../partials/messages.njk" %}
 
       <h1 class="govuk-heading-xl" data-qa="incentive-levels-detail">
-        {{ incentiveLevel.name }} level
+        {{ incentiveLevel.name }}
       </h1>
 
       {{ govukBackLink({

--- a/server/views/pages/incentiveLevelCreateForm.njk
+++ b/server/views/pages/incentiveLevelCreateForm.njk
@@ -1,0 +1,70 @@
+{% extends "../partials/layout.njk" %}
+
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/input/macro.njk" import govukInput %}
+
+{% set pageTitle = applicationName + " – Create a new incentive level" %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-one-half">
+
+      {% include "../partials/messages.njk" %}
+      {% include "../partials/formErrorSummary.njk" %}
+
+      <h1 class="govuk-heading-xl" data-qa="incentive-levels-create">
+        Create a new incentive level
+      </h1>
+      <p>
+        Enter details of the incentive level you want to create.
+        These details cannot be changed later.
+      </p>
+
+      <form id="form-{{ form.formId }}" method="post" novalidate>
+
+        {% set fieldId = "name" %}
+        {% set field = form.getField(fieldId) %}
+        {{ govukInput({
+          label: { text: "Name of incentive level", classes: "govuk-label--m" },
+          classes: "govuk-input--width-20",
+          id: form.formId + "-" + fieldId,
+          name: fieldId,
+          value: field.value,
+          errorMessage: { text: field.error } if field.error else undefined
+        }) }}
+
+        {% set fieldId = "code" %}
+        {% set field = form.getField(fieldId) %}
+        {{ govukInput({
+          label: { text: "Code", classes: "govuk-label--m" },
+          hint: { text: "Enter a code containing 3 letters or numbers. For example, EN4. This will only be visible in NOMIS." },
+          classes: "govuk-input--width-3",
+          id: form.formId + "-" + fieldId,
+          name: fieldId,
+          value: field.value,
+          spellcheck: false,
+          errorMessage: { text: field.error } if field.error else undefined
+        }) }}
+
+        <input type="hidden" name="formId" value="{{ form.formId }}" />
+        <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
+
+        <div class="govuk-button-group govuk-!-margin-top-8">
+          {{ govukButton({
+            text: "Save",
+            preventDoubleClick: true
+          }) }}
+
+          {{ govukButton({
+            text: "Cancel",
+            classes: "govuk-button--secondary",
+            element: "a",
+            href: "/incentive-levels"
+          }) }}
+        </div>
+
+      </form>
+
+    </div>
+  </div>
+{% endblock %}

--- a/server/views/pages/incentiveLevelEditForm.njk
+++ b/server/views/pages/incentiveLevelEditForm.njk
@@ -13,7 +13,7 @@
       {% include "../partials/messages.njk" %}
       {% include "../partials/formErrorSummary.njk" %}
 
-      <h1 class="govuk-heading-xl" data-qa="incentive-levels-form">
+      <h1 class="govuk-heading-xl" data-qa="incentive-levels-edit">
         Change details for {{ incentiveLevel.name }}
       </h1>
 

--- a/server/views/pages/incentiveLevelForm.njk
+++ b/server/views/pages/incentiveLevelForm.njk
@@ -16,9 +16,9 @@
 
       <h1 class="govuk-heading-xl" data-qa="incentive-levels-form">
         {% if incentiveLevel %}
-          {{ incentiveLevel.name }} level
+          Change incentive level details
         {% else %}
-          Add new level
+          Create a new incentive level
         {% endif %}
       </h1>
 

--- a/server/views/pages/incentiveLevelForm.njk
+++ b/server/views/pages/incentiveLevelForm.njk
@@ -1,11 +1,10 @@
 {% extends "../partials/layout.njk" %}
 
-{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/input/macro.njk" import govukInput %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 
-{% set pageTitle = applicationName + " – " + incentiveLevel.name + " level" %}
+{% set pageTitle = applicationName + " – Change details for " + incentiveLevel.name %}
 
 {% block content %}
   <div class="govuk-grid-row">
@@ -15,34 +14,10 @@
       {% include "../partials/formErrorSummary.njk" %}
 
       <h1 class="govuk-heading-xl" data-qa="incentive-levels-form">
-        {% if incentiveLevel %}
-          Change incentive level details
-        {% else %}
-          Create a new incentive level
-        {% endif %}
+        Change details for {{ incentiveLevel.name }}
       </h1>
 
-      {{ govukBackLink({
-        text: "Back",
-        href: "/incentive-levels/view/" + incentiveLevel.code if incentiveLevel else "/incentive-levels"
-      }) }}
-
       <form id="form-{{ form.formId }}" method="post" novalidate>
-
-        {% if not incentiveLevel %}
-          {% set fieldId = "code" %}
-          {% set field = form.getField(fieldId) %}
-          {{ govukInput({
-            label: { text: "Code" },
-            hint: { text: "Only used internally, normally 3 capital letters" },
-            classes: "govuk-input--width-3",
-            id: form.formId + "-" + fieldId,
-            name: fieldId,
-            value: field.value,
-            spellcheck: false,
-            errorMessage: { text: field.error } if field.error else undefined
-          }) }}
-        {% endif %}
 
         {% set fieldId = "name" %}
         {% set field = form.getField(fieldId) %}
@@ -66,7 +41,7 @@
           },
           items: [
             {
-              text: "Required in all prisons",
+              text: "Mandatory in all prisons",
               value: "required",
               checked: field.value === "required"
             },
@@ -76,7 +51,7 @@
               checked: field.value === "active"
             },
             {
-              text: "Disabled",
+              text: "Not available for prisons to use",
               value: "inactive",
               checked: field.value === "inactive"
             }
@@ -87,10 +62,19 @@
         <input type="hidden" name="formId" value="{{ form.formId }}" />
         <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
 
-        {{ govukButton({
-          text: "Save",
-          preventDoubleClick: true
-        }) }}
+        <div class="govuk-button-group govuk-!-margin-top-8">
+          {{ govukButton({
+            text: "Save",
+            preventDoubleClick: true
+          }) }}
+
+          {{ govukButton({
+            text: "Cancel",
+            classes: "govuk-button--secondary",
+            element: "a",
+            href: "/incentive-levels/view/" + incentiveLevel.code
+          }) }}
+        </div>
 
       </form>
 

--- a/server/views/pages/incentiveLevelReorderForm.njk
+++ b/server/views/pages/incentiveLevelReorderForm.njk
@@ -1,0 +1,100 @@
+{% extends "../partials/layout.njk" %}
+
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/table/macro.njk" import govukTable %}
+{% from "govuk/components/tag/macro.njk" import govukTag %}
+
+{% set pageTitle = applicationName + " – Change order of levels" %}
+
+{% block head %}
+  {{ super() }}
+  <style nonce="{{ cspNonce }}">
+    [data-qa=incentive-levels-reorder-table] .govuk-button {
+      margin: 0;
+    }
+  </style>
+{% endblock %}
+
+{% macro moveForm(code, direction) %}
+  <form id="form-{{ form.formId }}-{{ code }}" method="post" novalidate>
+    <input type="hidden" name="code" value="{{ code }}" />
+    {{ govukButton({
+      text: "Move " + direction,
+      name: "direction",
+      value: direction,
+      preventDoubleClick: true
+    }) }}
+    <input type="hidden" name="formId" value="{{ form.formId }}" />
+    <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
+  </form>
+{% endmacro %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      {% include "../partials/messages.njk" %}
+      {% include "../partials/formErrorSummary.njk" %}
+
+      <h1 class="govuk-heading-xl" data-qa="incentive-levels-reorder">
+        Change order of levels
+      </h1>
+
+      {% set rows = [] %}
+
+      {% for incentiveLevel in incentiveLevels %}
+        {% set statusHtml %}
+          {% if incentiveLevel.active %}
+            {{ govukTag({ text: "Active" }) }}
+          {% else %}
+            {{ govukTag({ text: "Inactive", classes: "govuk-tag--grey" }) }}
+          {% endif %}
+        {% endset %}
+
+        {% set moveUpForm -%}
+          {% if not loop.first %}
+            {{ moveForm(incentiveLevel.code, "up") }}
+          {% endif %}
+        {%- endset %}
+
+        {% set moveDownForm -%}
+          {% if not loop.last %}
+            {{ moveForm(incentiveLevel.code, "down") }}
+          {% endif %}
+        {%- endset %}
+
+        {% set rows = (rows.push([
+          { text: incentiveLevel.name },
+          { text: incentiveLevel.code },
+          { html: statusHtml },
+          { html: moveUpForm },
+          { html: moveDownForm }
+        ]), rows) %}
+      {% endfor %}
+
+      {% set head = [
+        { text: "Incentive level" },
+        { text: "Code" },
+        { text: "Status" },
+        { text: "Action", colspan: 2 }
+      ] %}
+      {{ govukTable({
+        caption: "Move incentive levels up and down for all establishments",
+        captionClasses: "govuk-table__caption--m",
+        attributes: { "data-qa": "incentive-levels-reorder-table" },
+        head: head,
+        rows: rows
+      }) }}
+
+      <div class="govuk-button-group govuk-!-margin-top-8">
+        {{ govukButton({
+          text: "Cancel",
+          classes: "govuk-button--secondary",
+          element: "a",
+          href: "/incentive-levels"
+        }) }}
+      </div>
+
+    </div>
+  </div>
+{% endblock %}

--- a/server/views/pages/incentiveLevelStatusForm.njk
+++ b/server/views/pages/incentiveLevelStatusForm.njk
@@ -1,0 +1,68 @@
+{% extends "../partials/layout.njk" %}
+
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
+
+{% set pageTitle = applicationName + " – Select incentive level status" %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      {% include "../partials/messages.njk" %}
+      {% include "../partials/formErrorSummary.njk" %}
+
+      <h1 class="govuk-heading-xl" data-qa="incentive-levels-status">
+        Select incentive level status
+      </h1>
+
+      <form id="form-{{ form.formId }}" method="post" novalidate>
+
+        {% set fieldId = "status" %}
+        {% set field = form.getField(fieldId) %}
+        {{ govukRadios({
+          attributes: { id: form.formId + "-" + fieldId },
+          name: fieldId,
+          items: [
+            {
+              text: "Active",
+              hint: {
+                text: "Make the level available for all establishments to use."
+              },
+              value: "active",
+              checked: field.value === "active"
+            },
+            {
+              text: "Inactive",
+              hint: {
+                text: "Prevent establishments from using the level. It will not show up in local settings. This cannot be selected if any establishments already use the level."
+              },
+              value: "inactive",
+              checked: field.value === "inactive"
+            }
+          ],
+          errorMessage: { text: field.error } if field.error else undefined
+        }) }}
+
+        <input type="hidden" name="formId" value="{{ form.formId }}" />
+        <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
+
+        <div class="govuk-button-group govuk-!-margin-top-8">
+          {{ govukButton({
+            text: "Save",
+            preventDoubleClick: true
+          }) }}
+
+          {{ govukButton({
+            text: "Cancel",
+            classes: "govuk-button--secondary",
+            element: "a",
+            href: "/incentive-levels"
+          }) }}
+        </div>
+
+      </form>
+
+    </div>
+  </div>
+{% endblock %}

--- a/server/views/pages/incentiveLevels.njk
+++ b/server/views/pages/incentiveLevels.njk
@@ -29,32 +29,14 @@
           {% endif %}
         {% endset %}
 
-        {% set actions = [] %}
-        {% if not loop.first %}
-          {%  set actions = (actions.push({
-            href: "/incentive-levels/move-up/" + incentiveLevel.code,
-            text: "▲",
-            visuallyHiddenText: "Move level up"
-          }), actions) %}
-        {% endif %}
-        {% if not loop.last %}
-          {%  set actions = (actions.push({
-            href: "/incentive-levels/move-down/" + incentiveLevel.code,
-            text: "▼",
-            visuallyHiddenText: "Move level down"
-          }), actions) %}
-        {% endif %}
-        {%  set actions = (actions.push({
-          href: "/incentive-levels/view/" + incentiveLevel.code,
-          text: "View",
-          visuallyHiddenText: "level details"
-        }), actions) %}
-
         {% set rows = (rows.push({
-          classes: "app-incentive-levels-list",
           key: { text: "Level" },
           value: { html: nameHtml },
-          actions: { items: actions }
+          actions: { items: [{
+            href: "/incentive-levels/view/" + incentiveLevel.code,
+            text: "View",
+            visuallyHiddenText: "level details"
+          }] }
         }), rows) %}
       {% endfor %}
 

--- a/server/views/pages/incentiveLevels.njk
+++ b/server/views/pages/incentiveLevels.njk
@@ -1,7 +1,7 @@
 {% extends "../partials/layout.njk" %}
 
 {% from "govuk/components/button/macro.njk" import govukButton %}
-{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+{% from "govuk/components/table/macro.njk" import govukTable %}
 {% from "govuk/components/tag/macro.njk" import govukTag %}
 
 {% set pageTitle = applicationName + " – Incentive levels" %}
@@ -19,38 +19,61 @@
       {% set rows = [] %}
 
       {% for incentiveLevel in incentiveLevels %}
-        {% set nameHtml %}
-          {{ incentiveLevel.name }}
-          {% if not incentiveLevel.active %}
-            {{ govukTag({
-              text: "Disabled",
-              classes: "govuk-tag--grey"
-            }) }}
+        {% set statusHtml %}
+          {% if incentiveLevel.active %}
+            {{ govukTag({ text: "Active" }) }}
+          {% else %}
+            {{ govukTag({ text: "Inactive", classes: "govuk-tag--grey" }) }}
           {% endif %}
         {% endset %}
 
-        {% set rows = (rows.push({
-          key: { text: "Level" },
-          value: { html: nameHtml },
-          actions: { items: [{
-            href: "/incentive-levels/view/" + incentiveLevel.code,
-            text: "View",
-            visuallyHiddenText: "level details"
-          }] }
-        }), rows) %}
+        {% set changeAction -%}
+          {% if not incentiveLevel.required %}
+            <a href="/incentive-levels/status/{{ incentiveLevel.code }}">Change status</a>
+          {% endif %}
+        {%- endset %}
+
+        {% set row = [
+          { text: incentiveLevel.name },
+          { text: incentiveLevel.code },
+          { html: statusHtml }
+        ] %}
+        {% if canChangeStatus %}
+          {% set row = (row.push(
+            { html: changeAction, classes: "govuk-!-text-align-right" }
+          ), row) %}
+        {% endif %}
+
+        {% set rows = (rows.push(row), rows) %}
       {% endfor %}
 
-      {{ govukSummaryList({
+      {% set head = [
+        { text: "Incentive level" },
+        { text: "Code" },
+        { text: "Status" }
+      ] %}
+      {% if canChangeStatus %}
+        {% set head = (head.push(
+          { text: "Action", classes: "govuk-!-text-align-right" }
+        ), head) %}
+      {% endif %}
+
+      {{ govukTable({
+        caption: "Incentive levels across all establishments",
+        captionClasses: "govuk-table__caption--m",
+        classes: "govuk-!-margin-top-8",
+        attributes: { "data-qa": "incentive-levels-table" },
+        head: head,
         rows: rows
       }) }}
 
-      <p>
+      <div class="govuk-button-group govuk-!-margin-top-8">
         {{ govukButton({
-          text: "Add a new level",
+          text: "Create a new incentive level",
           element: "a",
           href: "/incentive-levels/add"
         }) }}
-      </p>
+      </div>
 
     </div>
   </div>

--- a/server/views/pages/incentiveLevels.njk
+++ b/server/views/pages/incentiveLevels.njk
@@ -13,7 +13,7 @@
       {% include "../partials/messages.njk" %}
 
       <h1 class="govuk-heading-xl" data-qa="incentive-levels-list">
-        Incentive levels
+        Global incentive level admin
       </h1>
 
       {% set rows = [] %}


### PR DESCRIPTION
Improves on #436 and #437. Users…
• can only access this section with an appropriate role (only in `dev` for now)
• can create new incentive levels at the end of the existing list
• can change the status of existing incentive levels unless they are required in every prison
• _cannot_ update levels’ names (must be done using incentives api)
• _cannot_ set whether any level is required in all prisons (must be done using incentives api)
• _cannot_ reorder levels (must be done using incentives api)
