### PR TITLE
Stop using `curl` in docker compose init script

### DIFF
--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -50,11 +50,10 @@ services:
     entrypoint: |
       /bin/sh -c "
         echo Provisioning bucket with minio
-        until $$(curl --output /dev/null --silent http://minio:9000); do
+        until $$(mc config host add local http://minio:9000 $$MINIO_ROOT_USER $$MINIO_ROOT_PASSWORD); do
           echo 'Waiting for http://minio:9000'
           sleep 3
         done
-        mc config host add local http://minio:9000 $$MINIO_ROOT_USER $$MINIO_ROOT_PASSWORD
         mc mb --region eu-west-1 --ignore-existing local/incentives
         mc mirror --overwrite /tmp/s3Bucket local/incentives
         exit 0


### PR DESCRIPTION
…because [minio/mc image no longer includes it](https://github.com/minio/minio/pull/18329) (nor wget, netcat, socat or even package management tools)