### PR TITLE
Tie css cache to version of application

### DIFF
--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -4,6 +4,7 @@ import express from 'express'
 import * as pathModule from 'path'
 
 import config from '../config'
+import applicationVersion from '../applicationVersion'
 import { calculateTrendsRange, makeChartPalette } from './analytics'
 import format from './format'
 import { daysSince, initialiseName } from './utils'
@@ -27,8 +28,8 @@ export default function nunjucksSetup(app: express.Express, path: pathModule.Pla
 
   // Cachebusting version string
   if (production) {
-    // Version only changes on reboot
-    app.locals.version = Date.now().toString()
+    // Version only changes with new commits
+    app.locals.version = applicationVersion.gitRef
   } else {
     // Version changes every request
     app.use((req, res, next) => {


### PR DESCRIPTION
(slight modification to [hmpps-template-typescript#188](https://github.com/ministryofjustice/hmpps-template-typescript/pull/188))

At the moment the cache is linked to the start up time of pod, so get unnecessary cache misses for each pod in the cluster and also when pods restart

This ties the cache to the git ~short~ hash of the deployment