### PR TITLE
Follow latest DPS standards for breadcrumbs so that the current page is not presented

### DIFF
--- a/integration_tests/e2e/aboutAnalytics.cy.ts
+++ b/integration_tests/e2e/aboutAnalytics.cy.ts
@@ -18,6 +18,7 @@ context('About Analytics page', () => {
 
   it('users can submit feedback', () => {
     let page = Page.verifyOnPage(AboutAnalyticsPage)
+    page.checkLastBreadcrumb('Manage incentives', '/')
 
     // leave some comments and submit
     page.feedbackForm.find('[name=informationUseful][value=no]').click()

--- a/integration_tests/e2e/aboutNationalPolicy.cy.ts
+++ b/integration_tests/e2e/aboutNationalPolicy.cy.ts
@@ -15,7 +15,8 @@ context('About National policy page', () => {
   })
 
   it('contains a summary of the National incentives policy', () => {
-    Page.verifyOnPage(AboutNationalPolicyPage)
+    const page = Page.verifyOnPage(AboutNationalPolicyPage)
+    page.checkLastBreadcrumb('Manage incentives', '/')
 
     cy.get('p').contains(
       'The national incentives policy framework (2020) is designed to help prisons incentivise good behaviour.',

--- a/integration_tests/e2e/analytics/behaviourEntries.cy.ts
+++ b/integration_tests/e2e/analytics/behaviourEntries.cy.ts
@@ -24,6 +24,7 @@ context('Analytics section > Behaviour entries page', () => {
     const homePage = Page.verifyOnPage(HomePage)
     homePage.viewAnalyticsLink().click()
     const analyticsPage = Page.verifyOnPage(AnalyticsIncentiveLevels)
+    analyticsPage.checkLastBreadcrumb('Manage incentives', '/')
     analyticsPage.behaviourEntriesNavItem.click()
   })
 
@@ -126,6 +127,7 @@ context('Pgd Region selection > National > Analytics section > Behaviour entries
     locationSelectionPage.changePgdRegionSelect().select('National')
     locationSelectionPage.continueButton().click()
     const analyticsPage = Page.verifyOnPage(AnalyticsIncentiveLevels)
+    analyticsPage.checkLastBreadcrumb('Manage incentives', '/')
     analyticsPage.behaviourEntriesNavItem.click()
   })
 
@@ -227,6 +229,7 @@ context('Pgd Region selection > LTHS > Analytics section > Behaviour entries pag
     locationSelectionPage.changePgdRegionSelect().select('LTHS')
     locationSelectionPage.continueButton().click()
     const analyticsPage = Page.verifyOnPage(AnalyticsIncentiveLevels)
+    analyticsPage.checkLastBreadcrumb('Manage incentives', '/')
     analyticsPage.behaviourEntriesNavItem.click()
   })
 

--- a/integration_tests/e2e/analytics/incentiveLevels.cy.ts
+++ b/integration_tests/e2e/analytics/incentiveLevels.cy.ts
@@ -22,7 +22,8 @@ context('Analytics section > Incentive levels page', () => {
 
     const homePage = Page.verifyOnPage(HomePage)
     homePage.viewAnalyticsLink().click()
-    Page.verifyOnPage(AnalyticsIncentiveLevels)
+    const analyticsPage = Page.verifyOnPage(AnalyticsIncentiveLevels)
+    analyticsPage.checkLastBreadcrumb('Manage incentives', '/')
   })
 
   it('has correct title', () => {
@@ -98,7 +99,8 @@ context('Pgd Region selection > National > Analytics section > Incentive levels 
     const locationSelectionPage = Page.verifyOnPage(PgdRegionSelection)
     locationSelectionPage.changePgdRegionSelect().select('National')
     locationSelectionPage.continueButton().click()
-    Page.verifyOnPage(AnalyticsIncentiveLevels)
+    const analyticsPage = Page.verifyOnPage(AnalyticsIncentiveLevels)
+    analyticsPage.checkLastBreadcrumb('Manage incentives', '/')
   })
 
   it('has correct title', () => {
@@ -180,7 +182,8 @@ context('Pgd Region selection > LTHS > Analytics section > Incentive levels page
     const locationSelectionPage = Page.verifyOnPage(PgdRegionSelection)
     locationSelectionPage.changePgdRegionSelect().select('LTHS')
     locationSelectionPage.continueButton().click()
-    Page.verifyOnPage(AnalyticsIncentiveLevels)
+    const analyticsPage = Page.verifyOnPage(AnalyticsIncentiveLevels)
+    analyticsPage.checkLastBreadcrumb('Manage incentives', '/')
   })
 
   it('has correct title', () => {

--- a/integration_tests/e2e/analytics/pgdRegionSelection.cy.ts
+++ b/integration_tests/e2e/analytics/pgdRegionSelection.cy.ts
@@ -17,6 +17,7 @@ context('Prison group selection', () => {
 
   it('user can select national', () => {
     const locationSelectionPage = Page.verifyOnPage(PgdRegionSelection)
+    locationSelectionPage.checkLastBreadcrumb('Manage incentives', '/')
     locationSelectionPage.changePgdRegionSelect().select('National')
     locationSelectionPage.continueButton().click()
 

--- a/integration_tests/e2e/analytics/protectedCharacteristics.cy.ts
+++ b/integration_tests/e2e/analytics/protectedCharacteristics.cy.ts
@@ -46,6 +46,7 @@ context('Analytics section > Protected characteristics page', () => {
     const homePage = Page.verifyOnPage(HomePage)
     homePage.viewAnalyticsLink().click()
     const analyticsPage = Page.verifyOnPage(AnalyticsIncentiveLevels)
+    analyticsPage.checkLastBreadcrumb('Manage incentives', '/')
     analyticsPage.protectedCharacteristicsNavItem.click()
   })
 
@@ -230,6 +231,7 @@ context('Pgd Region selection > National > Analytics section > Protected charact
     locationSelectionPage.changePgdRegionSelect().select('National')
     locationSelectionPage.continueButton().click()
     const analyticsPage = Page.verifyOnPage(AnalyticsIncentiveLevels)
+    analyticsPage.checkLastBreadcrumb('Manage incentives', '/')
     analyticsPage.protectedCharacteristicsNavItem.click()
   })
 
@@ -391,6 +393,7 @@ context('Pgd Region selection > LTHS > Analytics section > Protected characteris
     locationSelectionPage.changePgdRegionSelect().select('LTHS')
     locationSelectionPage.continueButton().click()
     const analyticsPage = Page.verifyOnPage(AnalyticsIncentiveLevels)
+    analyticsPage.checkLastBreadcrumb('Manage incentives', '/')
     analyticsPage.protectedCharacteristicsNavItem.click()
   })
 

--- a/integration_tests/e2e/home.cy.ts
+++ b/integration_tests/e2e/home.cy.ts
@@ -14,6 +14,7 @@ context('Home page', () => {
   it('should open card when clicked anywhere inside', () => {
     cy.signIn()
     const homePage = Page.verifyOnPage(HomePage)
+    homePage.checkLastBreadcrumb('Digital Prison Service', 'http://localhost:3000')
     homePage.cards.last().find('.dps-card__description').contains('Information on how we collect').click()
     Page.verifyOnPage(AboutAnalyticsPage)
   })

--- a/integration_tests/e2e/incentiveLevels.cy.ts
+++ b/integration_tests/e2e/incentiveLevels.cy.ts
@@ -25,7 +25,8 @@ context('Incentive level management', () => {
     homePage.manageIncentiveLevelsLink().click()
 
     const listPage = Page.verifyOnPage(IncentiveLevelsPage)
-    listPage.checkLastBreadcrumb()
+    listPage.checkLastBreadcrumb('Global incentive level admin', '/incentive-levels')
+
     listPage.contentsOfTable.should(
       'have.all.key',
       'Basic',
@@ -52,7 +53,7 @@ context('Incentive level management', () => {
     listPage.createLink.click()
 
     const createPage = Page.verifyOnPage(IncentiveLevelCreateFormPage)
-    createPage.checkLastBreadcrumb()
+    createPage.checkLastBreadcrumb('Global incentive level admin', '/incentive-levels')
 
     createPage.form.submit() // empty form
     Page.verifyOnPage(IncentiveLevelCreateFormPage)
@@ -88,7 +89,7 @@ context('Incentive level management', () => {
     listPage.findTableLink(4, 'Change status').click()
 
     const statusPage = Page.verifyOnPage(IncentiveLevelStatusFormPage)
-    statusPage.checkLastBreadcrumb()
+    statusPage.checkLastBreadcrumb('Global incentive level admin', '/incentive-levels')
 
     statusPage.statusRadios.eq(1).find('label').click()
     statusPage.form.submit()

--- a/integration_tests/e2e/locationSelection.cy.ts
+++ b/integration_tests/e2e/locationSelection.cy.ts
@@ -18,6 +18,7 @@ context('Location selection', () => {
 
   it('user sees correct locations for their active case load', () => {
     const locationSelectionPage = Page.verifyOnPage(LocationSelectionPage)
+    locationSelectionPage.checkLastBreadcrumb('Manage incentives', '/')
     locationSelectionPage.locationSelectOptions().should('contain.text', 'Houseblock 2')
     locationSelectionPage.locationSelectOptions().should('contain.text', 'Houseblock 42')
   })

--- a/integration_tests/e2e/prisonIncentiveLevels.cy.ts
+++ b/integration_tests/e2e/prisonIncentiveLevels.cy.ts
@@ -29,14 +29,16 @@ context('Prison incentive level management', () => {
     homePage.managePrisonIncentiveLevelsLink().click()
 
     const listPage = Page.verifyOnPage(PrisonIncentiveLevelsPage)
-    listPage.checkLastBreadcrumb()
+    listPage.checkLastBreadcrumb('Incentive level settings', '/prison-incentive-levels')
+
     listPage.contentsOfTable.should('have.all.key', 'Basic', 'Standard', 'Enhanced')
     listPage.contentsOfTable.its('Standard').its('tags').should('contain', 'Default')
 
     listPage.findTableLink(1, 'View settings').click()
 
     const detailPage = Page.verifyOnPage(PrisonIncentiveLevelPage, 'Standard')
-    detailPage.checkLastBreadcrumb()
+    detailPage.checkLastBreadcrumb('Incentive level settings', '/prison-incentive-levels')
+
     detailPage.contentsOfTables
       .should('have.length', 4)
       .should('deep.equal', [
@@ -67,7 +69,7 @@ context('Prison incentive level management', () => {
     listPage.addLink.click()
 
     const addPage = Page.verifyOnPage(PrisonIncentiveLevelNextAddFormPage, 'Enhanced 2')
-    addPage.checkLastBreadcrumb()
+    addPage.checkLastBreadcrumb('Incentive level settings', '/prison-incentive-levels')
 
     addPage.form.submit() // empty form
     Page.verifyOnPage(PrisonIncentiveLevelNextAddFormPage, 'Enhanced 2')
@@ -117,7 +119,7 @@ context('Prison incentive level management', () => {
     listPage.findTableLink(3, 'Remove level').click()
 
     let deactivatePage = Page.verifyOnPage(PrisonIncentiveLevelDeactivateFormPage)
-    deactivatePage.checkLastBreadcrumb()
+    deactivatePage.checkLastBreadcrumb('Incentive level settings', '/prison-incentive-levels')
 
     deactivatePage.form.submit() // empty form
     Page.verifyOnPage(PrisonIncentiveLevelDeactivateFormPage)
@@ -153,7 +155,7 @@ context('Prison incentive level management', () => {
     detailPage.changeLink.click()
 
     const editPage = Page.verifyOnPage(PrisonIncentiveLevelEditFormPage, 'Basic')
-    editPage.checkLastBreadcrumb()
+    editPage.checkLastBreadcrumb('Incentive level settings', '/prison-incentive-levels')
 
     editPage.getInputField('convictedTransferLimit').clear()
     editPage.form.submit() // 1 invalid field

--- a/integration_tests/e2e/reviewsTablePage.cy.ts
+++ b/integration_tests/e2e/reviewsTablePage.cy.ts
@@ -65,6 +65,8 @@ context('Manage incentive reviews', () => {
 
   it('has reviews table', () => {
     const page = Page.verifyOnPage(ReviewsTablePage)
+    page.checkLastBreadcrumb('Manage incentives', '/')
+
     page
       .getReviewsTable()
       .first()

--- a/integration_tests/pages/page.ts
+++ b/integration_tests/pages/page.ts
@@ -29,12 +29,9 @@ export default abstract class Page {
     return cy.get('.govuk-breadcrumbs__list-item')
   }
 
-  checkLastBreadcrumb() {
-    cy.url().then(location => {
-      const url = new URL(location)
-      this.breadcrumbs.last().should('contain.text', this.title)
-      this.breadcrumbs.last().find('a').should('have.attr', 'href', url.pathname)
-    })
+  checkLastBreadcrumb(label: string, href: string): void {
+    this.breadcrumbs.last().should('contain.text', label)
+    this.breadcrumbs.last().find('a').should('have.attr', 'href', href)
   }
 
   get messages(): PageElement<HTMLDivElement> {

--- a/server/middleware/breadcrumbs.ts
+++ b/server/middleware/breadcrumbs.ts
@@ -18,6 +18,10 @@ class Breadcrumbs {
     ]
   }
 
+  popLastItem(): Breadcrumb {
+    return this.breadcrumbs.pop()
+  }
+
   addItems(...items: Breadcrumb[]): void {
     this.breadcrumbs.push(...items)
   }

--- a/server/routes/analyticsRouter.ts
+++ b/server/routes/analyticsRouter.ts
@@ -129,8 +129,6 @@ export default function routes(router: Router): Router {
     'trends-entries',
   ]
   routeWithFeedback('/behaviour-entries', behaviourEntryChartIds, async (req, res) => {
-    res.locals.breadcrumbs.addItems({ text: 'Behaviour entries', href: req.originalUrl })
-
     const { pgdRegionCode } = req.params as { pgdRegionCode: PgdRegionCode }
     const activeCaseLoad = res.locals.user.activeCaseload.id
     const analyticsView = new AnalyticsView(pgdRegionCode, 'behaviour-entries', activeCaseLoad)
@@ -160,8 +158,6 @@ export default function routes(router: Router): Router {
 
   const incentiveLevelChartIds: ChartId[] = ['incentive-levels-by-location', 'trends-incentive-levels']
   routeWithFeedback('/incentive-levels', incentiveLevelChartIds, async (req, res) => {
-    res.locals.breadcrumbs.addItems({ text: 'Incentive levels', href: req.originalUrl })
-
     const { pgdRegionCode } = req.params as { pgdRegionCode: PgdRegionCode }
     const activeCaseLoad = res.locals.user.activeCaseload.id
     const analyticsView = new AnalyticsView(pgdRegionCode, 'incentive-levels', activeCaseLoad)
@@ -223,8 +219,6 @@ export default function routes(router: Router): Router {
     'prisoners-with-entries-by-sexual-orientation',
   ]
   routeWithFeedback('/protected-characteristic', protectedCharacteristicChartIds, async (req, res, next) => {
-    res.locals.breadcrumbs.addItems({ text: 'Protected characteristics', href: req.originalUrl })
-
     const activeCaseLoad = res.locals.user.activeCaseload.id
 
     const { pgdRegionCode } = req.params as { pgdRegionCode: PgdRegionCode }

--- a/server/routes/home.ts
+++ b/server/routes/home.ts
@@ -42,6 +42,8 @@ export default function routes(router: Router): Router {
     const canManagePrisonIncentiveLevels =
       canViewLocationBasedTiles && userRoles.includes(managePrisonIncentiveLevelsRole)
 
+    res.locals.breadcrumbs.popLastItem()
+
     res.render('pages/home.njk', {
       canViewLocationBasedTiles,
       canManageIncentiveLevels,
@@ -50,8 +52,6 @@ export default function routes(router: Router): Router {
   })
 
   get('/about-national-policy', (req, res) => {
-    res.locals.breadcrumbs.addItems({ text: 'National policy: frequency of reviews', href: req.originalUrl })
-
     res.render('pages/about-national-policy.njk')
   })
 
@@ -139,8 +139,6 @@ ${noComments}`
       next()
     }),
     asyncMiddleware(async (req: Request, res: Response) => {
-      res.locals.breadcrumbs.addItems({ text: 'About', href: req.originalUrl })
-
       const activeCaseLoad = res.locals.user.activeCaseload.id
       const prisonRegions = await getPrisonRegions(activeCaseLoad)
       const prisonRegionTableRows = Object.entries(prisonRegions).map(([region, prisons]) => {

--- a/server/routes/incentiveLevels.ts
+++ b/server/routes/incentiveLevels.ts
@@ -17,6 +17,11 @@ export const manageIncentiveLevelsRole = 'ROLE_MAINTAIN_INCENTIVE_LEVELS'
 export default function routes(router: Router): Router {
   const get = (path: string, handler: RequestHandler) => router.get(path, asyncMiddleware(handler))
 
+  router.use((req, res, next) => {
+    res.locals.breadcrumbs.addItems({ text: 'Global incentive level admin', href: '/incentive-levels' })
+    next()
+  })
+
   /*
    * List of all incentive levels that exist globally, whether in use or historic
    */
@@ -26,7 +31,6 @@ export default function routes(router: Router): Router {
     const incentiveLevels = await incentivesApi.getIncentiveLevels(true)
     const canChangeStatus = incentiveLevels.some(incentiveLevel => !incentiveLevel.required)
 
-    res.locals.breadcrumbs.addItems({ text: 'Global incentive level admin', href: req.originalUrl })
     res.render('pages/incentiveLevels.njk', { messages: req.flash(), incentiveLevels, canChangeStatus })
   })
 
@@ -40,10 +44,6 @@ export default function routes(router: Router): Router {
     const { levelCode } = req.params
     const incentiveLevel = await incentivesApi.getIncentiveLevel(levelCode)
 
-    res.locals.breadcrumbs.addItems(
-      { text: 'Global incentive level admin', href: '/incentive-levels' },
-      { text: `View details for ${incentiveLevel.name}`, href: req.originalUrl },
-    )
     res.render('pages/incentiveLevel.njk', { messages: req.flash(), incentiveLevel })
   })
 
@@ -122,10 +122,6 @@ export default function routes(router: Router): Router {
         })
       }
 
-      res.locals.breadcrumbs.addItems(
-        { text: 'Global incentive level admin', href: '/incentive-levels' },
-        { text: 'Select incentive level status', href: req.originalUrl },
-      )
       res.render('pages/incentiveLevelStatusForm.njk', {
         messages: req.flash(),
         form,
@@ -233,10 +229,6 @@ export default function routes(router: Router): Router {
         })
       }
 
-      res.locals.breadcrumbs.addItems(
-        { text: 'Global incentive level admin', href: '/incentive-levels' },
-        { text: `Change details for ${incentiveLevel.name}`, href: req.originalUrl },
-      )
       res.render('pages/incentiveLevelEditForm.njk', {
         messages: req.flash(),
         form,
@@ -306,10 +298,6 @@ export default function routes(router: Router): Router {
     asyncMiddleware(async (req, res) => {
       const form: IncentiveLevelCreateForm = res.locals.forms[createFormId]
 
-      res.locals.breadcrumbs.addItems(
-        { text: 'Global incentive level admin', href: '/incentive-levels' },
-        { text: 'Create a new incentive level', href: req.originalUrl },
-      )
       res.render('pages/incentiveLevelCreateForm.njk', {
         messages: req.flash(),
         form,
@@ -385,10 +373,6 @@ export default function routes(router: Router): Router {
 
       const form: IncentiveLevelCreateForm = res.locals.forms[reorderFormId]
 
-      res.locals.breadcrumbs.addItems(
-        { text: 'Global incentive level admin', href: '/incentive-levels' },
-        { text: 'Change order of levels', href: req.originalUrl },
-      )
       res.render('pages/incentiveLevelReorderForm.njk', {
         messages: req.flash(),
         form,

--- a/server/routes/prisonIncentiveLevels.ts
+++ b/server/routes/prisonIncentiveLevels.ts
@@ -22,6 +22,11 @@ export const managePrisonIncentiveLevelsRole = 'ROLE_MAINTAIN_PRISON_IEP_LEVELS'
 export default function routes(router: Router): Router {
   const get = (path: string, handler: RequestHandler) => router.get(path, asyncMiddleware(handler))
 
+  router.use((req, res, next) => {
+    res.locals.breadcrumbs.addItems({ text: 'Incentive level settings', href: '/prison-incentive-levels' })
+    next()
+  })
+
   /*
    * List of active incentive levels in the prison
    */
@@ -82,7 +87,6 @@ export default function routes(router: Router): Router {
       }
     }
 
-    res.locals.breadcrumbs.addItems({ text: 'Incentive level settings', href: req.originalUrl })
     res.render('pages/prisonIncentiveLevels.njk', {
       messages: req.flash(),
       prisonIncentiveLevels: prisonIncentiveLevelsWithRequiredFlag,
@@ -105,10 +109,6 @@ export default function routes(router: Router): Router {
       incentivesApi.getPrisonIncentiveLevel(prisonId, levelCode),
     ])
 
-    res.locals.breadcrumbs.addItems(
-      { text: 'Incentive level settings', href: '/prison-incentive-levels' },
-      { text: `View settings for ${prisonIncentiveLevel.levelName}`, href: req.originalUrl },
-    )
     res.render('pages/prisonIncentiveLevel.njk', {
       messages: req.flash(),
       incentiveLevel,
@@ -216,10 +216,6 @@ export default function routes(router: Router): Router {
         throw BadRequest('Incentive level is required globally')
       }
 
-      res.locals.breadcrumbs.addItems(
-        { text: 'Incentive level settings', href: '/prison-incentive-levels' },
-        { text: 'Remove an incentive level', href: req.originalUrl },
-      )
       res.render('pages/prisonIncentiveLevelDeactivateForm.njk', {
         messages: req.flash(),
         form,
@@ -340,10 +336,6 @@ export default function routes(router: Router): Router {
         })
       }
 
-      res.locals.breadcrumbs.addItems(
-        { text: 'Incentive level settings', href: '/prison-incentive-levels' },
-        { text: `Change settings for ${prisonIncentiveLevel.levelName}`, href: req.originalUrl },
-      )
       res.render('pages/prisonIncentiveLevelEditForm.njk', {
         messages: req.flash(),
         form,
@@ -458,10 +450,6 @@ export default function routes(router: Router): Router {
         throw NotFound(`Level "${levelCode}" is not available to add`)
       }
 
-      res.locals.breadcrumbs.addItems(
-        { text: 'Incentive level settings', href: '/prison-incentive-levels' },
-        { text: incentiveLevel ? `Add ${incentiveLevel.name}` : 'Add a new incentive level', href: req.originalUrl },
-      )
       res.render(
         incentiveLevel ? 'pages/prisonIncentiveLevelNextAddForm.njk' : 'pages/prisonIncentiveLevelAddForm.njk',
         {

--- a/server/routes/reviewsTable.ts
+++ b/server/routes/reviewsTable.ts
@@ -39,8 +39,6 @@ export default function routes(router: Router): Router {
   const get = (path: string, handler: RequestHandler) => router.get(path, asyncMiddleware(handler))
 
   get('/', async (req, res) => {
-    res.locals.breadcrumbs.addItems({ text: 'Manage incentive reviews', href: req.originalUrl })
-
     const { user } = res.locals
     const { locationPrefix } = req.params
     let { level: selectedLevelCode }: { level?: string } = req.query


### PR DESCRIPTION
i.e. pop off the last item from every page’s breadcrumb list. Now, the last item is tested for every page.