### PR TITLE
INC-1335: Display default image when user is not authorised to view a prisoner’s photo

### DIFF
--- a/server/data/prisonApi.test.ts
+++ b/server/data/prisonApi.test.ts
@@ -1,0 +1,70 @@
+import nock from 'nock'
+
+import config from '../config'
+import { PrisonApi } from './prisonApi'
+
+describe('PrisonApi', () => {
+  let prisonApi: nock.Scope
+  let prisonApiClient: PrisonApi
+
+  const accessToken = 'test token'
+  const prisonerNumber = 'A1234BC'
+
+  beforeEach(() => {
+    prisonApi = nock(config.apis.hmppsPrisonApi.url)
+    prisonApiClient = new PrisonApi(accessToken)
+  })
+
+  afterEach(() => {
+    nock.cleanAll()
+  })
+
+  describe('getImageByPrisonerNumber()', () => {
+    it('should return an image', async () => {
+      const imageData = Buffer.from('image data')
+      prisonApi
+        .get(`/api/bookings/offenderNo/${prisonerNumber}/image/data`)
+        .query({ fullSizeImage: 'false' })
+        .matchHeader('authorization', `Bearer ${accessToken}`)
+        .reply(200, imageData, { 'Content-Type': 'image/jpeg' })
+
+      const response = await prisonApiClient.getImageByPrisonerNumber(prisonerNumber)
+      expect(response).toEqual(imageData)
+    })
+
+    it('should return null if not found', async () => {
+      prisonApi
+        .get(`/api/bookings/offenderNo/${prisonerNumber}/image/data`)
+        .query({ fullSizeImage: 'false' })
+        .matchHeader('authorization', `Bearer ${accessToken}`)
+        .thrice()
+        .reply(404)
+
+      const response = await prisonApiClient.getImageByPrisonerNumber(prisonerNumber)
+      expect(response).toBeNull()
+    })
+
+    it('should return null if unauthorised', async () => {
+      prisonApi
+        .get(`/api/bookings/offenderNo/${prisonerNumber}/image/data`)
+        .query({ fullSizeImage: 'false' })
+        .matchHeader('authorization', `Bearer ${accessToken}`)
+        .thrice()
+        .reply(403)
+
+      const response = await prisonApiClient.getImageByPrisonerNumber(prisonerNumber)
+      expect(response).toBeNull()
+    })
+
+    it('should throw when it receives another error', async () => {
+      prisonApi
+        .get(`/api/bookings/offenderNo/${prisonerNumber}/image/data`)
+        .query({ fullSizeImage: 'false' })
+        .matchHeader('authorization', `Bearer ${accessToken}`)
+        .thrice()
+        .reply(500)
+
+      await expect(prisonApiClient.getImageByPrisonerNumber(prisonerNumber)).rejects.toThrow('Internal Server Error')
+    })
+  })
+})

--- a/server/data/prisonApi.ts
+++ b/server/data/prisonApi.ts
@@ -25,11 +25,17 @@ export class PrisonApi extends RestClient {
     super('HMPPS Prison API', config.apis.hmppsPrisonApi, token)
   }
 
-  getImageByPrisonerNumber(prisonerNumber: string): Promise<Buffer> {
-    return this.get({
+  getImageByPrisonerNumber(prisonerNumber: string): Promise<Buffer | null> {
+    return this.get<Buffer>({
       path: `/api/bookings/offenderNo/${encodeURIComponent(prisonerNumber)}/image/data`,
       query: { fullSizeImage: 'false' },
-      handle404: true,
+    }).catch(error => {
+      const status = error?.status
+      if (status === 403 || status === 404) {
+        // return null if unauthorised or not found
+        return null
+      }
+      throw error
     })
   }
 

--- a/server/data/restClient.ts
+++ b/server/data/restClient.ts
@@ -53,8 +53,7 @@ export default class RestClient {
     headers = {},
     responseType = '',
     raw = false,
-    handle404 = false,
-  }: Request & { handle404?: boolean }): Promise<Response> {
+  }: Request): Promise<Response> {
     logger.info(`${this.name} GET: ${path}`)
     try {
       const result = await superagent
@@ -74,9 +73,6 @@ export default class RestClient {
       return raw ? result : result.body
     } catch (error) {
       const sanitisedError = sanitiseError(error)
-      if (handle404 === true && error?.response?.status === 404) {
-        return null
-      }
       logger.warn({ ...sanitisedError }, `Error calling ${this.name}, path: '${path}', verb: 'GET'`)
       throw sanitisedError
     }


### PR DESCRIPTION
`prison-api` now (sensibly!) returns 403 instead of 404 if token is unauthorised. We should swallow the error and display a placeholder rather than a broken image; same as is done when none is found.