### PR TITLE
INC-1337: Fix from/to date filter validation on incentive history page

### DIFF
--- a/server/routes/prisonerIncentiveLevelDetails.ts
+++ b/server/routes/prisonerIncentiveLevelDetails.ts
@@ -162,7 +162,7 @@ export default function routes(router: Router): Router {
     } catch (e) {
       errors.push({ href: '#toDate', text: `Enter a to date, for example ${todayAsShortDate}` })
     }
-    if (fromDate && toDate && fromDateInput > toDateInput) {
+    if (fromDate && toDate && fromDate > toDate) {
       errors.push({ href: '#fromDate', text: 'Enter a from date which is not after the to date' })
       errors.push({ href: '#toDate', text: 'Enter a to date which is not before the from date' })
     }


### PR DESCRIPTION
Comparison was incorrectly using the text input instead of parsed & validated `Date`