### PR TITLE
INC-1270: Handle location and characteristic labels being null in analytics charts source data

### DIFF
--- a/server/services/analyticsServiceUtils.test.ts
+++ b/server/services/analyticsServiceUtils.test.ts
@@ -21,11 +21,15 @@ describe('comparators and filters', () => {
     { a: { label: '1' }, b: { label: 'Unknown' }, expected: -1 },
     { a: { label: 'A' }, b: { label: '1' }, expected: 1 },
     { a: { label: 'A' }, b: { label: 'B' }, expected: -1 },
+    { a: { label: 'C' }, b: { label: 'C' }, expected: 0 },
     { a: { label: 'SEG' }, b: { label: 'X' }, expected: 1 },
     { a: { label: 'RECP' }, b: { label: 'SEG' }, expected: -1 },
     { a: { label: 'RECP' }, b: { label: 'Non-wing' }, expected: -1 },
     { a: { label: 'RECP' }, b: { label: 'Unknown' }, expected: -1 },
     { a: { label: 'Unknown' }, b: { label: 'Non-wing' }, expected: 1 },
+    { a: { label: null }, b: { label: 'Non-wing' }, expected: 1 },
+    { a: { label: 'RECP' }, b: { label: null }, expected: -1 },
+    { a: { label: null }, b: { label: null }, expected: 1 },
   ])('compareLocations()', ({ a, b, expected }) => {
     let compares = '='
     if (expected > 0) {
@@ -44,11 +48,15 @@ describe('comparators and filters', () => {
     { a: { label: 'Unknown' }, b: { label: 'All' }, expected: 1 },
     { a: { label: 'Other' }, b: { label: 'All' }, expected: 1 },
     { a: { label: 'White' }, b: { label: 'All' }, expected: 1 },
+    { a: { label: 'Asian or Asian British' }, b: { label: 'Asian or Asian British' }, expected: 0 },
     { a: { label: 'Asian or Asian British' }, b: { label: 'Other' }, expected: -1 },
     { a: { label: 'Asian or Asian British' }, b: { label: 'Unknown' }, expected: -1 },
     { a: { label: 'Yes' }, b: { label: 'Unknown' }, expected: -1 },
     { a: { label: 'Other' }, b: { label: 'Yes' }, expected: 1 },
     { a: { label: 'Unknown' }, b: { label: 'Other' }, expected: 1 },
+    { a: { label: null }, b: { label: 'Other' }, expected: 1 },
+    { a: { label: 'Yes' }, b: { label: null }, expected: -1 },
+    { a: { label: null }, b: { label: null }, expected: 1 },
   ])('compareCharacteristics()', ({ a, b, expected }) => {
     let compares = '='
     if (expected > 0) {

--- a/server/services/analyticsServiceUtils.ts
+++ b/server/services/analyticsServiceUtils.ts
@@ -115,7 +115,9 @@ type BaseReportRow = { label: string }
 /**
  * Used to sort rows with locations
  */
-export function compareLocations({ label: location1 }: BaseReportRow, { label: location2 }: BaseReportRow) {
+export function compareLocations({ label: label1 }: BaseReportRow, { label: label2 }: BaseReportRow) {
+  const location1 = label1 ?? 'Unknown'
+  const location2 = label2 ?? 'Unknown'
   if (location1 === 'All') {
     return -1
   }
@@ -146,10 +148,9 @@ export function compareLocations({ label: location1 }: BaseReportRow, { label: l
 /**
  * Used to sort rows with protected characteristics
  */
-export function compareCharacteristics(
-  { label: characteristic1 }: BaseReportRow,
-  { label: characteristic2 }: BaseReportRow,
-) {
+export function compareCharacteristics({ label: label1 }: BaseReportRow, { label: label2 }: BaseReportRow) {
+  const characteristic1 = label1 ?? 'Unknown'
+  const characteristic2 = label2 ?? 'Unknown'
   if (characteristic1 === 'All') {
     return -1
   }


### PR DESCRIPTION
The source data was expected to always provide a `pgd_region` (one of https://github.com/ministryofjustice/hmpps-incentives-ui/blob/77e78f4cfe04360679871e37aeae75d4113c1de4/server/services/pgdRegionService.ts#L8-L29) but it’s become necessary to handle nulls. It’s likely that the data-exporting pipeline does not handle new/unexpected prisons.