### PR TITLE
Migrating project to use groups in allowlist

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  hmpps: ministryofjustice/hmpps@7.5
+  hmpps: ministryofjustice/hmpps@7
   slack: circleci/slack@4.12.5
 
 parameters:
@@ -63,7 +63,8 @@ jobs:
       - run:
           name: Build application
           command: npm run build
-      - run: # Run linter after build because the integration test code depend on compiled typescript...
+      - run:
+          # Run linter after build because the integration test code depend on compiled typescript...
           name: Linter check
           command: npm run lint
       - persist_to_workspace:
@@ -103,7 +104,8 @@ jobs:
           key: dependency-cache-{{ checksum "package-lock.json" }}
       - run:
           name: Get wiremock
-          command: curl -o wiremock.jar https://repo1.maven.org/maven2/com/github/tomakehurst/wiremock-jre8-standalone/2.35.0/wiremock-jre8-standalone-2.35.0.jar
+          command: curl -o wiremock.jar
+            https://repo1.maven.org/maven2/com/github/tomakehurst/wiremock-jre8-standalone/2.35.0/wiremock-jre8-standalone-2.35.0.jar
       - run:
           name: Run wiremock
           command: java -jar wiremock.jar --port 9091
@@ -128,7 +130,8 @@ jobs:
           command: sleep 5
       - run:
           name: Run integration tests
-          command: npm run int-test -- --config video=<< pipeline.parameters.cypress-videos >>
+          command: npm run int-test -- --config video=<<
+            pipeline.parameters.cypress-videos >>
       - store_test_results:
           path: test_results
       - store_artifacts:

--- a/helm_deploy/hmpps-incentives-ui/Chart.yaml
+++ b/helm_deploy/hmpps-incentives-ui/Chart.yaml
@@ -5,7 +5,7 @@ name: hmpps-incentives-ui
 version: 0.2.0
 dependencies:
   - name: generic-service
-    version: 2.8.1
+    version: "2.8"
     repository: https://ministryofjustice.github.io/hmpps-helm-charts
   - name: generic-prometheus-alerts
     version: 1.3.3

--- a/helm_deploy/hmpps-incentives-ui/values.yaml
+++ b/helm_deploy/hmpps-incentives-ui/values.yaml
@@ -1,4 +1,3 @@
----
 generic-service:
   nameOverride: hmpps-incentives-ui
   productId: DPS020
@@ -7,12 +6,12 @@ generic-service:
 
   image:
     repository: quay.io/hmpps/hmpps-incentives-ui
-    tag: app_version    # override at deployment time
+    tag: app_version # override at deployment time
     port: 3000
 
   ingress:
     enabled: true
-    host: app-hostname.local    # override per environment
+    host: app-hostname.local # override per environment
     tlsSecretName: hmpps-incentives-ui-cert
     annotations:
       nginx.ingress.kubernetes.io/proxy-connect-timeout: "120"
@@ -69,15 +68,11 @@ generic-service:
       S3_BUCKET_NAME: "bucket_name"
 
   allowlist:
-    groups:
-      - internal
-      - prisons
-      - private_prisons
-
-    # hotjar servers: https://help.hotjar.com/hc/en-us/articles/115011789288
-    hotjar-1: 18.203.61.76
-    hotjar-2: 18.203.176.135
-    hotjar-3: 52.17.197.221
+    undefined: internal,prisons,private_prisons/32
+    hotjar-1: 18.203.61.76/32
+    hotjar-2: 18.203.176.135/32
+    hotjar-3: 52.17.197.221/32
+    groups: []
 
 generic-prometheus-alerts:
   targetApplication: hmpps-incentives-ui


### PR DESCRIPTION
This PR migrates the project to use groups of IPs in their allowlist.

By referring to groups to IP addresses, we can centralize the definition of groups of ip addresses.
If these lists require changing in the future, we can change the definition once and future deploys across all services will automatically include these new IPs.

1 allowlist(s) have been detected that can be migrated.



## Allowlist: helm_deploy/hmpps-incentives-ui/values.yaml

### New Groups

The effect of applying this PR is as follows:

- The following groups will be applied: ``
- The size of the allowlist defined in this file will change: `4 => 4 (0 removed)`

### Added IPs

The new Group membership will result in the following IPs being added to your allowlist by applying this PR:

  Merging this PR should not result in any additional IP addresses being added to the allowlist.

### Removed IPs

The following IPs have been identified as unnecessary and will be removed by applying this PR:

  **No IPs have been identified for removal**
  
