### PR TITLE
INC-1280: Make non-production S3 buckets entirely read-only

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -132,30 +132,6 @@ jobs:
       - store_artifacts:
           path: integration-tests/screenshots
 
-  upload_test_data_to_s3:
-    executor:
-      name: hmpps/default_small
-      tag: << pipeline.parameters.python-version >>
-    steps:
-      - checkout
-      - hmpps/k8s_setup
-      - hmpps/install_aws_cli
-      - run:
-          name: Upload test data to S3 bucket
-          command: |
-            S3_BUCKET_NAME=$(kubectl --namespace="${KUBE_ENV_NAMESPACE}" get secret analytical-platform-s3-bucket-output -o go-template='{{.data.bucket_name|base64decode}}')
-            export AWS_ACCESS_KEY_ID=$(kubectl --namespace="${KUBE_ENV_NAMESPACE}" get secret analytical-platform-s3-bucket-output -o go-template='{{.data.access_key_id|base64decode}}')
-            export AWS_SECRET_ACCESS_KEY=$(kubectl --namespace="${KUBE_ENV_NAMESPACE}" get secret analytical-platform-s3-bucket-output -o go-template='{{.data.secret_access_key|base64decode}}')
-            aws s3 sync server/testData/s3Bucket s3://${S3_BUCKET_NAME} || export UPLOAD_FAILED=1
-            unset AWS_ACCESS_KEY_ID
-            unset AWS_SECRET_ACCESS_KEY
-            [ -n "$UPLOAD_FAILED" ] && {
-              echo 'Failed to upload test data'
-              exit 1
-            } || exit 0
-          environment:
-            AWS_DEFAULT_REGION: eu-west-2
-
 workflows:
   version: 2
   build-test-and-deploy:
@@ -193,12 +169,6 @@ workflows:
             - unit_test
             - integration_test
             - build_docker
-      - upload_test_data_to_s3:
-          name: upload_test_data_to_s3_dev
-          context:
-            - hmpps-common-vars
-          requires:
-            - deploy_dev
       - request-preprod-approval:
           type: approval
           requires:
@@ -214,13 +184,6 @@ workflows:
             - hmpps-incentives-ui-preprod
           requires:
             - request-preprod-approval
-      - upload_test_data_to_s3:
-          name: upload_test_data_to_s3_preprod
-          context:
-            - hmpps-common-vars
-            - hmpps-incentives-ui-preprod
-          requires:
-            - deploy_preprod
       - request-prod-approval:
           type: approval
           requires:

--- a/server/config.ts
+++ b/server/config.ts
@@ -68,6 +68,11 @@ export default {
   s3: {
     region: get('S3_REGION', 'eu-west-1', notRequiredInProduction),
     bucket: get('S3_BUCKET_NAME', 'example-bucket', requiredInProduction),
+    /**
+     * NB: the IAM access key is _not_ available to apps running in Cloud Platform,
+     * IRSA is used instead for read-only access to the bucket.
+     * For running locally and for integration testing, minio is used with an IAM access key.
+     */
     accessKeyId: get('S3_ACCESS_KEY_ID', null, notRequiredInProduction),
     secretAccessKey: get('S3_SECRET_ACCESS_KEY', null, notRequiredInProduction),
     endpoint: get('S3_ENDPOINT', null, notRequiredInProduction),

--- a/server/testData/s3Bucket/README.md
+++ b/server/testData/s3Bucket/README.md
@@ -1,0 +1,4 @@
+These files are used for testing analytics charts.
+
+They are also stored in the S3 buckets used in non-production applications runnin in Cloud Platform.
+NB: there is currently NO mechanism to update these file in the non-production S3 buckets.


### PR DESCRIPTION
CircleCI uses long-lived IAM access keys to upload test data into S3 buckets. Those credentials are being removed so the deployment pipeline cannot update S3 anymore from CircleCI.