### PR TITLE
Add type assertions to prevent "implicit any" errors

### DIFF
--- a/bin/download-source-tables.ts
+++ b/bin/download-source-tables.ts
@@ -22,7 +22,7 @@ const [tableTypeKey, date, savePath] = process.argv.slice(2, 5)
 if (process.argv.length !== 5 || !tableTypes.includes(tableTypeKey) || !/^\d\d\d\d-\d\d-\d\d$/.test(date)) {
   printHelpAndExit()
 }
-const tableType = TableType[tableTypeKey]
+const tableType = TableType[tableTypeKey as keyof typeof TableType]
 const tableKey = `${tableType}/${date}.json`
 
 const s3Client = new S3Client(config.s3)

--- a/bin/list-source-tables.ts
+++ b/bin/list-source-tables.ts
@@ -18,7 +18,7 @@ const [tableTypeKey] = process.argv.slice(2, 3)
 if (process.argv.length !== 3 || !tableTypes.includes(tableTypeKey)) {
   printHelpAndExit()
 }
-const tableType = TableType[tableTypeKey]
+const tableType = TableType[tableTypeKey as keyof typeof TableType]
 
 const s3Client = new S3Client(config.s3)
 s3Client.listObjects(tableType).then(objects => {

--- a/bin/truncate-source-table.ts
+++ b/bin/truncate-source-table.ts
@@ -20,7 +20,7 @@ if (process.argv.length !== 4 || !tableTypes.includes(chosenTableType)) {
 }
 const destPath = path.resolve(
   __dirname,
-  `../server/testData/s3Bucket/${TableType[chosenTableType]}/${path.basename(sourcePath)}`,
+  `../server/testData/s3Bucket/${TableType[chosenTableType as keyof typeof TableType]}/${path.basename(sourcePath)}`,
 )
 
 const characteristicsToKeep: ReadonlySet<string> = new Set([

--- a/integration_tests/tsconfig.json
+++ b/integration_tests/tsconfig.json
@@ -6,7 +6,7 @@
     "types": ["cypress", "express", "express-session"],
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "typeRoots": ["../server/@types"]
+    "typeRoots": ["../server/@types", "../node_modules/@types", "../node_modules"],
   },
   "include": ["**/*.ts"]
 }

--- a/server/routes/analyticsPrecacheTables.ts
+++ b/server/routes/analyticsPrecacheTables.ts
@@ -6,10 +6,10 @@ import S3Client from '../data/s3Client'
 import AnalyticsView from '../services/analyticsView'
 import AnalyticsService from '../services/analyticsService'
 import { Ages, ProtectedCharacteristic } from '../services/analyticsServiceTypes'
-import PgdRegionService, { National } from '../services/pgdRegionService'
+import PgdRegionService, { National, type PgdRegionCode } from '../services/pgdRegionService'
 import { cache } from './analyticsRouter'
 
-async function precacheTablesForRegion(region: string | null) {
+async function precacheTablesForRegion(region: typeof National | PgdRegionCode | null) {
   // NB: viewType and activeCaseLoad have no effect on what data is loaded and stitched
   const analyticsView = new AnalyticsView(region, 'behaviour-entries', 'MDI')
   const s3Client = new S3Client(config.s3)
@@ -39,7 +39,7 @@ async function precachePrisonTables() {
 
 async function precacheRegionTables() {
   // NB: specific region has no effect on what data is loaded and stitched
-  await precacheTablesForRegion(PgdRegionService.getPgdRegionByCode('WLS').code)
+  await precacheTablesForRegion(PgdRegionService.getPgdRegionByCode('WLS').code as PgdRegionCode)
   setImmediate(precacheNationalTables)
 }
 

--- a/server/routes/analyticsRouter.ts
+++ b/server/routes/analyticsRouter.ts
@@ -17,7 +17,7 @@ import type { ChartId } from './analyticsChartTypes'
 import { requireGetOrPost } from './forms/forms'
 import ChartFeedbackForm from './forms/chartFeedbackForm'
 import PrisonRegister from '../data/prisonRegister'
-import PgdRegionService, { National, type PgdRegion } from '../services/pgdRegionService'
+import PgdRegionService, { National, type PgdRegionCode } from '../services/pgdRegionService'
 import {
   StitchedTablesCache,
   MemoryStitchedTablesCache,
@@ -94,8 +94,9 @@ export default function routes(router: Router): Router {
   })
 
   get('/select-pgd-region', async (req, res) => {
-    const options = [{ value: National, text: National }].concat(
-      PgdRegionService.getAllPgdRegions().map((pgdRegion: PgdRegion) => ({
+    const options: { value: string; text: string }[] = [{ value: National, text: National }]
+    options.push(
+      ...PgdRegionService.getAllPgdRegions().map(pgdRegion => ({
         value: pgdRegion.code,
         text: pgdRegion.name,
       })),
@@ -131,7 +132,7 @@ export default function routes(router: Router): Router {
   routeWithFeedback('/behaviour-entries', behaviourEntryChartIds, async (req, res) => {
     res.locals.breadcrumbs.addItems({ text: 'Behaviour entries' })
 
-    const { pgdRegionCode } = req.params
+    const { pgdRegionCode } = req.params as { pgdRegionCode: PgdRegionCode }
     const activeCaseLoad = res.locals.user.activeCaseload.id
     const analyticsView = new AnalyticsView(pgdRegionCode, 'behaviour-entries', activeCaseLoad)
     if (!analyticsView.isValidPgdRegion) {
@@ -162,7 +163,7 @@ export default function routes(router: Router): Router {
   routeWithFeedback('/incentive-levels', incentiveLevelChartIds, async (req, res) => {
     res.locals.breadcrumbs.addItems({ text: 'Incentive levels' })
 
-    const { pgdRegionCode } = req.params
+    const { pgdRegionCode } = req.params as { pgdRegionCode: PgdRegionCode }
     const activeCaseLoad = res.locals.user.activeCaseload.id
     const analyticsView = new AnalyticsView(pgdRegionCode, 'incentive-levels', activeCaseLoad)
     if (!analyticsView.isValidPgdRegion) {
@@ -227,14 +228,14 @@ export default function routes(router: Router): Router {
 
     const activeCaseLoad = res.locals.user.activeCaseload.id
 
-    const { pgdRegionCode } = req.params
+    const { pgdRegionCode } = req.params as { pgdRegionCode: PgdRegionCode }
     const analyticsView = new AnalyticsView(pgdRegionCode, 'protected-characteristic', activeCaseLoad)
     if (!analyticsView.isValidPgdRegion) {
       res.redirect('/analytics/select-pgd-region')
       return
     }
 
-    const characteristicName = (req.query.characteristic || 'age') as string
+    const characteristicName = (req.query.characteristic || 'age') as keyof typeof protectedCharacteristicRoutes
     if (!(characteristicName in protectedCharacteristicRoutes)) {
       next(new NotFound())
       return

--- a/server/services/analyticsView.test.ts
+++ b/server/services/analyticsView.test.ts
@@ -1,4 +1,5 @@
 import AnalyticsView from './analyticsView'
+import type { PgdRegionCode } from './pgdRegionService'
 
 const viewTypes: ('behaviour-entries' | 'incentive-levels' | 'protected-characteristic')[] = [
   'behaviour-entries',
@@ -22,7 +23,7 @@ describe('AnalyticsView', () => {
       })
 
       it('returns false when PGD region code is not recognised', () => {
-        const analyticsView = new AnalyticsView('INVALID_REGION_CODE', 'behaviour-entries', 'MDI')
+        const analyticsView = new AnalyticsView('INVALID_REGION_CODE' as PgdRegionCode, 'behaviour-entries', 'MDI')
         expect(analyticsView.isValidPgdRegion).toEqual(false)
       })
     })

--- a/server/services/analyticsView.ts
+++ b/server/services/analyticsView.ts
@@ -1,4 +1,4 @@
-import PgdRegionService, { National, type PgdRegion } from './pgdRegionService'
+import PgdRegionService, { National, type PgdRegion, type PgdRegionCode } from './pgdRegionService'
 import type { AnalyticsChartContent } from '../routes/analyticsChartsContent'
 import {
   BehaviourEntriesChartsContent,
@@ -67,7 +67,7 @@ export default class AnalyticsView {
 
   protected protectedCharacteristicsChartsContent: Record<string, AnalyticsChartContent>
 
-  constructor(pgdRegionCode: string | null, viewType: ViewType, activeCaseLoad: string) {
+  constructor(pgdRegionCode: typeof National | PgdRegionCode | null, viewType: ViewType, activeCaseLoad: string) {
     if (pgdRegionCode) {
       if (pgdRegionCode === National) {
         this.viewLevel = 'national'

--- a/server/services/pgdRegionService.test.ts
+++ b/server/services/pgdRegionService.test.ts
@@ -1,4 +1,4 @@
-import PgdRegionService from './pgdRegionService'
+import PgdRegionService, { type PgdRegionCode } from './pgdRegionService'
 
 describe('PgdRegion Service', () => {
   it('getAllPgdRegions() returns all PgdRegions', () => {
@@ -14,7 +14,7 @@ describe('PgdRegion Service', () => {
     })
 
     it('does not return a PgdRegion if it cannot find one', () => {
-      const pgdRegion = PgdRegionService.getPgdRegionByCode('test')
+      const pgdRegion = PgdRegionService.getPgdRegionByCode('test' as PgdRegionCode)
       expect(pgdRegion).toBeNull()
     })
   })

--- a/server/services/pgdRegionService.ts
+++ b/server/services/pgdRegionService.ts
@@ -1,11 +1,11 @@
-export const National: string = 'National' as const
+export const National = 'National' as const
 
 export interface PgdRegion {
   name: string
   code: string
 }
 
-const pgdRegions = {
+export const pgdRegions = {
   ASD: 'Avon and South Dorset',
   BCN: 'Bedfordshire, Cambridgeshire and Norfolk',
   CNTR: 'Contracted',
@@ -28,6 +28,8 @@ const pgdRegions = {
   YCS: 'Youth custody service',
 }
 
+export type PgdRegionCode = keyof typeof pgdRegions
+
 export default class PgdRegionService {
   static getAllPgdRegions(): PgdRegion[] {
     return Object.entries(pgdRegions).map(([code, name]) => {
@@ -35,7 +37,7 @@ export default class PgdRegionService {
     })
   }
 
-  static getPgdRegionByCode(pgdRegionCode: string): PgdRegion {
+  static getPgdRegionByCode(pgdRegionCode: PgdRegionCode): PgdRegion {
     const pgdRegionName = pgdRegions[pgdRegionCode]
     if (pgdRegionName) {
       return { code: pgdRegionCode, name: pgdRegionName }

--- a/server/testData/s3Bucket.ts
+++ b/server/testData/s3Bucket.ts
@@ -15,7 +15,7 @@ const fileDates = {
   [TableType.behaviourEntriesNationalAll]: new Date('2022-08-04T19:33:00Z'),
   [TableType.incentiveLevels]: new Date('2022-08-04T19:34:00Z'),
   [TableType.trends]: new Date('2022-08-04T19:35:00Z'),
-}
+} as const
 
 export enum MockTable {
   /** mimics a normal table */
@@ -33,7 +33,7 @@ function mockedListObjects(prefix: string, tableResponse: MockTable): { key: str
 
   const [tableType] = prefix.split('/', 1)
   if (tableType in fileDates) {
-    const fileDate = fileDates[tableType]
+    const fileDate = fileDates[tableType as keyof typeof fileDates]
     const fileName = filenameFromDate(fileDate)
     return [{ key: `${tableType}/${fileName}`, modified: fileDate }]
   }
@@ -49,7 +49,7 @@ function mockedGetObject(key: string, tableResponse: MockTable): string {
   let fileName = 'empty.json'
   if (tableResponse !== MockTable.Empty) {
     if (tableType in fileDates) {
-      const fileDate = fileDates[tableType]
+      const fileDate = fileDates[tableType as keyof typeof fileDates]
       fileName = filenameFromDate(fileDate)
     } else {
       throw new Error('Not implemented')

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,6 @@
     "strict": false,
     "outDir": "./dist",
     "sourceMap": true,
-    "suppressImplicitAnyIndexErrors": true,
     "noEmit": false,
     "allowJs": true,
     "checkJs": true,
@@ -14,7 +13,6 @@
     "noImplicitAny": true,
     "experimentalDecorators": true,
     "typeRoots": ["./server/@types", "./node_modules/@types"],
-    "ignoreDeprecations": "5.0"
   },
   "exclude": ["node_modules", "assets", "dist", "helm_deploy", "integration_tests", "test_results", "cypress.config.ts"],
   "include": ["**/*.js", "**/*.ts"]


### PR DESCRIPTION
… so that we don't need to ignore upcoming deprecations.

This does mean that some of the analytics charts required more type annotations which feel a little awkward but I wanted to change as little as possible by way of resulting JS.