### PR TITLE
Revert "Auto-merge renovate’s non-major npm updates (#664)"

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -13,8 +13,7 @@
       "matchUpdateTypes": ["minor", "patch"],
       "groupName": "all non major NPM dependencies",
       "groupSlug": "all-npm-minor-patch",
-      "stabilityDays": 3,
-      "automerge": true
+      "stabilityDays": 3
     },
     {
       "matchDepTypes": ["engines"],


### PR DESCRIPTION
This reverts commit 67ca9cbf294ee3176a94142221182ce8357f5a70.