### PR TITLE
Fix CircleCI workspace persistence to include built front-end assets

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,7 +72,7 @@ jobs:
             - node_modules
             - build
             - dist
-            - .cache/Cypress
+            - assets/stylesheets
 
   unit_test:
     executor:


### PR DESCRIPTION
…and skip path ".cache/Cypress" which does not exist.

Copied from [non-api#103](https://github.com/ministryofjustice/hmpps-non-associations/pull/103)