### PR TITLE
INC-1250: Automatically add any missing required incentive levels to a prison

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -96,7 +96,7 @@
       },
       "engines": {
         "node": "^18",
-        "npm": "^9.6.5"
+        "npm": "^9"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/server/routes/incentiveLevels.ts
+++ b/server/routes/incentiveLevels.ts
@@ -49,6 +49,7 @@ export default function routes(router: Router): Router {
 
   /*
    * Set whether an incentive level is active, i.e. available for prisons to use
+   * NB: Deactivating is only allowed if the level is not active in any prison
    */
   const statusFormId = 'incentiveLevelStatusForm' as const
   router.all(

--- a/server/routes/incentiveLevels.ts
+++ b/server/routes/incentiveLevels.ts
@@ -408,7 +408,7 @@ async function errorMessageWhenCannotDeactivate(prisonApi: PrisonApi, errorRespo
     .map(prisonId => prisonId.trim())
     .filter(prisonName => prisonName)
     .map(prisonId =>
-      prisonApi.getAgency(prisonId.trim(), false).catch(error => {
+      prisonApi.getAgency(prisonId, false).catch(error => {
         logger.error(`Could not look up agency \`${prisonId}\` in prison-api`, error)
       }),
     )

--- a/server/routes/prisonIncentiveLevels.test.ts
+++ b/server/routes/prisonIncentiveLevels.test.ts
@@ -273,6 +273,27 @@ describe('Prison incentive level management', () => {
           expect(incentivesApi.updatePrisonIncentiveLevel).toHaveBeenCalledWith('MDI', 'ENH', { active: true })
         })
     })
+
+    it('should set Standard as the default level if there is none set when all require levels are actice', () => {
+      incentivesApi.getPrisonIncentiveLevels.mockResolvedValue(
+        samplePrisonIncentiveLevels
+          .filter(prisonIncentiveLevel => prisonIncentiveLevel.active)
+          .map(prisonIncentiveLevel => {
+            return { ...prisonIncentiveLevel, defaultOnAdmission: false }
+          }),
+      )
+
+      return request(app)
+        .get('/prison-incentive-levels')
+        .set('authorization', `bearer ${tokenWithNecessaryRole}`)
+        .expect(res => {
+          expect(incentivesApi.updatePrisonIncentiveLevel).toHaveBeenCalledTimes(1)
+          expect(incentivesApi.updatePrisonIncentiveLevel).toHaveBeenCalledWith('MDI', 'STD', {
+            active: true,
+            defaultOnAdmission: true,
+          })
+        })
+    })
   })
 
   describe('details of a level', () => {

--- a/server/routes/prisonIncentiveLevels.test.ts
+++ b/server/routes/prisonIncentiveLevels.test.ts
@@ -122,9 +122,11 @@ describe('Prison incentive level management', () => {
       const $ = jquery(new JSDOM().window) as unknown as typeof jquery
       // pretend that only BAS & STD are required
       incentivesApi.getIncentiveLevels.mockResolvedValue(
-        sampleIncentiveLevels.map((incentiveLevel, index) => {
-          return { ...incentiveLevel, required: index < 2 }
-        }),
+        sampleIncentiveLevels
+          .filter(incentiveLevel => incentiveLevel.active)
+          .map((incentiveLevel, index) => {
+            return { ...incentiveLevel, required: index < 2 }
+          }),
       )
 
       return request(app)
@@ -176,7 +178,7 @@ describe('Prison incentive level management', () => {
         })
     })
 
-    it('should show not add level button when there are no more available levels', () => {
+    it('should not show add level button when there are no more available levels', () => {
       // pretend that only BAS, STD & ENH exist all of which are already active
       incentivesApi.getIncentiveLevels.mockResolvedValue(
         sampleIncentiveLevels.filter(incentiveLevel =>
@@ -192,6 +194,63 @@ describe('Prison incentive level management', () => {
         .set('authorization', `bearer ${tokenWithNecessaryRole}`)
         .expect(res => {
           expect(res.text).not.toContain('Add a new incentive level')
+        })
+    })
+
+    it('should not activate any levels when no required level is missing', () => {
+      return request(app)
+        .get('/prison-incentive-levels')
+        .set('authorization', `bearer ${tokenWithNecessaryRole}`)
+        .expect(res => {
+          expect(res.redirect).toBeFalsy()
+          expect(incentivesApi.updatePrisonIncentiveLevel).not.toHaveBeenCalled()
+        })
+    })
+
+    it('should activate one missing required level', () => {
+      // pretend that EN2 is also required
+      incentivesApi.getIncentiveLevels.mockResolvedValue(
+        sampleIncentiveLevels
+          .filter(incentiveLevel => incentiveLevel.active)
+          .map(incentiveLevel => {
+            return {
+              ...incentiveLevel,
+              required: ['BAS', 'STD', 'ENH', 'EN2'].includes(incentiveLevel.code),
+            }
+          }),
+      )
+
+      return request(app)
+        .get('/prison-incentive-levels')
+        .set('authorization', `bearer ${tokenWithNecessaryRole}`)
+        .expect(res => {
+          expect(res.redirect).toBeTruthy()
+          expect(incentivesApi.updatePrisonIncentiveLevel).toHaveBeenCalledTimes(1)
+          expect(incentivesApi.updatePrisonIncentiveLevel).toHaveBeenCalledWith('MDI', 'EN2', { active: true })
+        })
+    })
+
+    it('should activate all missing required levels', () => {
+      // pretend that EN2 & EN3 are also required
+      incentivesApi.getIncentiveLevels.mockResolvedValue(
+        sampleIncentiveLevels
+          .filter(incentiveLevel => incentiveLevel.active)
+          .map(incentiveLevel => {
+            return {
+              ...incentiveLevel,
+              required: true,
+            }
+          }),
+      )
+
+      return request(app)
+        .get('/prison-incentive-levels')
+        .set('authorization', `bearer ${tokenWithNecessaryRole}`)
+        .expect(res => {
+          expect(res.redirect).toBeTruthy()
+          expect(incentivesApi.updatePrisonIncentiveLevel).toHaveBeenCalledTimes(2)
+          expect(incentivesApi.updatePrisonIncentiveLevel).toHaveBeenCalledWith('MDI', 'EN2', { active: true })
+          expect(incentivesApi.updatePrisonIncentiveLevel).toHaveBeenCalledWith('MDI', 'EN3', { active: true })
         })
     })
   })

--- a/server/routes/prisonIncentiveLevels.test.ts
+++ b/server/routes/prisonIncentiveLevels.test.ts
@@ -230,7 +230,7 @@ describe('Prison incentive level management', () => {
         })
     })
 
-    it('should activate all missing required levels', () => {
+    it('should activate several missing required levels', () => {
       // pretend that EN2 & EN3 are also required
       incentivesApi.getIncentiveLevels.mockResolvedValue(
         sampleIncentiveLevels
@@ -251,6 +251,26 @@ describe('Prison incentive level management', () => {
           expect(incentivesApi.updatePrisonIncentiveLevel).toHaveBeenCalledTimes(2)
           expect(incentivesApi.updatePrisonIncentiveLevel).toHaveBeenCalledWith('MDI', 'EN2', { active: true })
           expect(incentivesApi.updatePrisonIncentiveLevel).toHaveBeenCalledWith('MDI', 'EN3', { active: true })
+        })
+    })
+
+    it('should activate all missing required levels, but first make Standard the default for admissions', () => {
+      // simulate new prison
+      incentivesApi.getPrisonIncentiveLevels.mockResolvedValue([])
+
+      return request(app)
+        .get('/prison-incentive-levels')
+        .set('authorization', `bearer ${tokenWithNecessaryRole}`)
+        .expect(res => {
+          expect(res.redirect).toBeTruthy()
+          expect(incentivesApi.updatePrisonIncentiveLevel).toHaveBeenCalledTimes(4)
+          expect(incentivesApi.updatePrisonIncentiveLevel).toHaveBeenNthCalledWith(1, 'MDI', 'STD', {
+            active: true,
+            defaultOnAdmission: true,
+          })
+          expect(incentivesApi.updatePrisonIncentiveLevel).toHaveBeenCalledWith('MDI', 'BAS', { active: true })
+          expect(incentivesApi.updatePrisonIncentiveLevel).toHaveBeenCalledWith('MDI', 'STD', { active: true })
+          expect(incentivesApi.updatePrisonIncentiveLevel).toHaveBeenCalledWith('MDI', 'ENH', { active: true })
         })
     })
   })

--- a/server/routes/prisonIncentiveLevels.ts
+++ b/server/routes/prisonIncentiveLevels.ts
@@ -22,6 +22,9 @@ export const managePrisonIncentiveLevelsRole = 'ROLE_MAINTAIN_PRISON_IEP_LEVELS'
 export default function routes(router: Router): Router {
   const get = (path: string, handler: RequestHandler) => router.get(path, asyncMiddleware(handler))
 
+  /*
+   * List of active incentive levels in the prison
+   */
   get('/', async (req, res) => {
     const incentivesApi = new IncentivesApi(res.locals.user.token)
 
@@ -85,6 +88,9 @@ export default function routes(router: Router): Router {
     })
   })
 
+  /*
+   * Detail view of active incentive level in the prison with associated information
+   */
   get('/view/:levelCode', async (req, res) => {
     const incentivesApi = new IncentivesApi(res.locals.user.token)
 
@@ -107,6 +113,10 @@ export default function routes(router: Router): Router {
     })
   })
 
+  /*
+   * Remove an incentive level from the prison
+   * NB: Only allowed when there are no prisoners on the level
+   */
   const deactivateFormId = 'prisonIncentiveLevelDeactivateForm' as const
   router.all(
     '/remove/:levelCode',
@@ -215,6 +225,9 @@ export default function routes(router: Router): Router {
     }),
   )
 
+  /*
+   * Edit associated information of an active incentive level in the prison
+   */
   const editFormId = 'prisonIncentiveLevelEditForm' as const
   router.all(
     '/edit/:levelCode',
@@ -336,6 +349,9 @@ export default function routes(router: Router): Router {
     }),
   )
 
+  /*
+   * Add an available incentive level to the prison
+   */
   const addFormId = 'prisonIncentiveLevelAddForm' as const
   router.all(
     ['/add', '/add/:levelCode'],


### PR DESCRIPTION
This is useful for new prisons so that they adopt the standard set of levels.
Additionally, if a prison has no default-for-admissions level (a data inconsistency problem) it will automatically gain Standard.