### PR TITLE
INC-1233: Preliminary incentive level name validation

### DIFF
--- a/server/routes/forms/incentiveLevelCreateForm.test.ts
+++ b/server/routes/forms/incentiveLevelCreateForm.test.ts
@@ -12,11 +12,26 @@ describe('IncentiveLevelCreateForm', () => {
       name: 'Enhanced 4',
       code: 'EN4',
     },
+    {
+      name: ' Enhanced 4  ',
+      code: 'EN4',
+    },
   ]
   it.each(validData)('with valid data', testCase => {
     const form = new IncentiveLevelCreateForm(formId)
     form.submit({ formId, ...testCase })
     expect(form.hasErrors).toBeFalsy()
+  })
+
+  it('trims name', () => {
+    const form = new IncentiveLevelCreateForm(formId)
+    form.submit({
+      formId,
+      name: ' Enhanced 4  ',
+      code: 'EN4',
+    })
+    expect(form.hasErrors).toBeFalsy()
+    expect(form.getField('name').value).toEqual('Enhanced 4')
   })
 
   const invalidData: [string, unknown][] = [
@@ -25,6 +40,13 @@ describe('IncentiveLevelCreateForm', () => {
       'blank name',
       {
         name: '',
+        code: 'ABC',
+      },
+    ],
+    [
+      'name with only spaces',
+      {
+        name: '   ',
         code: 'ABC',
       },
     ],

--- a/server/routes/forms/incentiveLevelCreateForm.test.ts
+++ b/server/routes/forms/incentiveLevelCreateForm.test.ts
@@ -78,6 +78,13 @@ describe('IncentiveLevelCreateForm', () => {
         code: 'E 4',
       },
     ],
+    [
+      'excessively long name',
+      {
+        name: 'Standard level for all prisoners',
+        code: 'STD',
+      },
+    ],
   ]
   it.each(invalidData)('with invalid data: %s', (_, testCase: unknown) => {
     const form = new IncentiveLevelCreateForm(formId)

--- a/server/routes/forms/incentiveLevelCreateForm.ts
+++ b/server/routes/forms/incentiveLevelCreateForm.ts
@@ -7,11 +7,13 @@ export interface IncentiveLevelCreateData extends BaseFormData {
 
 export default class IncentiveLevelCreateForm extends Form<IncentiveLevelCreateData> {
   protected validate(): void {
-    if (!this.data.name || this.data.name.length < 1) {
+    this.data.name = this.data.name?.trim() ?? ''
+    if (this.data.name.length < 1) {
       this.addError('name', 'The level’s name is required')
     }
     // TODO: add max length limit to `name` & error message once determined
     //       NOMIS has hard limit of 40, incentives DB is 30
+
     const codeRE = /^[A-Za-z0-9]{3}$/
     if (!codeRE.test(this.data.code)) {
       this.addError('code', 'The level’s code must be 3 letters or numbers')

--- a/server/routes/forms/incentiveLevelCreateForm.ts
+++ b/server/routes/forms/incentiveLevelCreateForm.ts
@@ -10,9 +10,9 @@ export default class IncentiveLevelCreateForm extends Form<IncentiveLevelCreateD
     this.data.name = this.data.name?.trim() ?? ''
     if (this.data.name.length < 1) {
       this.addError('name', 'The level’s name is required')
+    } else if (this.data.name.length > 30) {
+      this.addError('name', 'The name must be no more than 30 characters in length')
     }
-    // TODO: add max length limit to `name` & error message once determined
-    //       NOMIS has hard limit of 40, incentives DB is 30
 
     const codeRE = /^[A-Za-z0-9]{3}$/
     if (!codeRE.test(this.data.code)) {

--- a/server/routes/forms/incentiveLevelEditForm.test.ts
+++ b/server/routes/forms/incentiveLevelEditForm.test.ts
@@ -7,6 +7,7 @@ describe('IncentiveLevelEditForm', () => {
     { name: 'Standard', availability: 'required' },
     { name: 'Basic', availability: 'active' },
     { name: 'Entry', availability: 'inactive' },
+    { name: 'Entry   ', availability: 'inactive' },
   ]
   it.each(validData)('with valid data', (testCase: Partial<IncentiveLevelEditData>) => {
     const form = new IncentiveLevelEditForm(formId)
@@ -14,10 +15,22 @@ describe('IncentiveLevelEditForm', () => {
     expect(form.hasErrors).toBeFalsy()
   })
 
+  it('trims name', () => {
+    const form = new IncentiveLevelEditForm(formId)
+    form.submit({
+      formId,
+      name: ' Enhanced 4  ',
+      availability: 'inactive',
+    })
+    expect(form.hasErrors).toBeFalsy()
+    expect(form.getField('name').value).toEqual('Enhanced 4')
+  })
+
   const invalidData: unknown[] = [
     {},
     { name: 'Standard' },
     { name: '', availability: 'required' },
+    { name: '    ', availability: 'required' },
     { name: 'Basic', availability: 'none' },
   ]
   it.each(invalidData)('with invalid data', (testCase: unknown) => {

--- a/server/routes/forms/incentiveLevelEditForm.test.ts
+++ b/server/routes/forms/incentiveLevelEditForm.test.ts
@@ -32,6 +32,7 @@ describe('IncentiveLevelEditForm', () => {
     { name: '', availability: 'required' },
     { name: '    ', availability: 'required' },
     { name: 'Basic', availability: 'none' },
+    { name: '123456789 123456789 123456789 X', availability: 'required' },
   ]
   it.each(invalidData)('with invalid data', (testCase: unknown) => {
     const form = new IncentiveLevelEditForm(formId)

--- a/server/routes/forms/incentiveLevelEditForm.test.ts
+++ b/server/routes/forms/incentiveLevelEditForm.test.ts
@@ -26,15 +26,15 @@ describe('IncentiveLevelEditForm', () => {
     expect(form.getField('name').value).toEqual('Enhanced 4')
   })
 
-  const invalidData: unknown[] = [
-    {},
-    { name: 'Standard' },
-    { name: '', availability: 'required' },
-    { name: '    ', availability: 'required' },
-    { name: 'Basic', availability: 'none' },
-    { name: '123456789 123456789 123456789 X', availability: 'required' },
+  const invalidData: [string, unknown][] = [
+    ['empty submission', {}],
+    ['missing availability', { name: 'Standard' }],
+    ['blank name', { name: '', availability: 'required' }],
+    ['name with only spaces', { name: '    ', availability: 'required' }],
+    ['invalid availability', { name: 'Basic', availability: 'none' }],
+    ['excessively long name', { name: '123456789 123456789 123456789 X', availability: 'required' }],
   ]
-  it.each(invalidData)('with invalid data', (testCase: unknown) => {
+  it.each(invalidData)('with invalid data: %s', (_, testCase: unknown) => {
     const form = new IncentiveLevelEditForm(formId)
     form.submit({ formId, ...(testCase as Partial<IncentiveLevelEditData>) })
     expect(form.hasErrors).toBeTruthy()

--- a/server/routes/forms/incentiveLevelEditForm.ts
+++ b/server/routes/forms/incentiveLevelEditForm.ts
@@ -10,9 +10,9 @@ export default class IncentiveLevelEditForm extends Form<IncentiveLevelEditData>
     this.data.name = this.data.name?.trim() ?? ''
     if (this.data.name.length < 1) {
       this.addError('name', 'The level’s name is required')
+    } else if (this.data.name.length > 30) {
+      this.addError('name', 'The name must be no more than 30 characters in length')
     }
-    // TODO: add max length limit to `name` & error message once determined
-    //       NOMIS has hard limit of 40, incentives DB is 30
 
     if (!['required', 'active', 'inactive'].includes(this.data.availability)) {
       delete this.data.availability

--- a/server/routes/forms/incentiveLevelEditForm.ts
+++ b/server/routes/forms/incentiveLevelEditForm.ts
@@ -7,9 +7,13 @@ export interface IncentiveLevelEditData extends BaseFormData {
 
 export default class IncentiveLevelEditForm extends Form<IncentiveLevelEditData> {
   protected validate(): void {
-    if (!this.data.name || this.data.name.length < 1) {
+    this.data.name = this.data.name?.trim() ?? ''
+    if (this.data.name.length < 1) {
       this.addError('name', 'The level’s name is required')
     }
+    // TODO: add max length limit to `name` & error message once determined
+    //       NOMIS has hard limit of 40, incentives DB is 30
+
     if (!['required', 'active', 'inactive'].includes(this.data.availability)) {
       delete this.data.availability
       this.addError('availability', 'Availability must be chosen')

--- a/server/routes/forms/incentiveLevelReorderForm.test.ts
+++ b/server/routes/forms/incentiveLevelReorderForm.test.ts
@@ -13,13 +13,13 @@ describe('IncentiveLevelReorderForm', () => {
     expect(form.hasErrors).toBeFalsy()
   })
 
-  const invalidData: unknown[] = [
-    {},
-    { code: 'ENT' },
-    { code: '', direction: 'up' },
-    { code: 'ENT', direction: 'higher' },
+  const invalidData: [string, unknown][] = [
+    ['empty submission', {}],
+    ['missing direction', { code: 'ENT' }],
+    ['blank code', { code: '', direction: 'up' }],
+    ['invalid direction', { code: 'ENT', direction: 'higher' }],
   ]
-  it.each(invalidData)('with invalid data', (testCase: unknown) => {
+  it.each(invalidData)('with invalid data: %s', (_, testCase: unknown) => {
     const form = new IncentiveLevelReorderForm(formId)
     form.submit({ formId, ...(testCase as Partial<IncentiveLevelReorderData>) })
     expect(form.hasErrors).toBeTruthy()

--- a/server/routes/incentiveLevels.test.ts
+++ b/server/routes/incentiveLevels.test.ts
@@ -585,13 +585,14 @@ describe('Incentive level management', () => {
         name: 'Gold 2',
         required: true,
       }
-
       incentivesApi.updateIncentiveLevel.mockResolvedValue(expected)
+
       const form: IncentiveLevelEditData = {
         formId: 'incentiveLevelEditForm',
         name: '    Gold 2    ',
         availability: 'required',
       }
+
       // When a user edits an incentive level name that includes leading/preceding whitespaces
       // Then expect the whitespaces to have been removed
       return request(app)
@@ -601,6 +602,7 @@ describe('Incentive level management', () => {
         .expect(res => {
           expect(res.redirect).toBeTruthy()
           expect(res.headers.location).toBe('/incentive-levels/view/EN2')
+
           expect(incentivesApi.updateIncentiveLevel).toHaveBeenCalledWith('EN2', {
             name: expected.name,
             active: expected.active,
@@ -901,11 +903,13 @@ describe('Incentive level management', () => {
         required: false,
       }
       incentivesApi.createIncentiveLevel.mockResolvedValue(expected)
+
       const form: IncentiveLevelCreateData = {
         formId: 'incentiveLevelCreateForm',
         name: ' Enhanced 5   ',
         code: 'EN5',
       }
+
       // When a user submits a form with a name that contains leading/preceding whitespaces
       // Then expect the whitespaces to have been removed
       return request(app)
@@ -915,6 +919,7 @@ describe('Incentive level management', () => {
         .expect(res => {
           expect(res.redirect).toBeTruthy()
           expect(res.headers.location).toBe('/incentive-levels/status/EN5')
+
           expect(incentivesApi.createIncentiveLevel).toHaveBeenCalledWith(expected)
         })
     })

--- a/server/routes/incentiveLevels.ts
+++ b/server/routes/incentiveLevels.ts
@@ -12,10 +12,6 @@ import IncentiveLevelEditForm from './forms/incentiveLevelEditForm'
 import IncentiveLevelReorderForm from './forms/incentiveLevelReorderForm'
 import IncentiveLevelStatusForm from './forms/incentiveLevelStatusForm'
 
-export function sanitiseIncentiveName(name: string) {
-  return name.trim()
-}
-
 export const manageIncentiveLevelsRole = 'ROLE_MAINTAIN_INCENTIVE_LEVELS'
 
 export default function routes(router: Router): Router {
@@ -187,7 +183,7 @@ export default function routes(router: Router): Router {
 
       try {
         const updatedIncentiveLevel = await incentivesApi.updateIncentiveLevel(levelCode, {
-          name: sanitiseIncentiveName(form.getField('name').value),
+          name: form.getField('name').value,
           active,
           required,
         })
@@ -232,7 +228,7 @@ export default function routes(router: Router): Router {
         }
         form.submit({
           formId: editFormId,
-          name: sanitiseIncentiveName(incentiveLevel.name),
+          name: incentiveLevel.name,
           availability,
         })
       }
@@ -282,7 +278,7 @@ export default function routes(router: Router): Router {
       try {
         const incentiveLevel = await incentivesApi.createIncentiveLevel({
           code: form.getField('code').value,
-          name: sanitiseIncentiveName(form.getField('name').value),
+          name: form.getField('name').value,
           active: true,
           required: false,
         })


### PR DESCRIPTION
Whilst the exact error messages and level name length limits are being determined, we can already put in the hard 30-character limit. That’s the maximum that the incentives-api will allow. As it happens, NOMIS permits up to 40 characters, but this has been deemed excessive.