### PR TITLE
Fix breadcrumbs

### DIFF
--- a/integration_tests/e2e/incentiveLevels.cy.ts
+++ b/integration_tests/e2e/incentiveLevels.cy.ts
@@ -25,7 +25,7 @@ context('Incentive level management', () => {
     homePage.manageIncentiveLevelsLink().click()
 
     const listPage = Page.verifyOnPage(IncentiveLevelsPage)
-    listPage.checkLastBreadcrumb('Global incentive level admin', '/incentive-levels')
+    listPage.checkLastBreadcrumb('Manage incentives', '/')
 
     listPage.contentsOfTable.should(
       'have.all.key',

--- a/integration_tests/e2e/prisonIncentiveLevels.cy.ts
+++ b/integration_tests/e2e/prisonIncentiveLevels.cy.ts
@@ -29,7 +29,7 @@ context('Prison incentive level management', () => {
     homePage.managePrisonIncentiveLevelsLink().click()
 
     const listPage = Page.verifyOnPage(PrisonIncentiveLevelsPage)
-    listPage.checkLastBreadcrumb('Incentive level settings', '/prison-incentive-levels')
+    listPage.checkLastBreadcrumb('Manage incentives', '/')
 
     listPage.contentsOfTable.should('have.all.key', 'Basic', 'Standard', 'Enhanced')
     listPage.contentsOfTable.its('Standard').its('tags').should('contain', 'Default')

--- a/server/routes/incentiveLevels.ts
+++ b/server/routes/incentiveLevels.ts
@@ -31,6 +31,7 @@ export default function routes(router: Router): Router {
     const incentiveLevels = await incentivesApi.getIncentiveLevels(true)
     const canChangeStatus = incentiveLevels.some(incentiveLevel => !incentiveLevel.required)
 
+    res.locals.breadcrumbs.popLastItem()
     res.render('pages/incentiveLevels.njk', { messages: req.flash(), incentiveLevels, canChangeStatus })
   })
 

--- a/server/routes/prisonIncentiveLevels.ts
+++ b/server/routes/prisonIncentiveLevels.ts
@@ -87,6 +87,7 @@ export default function routes(router: Router): Router {
       }
     }
 
+    res.locals.breadcrumbs.popLastItem()
     res.render('pages/prisonIncentiveLevels.njk', {
       messages: req.flash(),
       prisonIncentiveLevels: prisonIncentiveLevelsWithRequiredFlag,


### PR DESCRIPTION
The incentive level and prison incentive level _list_ pages should not include themselves in the breadcrumbs list
Fixes changes in #564 