### PR TITLE
INC-1296: Removed vestigial referenced to deprecated endpoint

### DIFF
--- a/integration_tests/mockApis/incentivesApi.ts
+++ b/integration_tests/mockApis/incentivesApi.ts
@@ -162,42 +162,6 @@ export default {
     })
   },
 
-  /**
-   * @deprecated use stubPrisonIncentiveLevels
-   */
-  stubGetAvailableLevels: (): SuperAgentRequest => {
-    return stubFor({
-      request: {
-        method: 'GET',
-        urlPattern: '/incentivesApi/iep/levels/MDI',
-      },
-      response: {
-        status: 200,
-        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
-        jsonBody: [
-          {
-            iepLevel: 'BAS',
-            iepDescription: 'Basic',
-            sequence: 1,
-            default: false,
-          },
-          {
-            iepLevel: 'STD',
-            iepDescription: 'Standard',
-            sequence: 2,
-            default: true,
-          },
-          {
-            iepLevel: 'ENH',
-            iepDescription: 'Enhanced',
-            sequence: 3,
-            default: false,
-          },
-        ],
-      },
-    })
-  },
-
   stubGetIncentivesLevelBasic: (): SuperAgentRequest => {
     return stubFor({
       request: {

--- a/integration_tests/plugins/index.ts
+++ b/integration_tests/plugins/index.ts
@@ -16,7 +16,6 @@ export default (on: (string, Record) => void): void => {
     ...tokenVerification,
 
     stubIncentivesApiPing: incentivesApi.stubPing,
-    stubGetAvailableLevels: incentivesApi.stubGetAvailableLevels,
     stubGetIncentivesLevelBasic: incentivesApi.stubGetIncentivesLevelBasic,
     stubGetIncentivesLevelStandard: incentivesApi.stubGetIncentivesLevelStandard,
     stubGetIncentivesSorted: incentivesApi.stubGetIncentivesSorted,

--- a/server/data/incentivesApi.ts
+++ b/server/data/incentivesApi.ts
@@ -207,13 +207,6 @@ export class IncentivesApi extends RestClient {
     })
   }
 
-  /**
-   * @deprecated use getPrisonIncentiveLevels
-   */
-  getAvailableLevels(agencyId: string): Promise<Level[]> {
-    return this.get<Level[]>({ path: `/iep/levels/${agencyId}` })
-  }
-
   getReviews({
     agencyId,
     locationPrefix,

--- a/server/data/incentivesApi.ts
+++ b/server/data/incentivesApi.ts
@@ -67,16 +67,6 @@ export interface PrisonIncentiveLevel {
 
 export type PrisonIncentiveLevelUpdate = Omit<Partial<PrisonIncentiveLevel>, 'prisonId' | 'levelCode' | 'levelName'>
 
-/**
- * @deprecated returned by legacy api endpoint
- */
-export interface Level {
-  iepLevel: string
-  iepDescription: string
-  sequence: number
-  default: boolean
-}
-
 export const sortOptions = [
   'PRISONER_NUMBER',
   'FIRST_NAME',


### PR DESCRIPTION
`GET /iep/levels/{prisonId}` has been deprecated for a long time and will be removed at some point soon.

The UI doesn't use this endpoint anymore but there were still a couple of methods related to this endpoint that can be removed.