### PR TITLE
Add (disabled) audit client (hmpps-template-typescript#327)

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -35,6 +35,8 @@
         "plugin:prettier/recommended"
       ],
       "rules": {
+        "no-shadow": "off",
+        "@typescript-eslint/no-shadow": ["error"],
         "@typescript-eslint/no-use-before-define": 0,
         "class-methods-use-this": 0,
         "no-useless-constructor": 0,

--- a/helm_deploy/hmpps-incentives-ui/values.yaml
+++ b/helm_deploy/hmpps-incentives-ui/values.yaml
@@ -42,6 +42,9 @@ generic-service:
     BUNYAN_NO_COLOR: "1"
     PHASE_NAME: ""
     FEATURE_ADD_TEST_ERROR_ENDPOINT: ""
+    AUDIT_ENABLED: "false"
+    AUDIT_SQS_REGION: "eu-west-2"
+    AUDIT_SERVICE_NAME: "UNASSIGNED"
 
   envFrom:
     - secretRef:
@@ -53,6 +56,9 @@ generic-service:
       REDIS_AUTH_TOKEN: "auth_token"
     analytical-platform-s3-bucket-output:
       S3_BUCKET_NAME: "bucket_name"
+    # sqs-hmpps-audit-secret:
+    #   AUDIT_SQS_QUEUE_URL: "sqs_queue_url"
+    #   AUDIT_SQS_QUEUE_NAME: "sqs_queue_name"
 
   allowlist:
     groups:

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.540.0",
+        "@aws-sdk/client-sqs": "^3.529.1",
         "@ministryofjustice/frontend": "^2.1.2",
         "@sentry/node": "^7.108.0",
         "agentkeepalive": "^4.5.0",
@@ -41,7 +42,7 @@
         "uuid": "^9.0.1"
       },
       "devDependencies": {
-        "@tsconfig/node20": "^20.1.2",
+        "@tsconfig/node20": "^20.1.3",
         "@types/bunyan": "^1.8.11",
         "@types/bunyan-format": "^0.2.9",
         "@types/compression": "^1.7.5",
@@ -63,9 +64,10 @@
         "@types/superagent": "^8.1.6",
         "@types/supertest": "^6.0.2",
         "@types/uuid": "^9.0.8",
-        "@typescript-eslint/eslint-plugin": "^7.3.1",
-        "@typescript-eslint/parser": "^7.3.1",
+        "@typescript-eslint/eslint-plugin": "^7.4.0",
+        "@typescript-eslint/parser": "^7.4.0",
         "audit-ci": "^6.6.1",
+        "aws-sdk-client-mock": "^4.0.0",
         "concurrently": "^8.2.2",
         "cookie-session": "^2.1.0",
         "cypress": "^13.7.1",
@@ -307,6 +309,58 @@
         "@smithy/util-stream": "^2.2.0",
         "@smithy/util-utf8": "^2.3.0",
         "@smithy/util-waiter": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs": {
+      "version": "3.540.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sqs/-/client-sqs-3.540.0.tgz",
+      "integrity": "sha512-PYyFIUZwN1LcrUtHQ/KJqNUgPgY3bNGjVp/SbwJ8cKGALBUvUNN6E7VpEDYglY1X/CuMolxK00TFZOSR9O056Q==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/client-sts": "3.540.0",
+        "@aws-sdk/core": "3.535.0",
+        "@aws-sdk/credential-provider-node": "3.540.0",
+        "@aws-sdk/middleware-host-header": "3.535.0",
+        "@aws-sdk/middleware-logger": "3.535.0",
+        "@aws-sdk/middleware-recursion-detection": "3.535.0",
+        "@aws-sdk/middleware-sdk-sqs": "3.535.0",
+        "@aws-sdk/middleware-user-agent": "3.540.0",
+        "@aws-sdk/region-config-resolver": "3.535.0",
+        "@aws-sdk/types": "3.535.0",
+        "@aws-sdk/util-endpoints": "3.540.0",
+        "@aws-sdk/util-user-agent-browser": "3.535.0",
+        "@aws-sdk/util-user-agent-node": "3.535.0",
+        "@smithy/config-resolver": "^2.2.0",
+        "@smithy/core": "^1.4.0",
+        "@smithy/fetch-http-handler": "^2.5.0",
+        "@smithy/hash-node": "^2.2.0",
+        "@smithy/invalid-dependency": "^2.2.0",
+        "@smithy/md5-js": "^2.2.0",
+        "@smithy/middleware-content-length": "^2.2.0",
+        "@smithy/middleware-endpoint": "^2.5.0",
+        "@smithy/middleware-retry": "^2.2.0",
+        "@smithy/middleware-serde": "^2.3.0",
+        "@smithy/middleware-stack": "^2.2.0",
+        "@smithy/node-config-provider": "^2.3.0",
+        "@smithy/node-http-handler": "^2.5.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/smithy-client": "^2.5.0",
+        "@smithy/types": "^2.12.0",
+        "@smithy/url-parser": "^2.2.0",
+        "@smithy/util-base64": "^2.3.0",
+        "@smithy/util-body-length-browser": "^2.2.0",
+        "@smithy/util-body-length-node": "^2.3.0",
+        "@smithy/util-defaults-mode-browser": "^2.2.0",
+        "@smithy/util-defaults-mode-node": "^2.3.0",
+        "@smithy/util-endpoints": "^1.2.0",
+        "@smithy/util-middleware": "^2.2.0",
+        "@smithy/util-retry": "^2.2.0",
+        "@smithy/util-utf8": "^2.3.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -720,6 +774,22 @@
         "@smithy/smithy-client": "^2.5.0",
         "@smithy/types": "^2.12.0",
         "@smithy/util-config-provider": "^2.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-sqs": {
+      "version": "3.535.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sqs/-/middleware-sdk-sqs-3.535.0.tgz",
+      "integrity": "sha512-E6En+QI7AFp5DsUhhA+DexMRjrJmYYte/wkArY47+6gw8VO6z7WYW6KtrhUP2OyJRYMil7o/1z76+j69vc2PBQ==",
+      "dependencies": {
+        "@aws-sdk/types": "3.535.0",
+        "@smithy/smithy-client": "^2.5.0",
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-hex-encoding": "^2.2.0",
+        "@smithy/util-utf8": "^2.3.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2636,6 +2706,32 @@
         "@sinonjs/commons": "^3.0.0"
       }
     },
+    "node_modules/@sinonjs/samsam": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-8.0.0.tgz",
+      "integrity": "sha512-Bp8KUVlLp8ibJZrnvq2foVhP0IVX2CIprMJPK0vqGqgrDa0OHVKeZyBykqskkrdxV6yKBPmGasO8LVjAKR3Gew==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^2.0.0",
+        "lodash.get": "^4.4.2",
+        "type-detect": "^4.0.8"
+      }
+    },
+    "node_modules/@sinonjs/samsam/node_modules/@sinonjs/commons": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-2.0.0.tgz",
+      "integrity": "sha512-uLa0j859mMrg2slwQYdO/AkrOfmH+X6LTVmNTS9CqexuE2IvVORIkSpJLqePAbEnKJ77aMmCwr1NUZ57120Xcg==",
+      "dev": true,
+      "dependencies": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "node_modules/@sinonjs/text-encoding": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.2.tgz",
+      "integrity": "sha512-sXXKG+uL9IrKqViTtao2Ws6dy0znu9sOaP1di/jKGW1M6VssO8vlpXCQcpZ+jisQ1tTFAC5Jo/EOzFbggBagFQ==",
+      "dev": true
+    },
     "node_modules/@smithy/abort-controller": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-2.2.0.tgz",
@@ -3291,9 +3387,9 @@
       }
     },
     "node_modules/@tsconfig/node20": {
-      "version": "20.1.2",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node20/-/node20-20.1.2.tgz",
-      "integrity": "sha512-madaWq2k+LYMEhmcp0fs+OGaLFk0OenpHa4gmI4VEmCKX4PJntQ6fnnGADVFrVkBj0wIdAlQnK/MrlYTHsa1gQ==",
+      "version": "20.1.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node20/-/node20-20.1.3.tgz",
+      "integrity": "sha512-XeWn6Gms5MaQWdj+C4fuxuo/Icy8ckh+BwAIijhX2LKRHHt1OuctLLLlB0F4EPi55m2IUJNTnv8FH9kSBI7Ogw==",
       "dev": true
     },
     "node_modules/@types/babel__core": {
@@ -3649,6 +3745,15 @@
       "resolved": "https://registry.npmjs.org/@types/shimmer/-/shimmer-1.0.2.tgz",
       "integrity": "sha512-dKkr1bTxbEsFlh2ARpKzcaAmsYixqt9UyCdoEZk8rHyE4iQYcDCyvSjDSf7JUWJHlJiTtbIoQjxKh6ViywqDAg=="
     },
+    "node_modules/@types/sinon": {
+      "version": "10.0.20",
+      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-10.0.20.tgz",
+      "integrity": "sha512-2APKKruFNCAZgx3daAyACGzWuJ028VVCUDk6o2rw/Z4PXT0ogwdV4KUegW0MwVs0Zu59auPXbbuBJHF12Sx1Eg==",
+      "dev": true,
+      "dependencies": {
+        "@types/sinonjs__fake-timers": "*"
+      }
+    },
     "node_modules/@types/sinonjs__fake-timers": {
       "version": "8.1.1",
       "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.1.tgz",
@@ -3726,16 +3831,16 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-7.3.1.tgz",
-      "integrity": "sha512-STEDMVQGww5lhCuNXVSQfbfuNII5E08QWkvAw5Qwf+bj2WT+JkG1uc+5/vXA3AOYMDHVOSpL+9rcbEUiHIm2dw==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-7.4.0.tgz",
+      "integrity": "sha512-yHMQ/oFaM7HZdVrVm/M2WHaNPgyuJH4WelkSVEWSSsir34kxW2kDJCxlXRhhGWEsMN0WAW/vLpKfKVcm8k+MPw==",
       "dev": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.5.1",
-        "@typescript-eslint/scope-manager": "7.3.1",
-        "@typescript-eslint/type-utils": "7.3.1",
-        "@typescript-eslint/utils": "7.3.1",
-        "@typescript-eslint/visitor-keys": "7.3.1",
+        "@typescript-eslint/scope-manager": "7.4.0",
+        "@typescript-eslint/type-utils": "7.4.0",
+        "@typescript-eslint/utils": "7.4.0",
+        "@typescript-eslint/visitor-keys": "7.4.0",
         "debug": "^4.3.4",
         "graphemer": "^1.4.0",
         "ignore": "^5.2.4",
@@ -3761,15 +3866,15 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-7.3.1.tgz",
-      "integrity": "sha512-Rq49+pq7viTRCH48XAbTA+wdLRrB/3sRq4Lpk0oGDm0VmnjBrAOVXH/Laalmwsv2VpekiEfVFwJYVk6/e8uvQw==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-7.4.0.tgz",
+      "integrity": "sha512-ZvKHxHLusweEUVwrGRXXUVzFgnWhigo4JurEj0dGF1tbcGh6buL+ejDdjxOQxv6ytcY1uhun1p2sm8iWStlgLQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "7.3.1",
-        "@typescript-eslint/types": "7.3.1",
-        "@typescript-eslint/typescript-estree": "7.3.1",
-        "@typescript-eslint/visitor-keys": "7.3.1",
+        "@typescript-eslint/scope-manager": "7.4.0",
+        "@typescript-eslint/types": "7.4.0",
+        "@typescript-eslint/typescript-estree": "7.4.0",
+        "@typescript-eslint/visitor-keys": "7.4.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -3789,13 +3894,13 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.3.1.tgz",
-      "integrity": "sha512-fVS6fPxldsKY2nFvyT7IP78UO1/I2huG+AYu5AMjCT9wtl6JFiDnsv4uad4jQ0GTFzcUV5HShVeN96/17bTBag==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.4.0.tgz",
+      "integrity": "sha512-68VqENG5HK27ypafqLVs8qO+RkNc7TezCduYrx8YJpXq2QGZ30vmNZGJJJC48+MVn4G2dCV8m5ZTVnzRexTVtw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "7.3.1",
-        "@typescript-eslint/visitor-keys": "7.3.1"
+        "@typescript-eslint/types": "7.4.0",
+        "@typescript-eslint/visitor-keys": "7.4.0"
       },
       "engines": {
         "node": "^18.18.0 || >=20.0.0"
@@ -3806,13 +3911,13 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-7.3.1.tgz",
-      "integrity": "sha512-iFhaysxFsMDQlzJn+vr3OrxN8NmdQkHks4WaqD4QBnt5hsq234wcYdyQ9uquzJJIDAj5W4wQne3yEsYA6OmXGw==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-7.4.0.tgz",
+      "integrity": "sha512-247ETeHgr9WTRMqHbbQdzwzhuyaJ8dPTuyuUEMANqzMRB1rj/9qFIuIXK7l0FX9i9FXbHeBQl/4uz6mYuCE7Aw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "7.3.1",
-        "@typescript-eslint/utils": "7.3.1",
+        "@typescript-eslint/typescript-estree": "7.4.0",
+        "@typescript-eslint/utils": "7.4.0",
         "debug": "^4.3.4",
         "ts-api-utils": "^1.0.1"
       },
@@ -3833,9 +3938,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.3.1.tgz",
-      "integrity": "sha512-2tUf3uWggBDl4S4183nivWQ2HqceOZh1U4hhu4p1tPiIJoRRXrab7Y+Y0p+dozYwZVvLPRI6r5wKe9kToF9FIw==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.4.0.tgz",
+      "integrity": "sha512-mjQopsbffzJskos5B4HmbsadSJQWaRK0UxqQ7GuNA9Ga4bEKeiO6b2DnB6cM6bpc8lemaPseh0H9B/wyg+J7rw==",
       "dev": true,
       "engines": {
         "node": "^18.18.0 || >=20.0.0"
@@ -3846,13 +3951,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.3.1.tgz",
-      "integrity": "sha512-tLpuqM46LVkduWP7JO7yVoWshpJuJzxDOPYIVWUUZbW+4dBpgGeUdl/fQkhuV0A8eGnphYw3pp8d2EnvPOfxmQ==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.4.0.tgz",
+      "integrity": "sha512-A99j5AYoME/UBQ1ucEbbMEmGkN7SE0BvZFreSnTd1luq7yulcHdyGamZKizU7canpGDWGJ+Q6ZA9SyQobipePg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "7.3.1",
-        "@typescript-eslint/visitor-keys": "7.3.1",
+        "@typescript-eslint/types": "7.4.0",
+        "@typescript-eslint/visitor-keys": "7.4.0",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -3898,17 +4003,17 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.3.1.tgz",
-      "integrity": "sha512-jIERm/6bYQ9HkynYlNZvXpzmXWZGhMbrOvq3jJzOSOlKXsVjrrolzWBjDW6/TvT5Q3WqaN4EkmcfdQwi9tDjBQ==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.4.0.tgz",
+      "integrity": "sha512-NQt9QLM4Tt8qrlBVY9lkMYzfYtNz8/6qwZg8pI3cMGlPnj6mOpRxxAm7BMJN9K0AiY+1BwJ5lVC650YJqYOuNg==",
       "dev": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
         "@types/json-schema": "^7.0.12",
         "@types/semver": "^7.5.0",
-        "@typescript-eslint/scope-manager": "7.3.1",
-        "@typescript-eslint/types": "7.3.1",
-        "@typescript-eslint/typescript-estree": "7.3.1",
+        "@typescript-eslint/scope-manager": "7.4.0",
+        "@typescript-eslint/types": "7.4.0",
+        "@typescript-eslint/typescript-estree": "7.4.0",
         "semver": "^7.5.4"
       },
       "engines": {
@@ -3923,12 +4028,12 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.3.1.tgz",
-      "integrity": "sha512-9RMXwQF8knsZvfv9tdi+4D/j7dMG28X/wMJ8Jj6eOHyHWwDW4ngQJcqEczSsqIKKjFiLFr40Mnr7a5ulDD3vmw==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.4.0.tgz",
+      "integrity": "sha512-0zkC7YM0iX5Y41homUUeW1CHtZR01K3ybjM1l6QczoMuay0XKtrb93kv95AxUGwdjGr64nNqnOCwmEl616N8CA==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "7.3.1",
+        "@typescript-eslint/types": "7.4.0",
         "eslint-visitor-keys": "^3.4.1"
       },
       "engines": {
@@ -4430,6 +4535,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/aws-sdk-client-mock": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk-client-mock/-/aws-sdk-client-mock-4.0.0.tgz",
+      "integrity": "sha512-/rxo+pzCFaUozK7TyCqo3GYwzdBGn9Ai6EsT8ytXDoUXlD/Q5hw9hj2lOkCAyubECzGJFHMmQg9GZ1GOGlN/qQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/sinon": "^10.0.10",
+        "sinon": "^16.1.3",
+        "tslib": "^2.1.0"
       }
     },
     "node_modules/aws-sign2": {
@@ -9166,6 +9282,12 @@
         "verror": "1.10.0"
       }
     },
+    "node_modules/just-extend": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-6.2.0.tgz",
+      "integrity": "sha512-cYofQu2Xpom82S6qD778jBDpwvvy39s1l/hrYij2u9AMdQcGRpaBu6kY4mVhuno5kJVi1DAz4aiphA2WI1/OAw==",
+      "dev": true
+    },
     "node_modules/jwa": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
@@ -9765,6 +9887,12 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
+    "node_modules/lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
+      "dev": true
+    },
     "node_modules/lodash.includes": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
@@ -10351,6 +10479,34 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/nise": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-5.1.9.tgz",
+      "integrity": "sha512-qOnoujW4SV6e40dYxJOb3uvuoPHtmLzIk4TFo+j0jPJoC+5Z9xja5qH5JZobEPsa8+YYphMrOSwnrshEhG2qww==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.0",
+        "@sinonjs/fake-timers": "^11.2.2",
+        "@sinonjs/text-encoding": "^0.7.2",
+        "just-extend": "^6.2.0",
+        "path-to-regexp": "^6.2.1"
+      }
+    },
+    "node_modules/nise/node_modules/@sinonjs/fake-timers": {
+      "version": "11.2.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-11.2.2.tgz",
+      "integrity": "sha512-G2piCSxQ7oWOxwGSAyFHfPIsyeJGXYtc6mFbnFA+kRXkiEnTl8c/8jul2S329iFBnDI9HGoeWWAZvuvOkZccgw==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.0"
+      }
+    },
+    "node_modules/nise/node_modules/path-to-regexp": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.1.tgz",
+      "integrity": "sha512-JLyh7xT1kizaEvcaXOQwOc2/Yhw6KZOvPf1S8401UyLk86CU79LN3vl7ztXGm/pZ+YjoyAJ4rxmHwbkBXJX+yw==",
+      "dev": true
     },
     "node_modules/nocache": {
       "version": "4.0.0",
@@ -11762,6 +11918,45 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/sinon": {
+      "version": "16.1.3",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-16.1.3.tgz",
+      "integrity": "sha512-mjnWWeyxcAf9nC0bXcPmiDut+oE8HYridTNzBbF98AYVLmWwGRp2ISEpyhYflG1ifILT+eNn3BmKUJPxjXUPlA==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.0",
+        "@sinonjs/fake-timers": "^10.3.0",
+        "@sinonjs/samsam": "^8.0.0",
+        "diff": "^5.1.0",
+        "nise": "^5.1.4",
+        "supports-color": "^7.2.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/sinon"
+      }
+    },
+    "node_modules/sinon/node_modules/diff": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.0.tgz",
+      "integrity": "sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/sinon/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/sisteransi": {

--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.540.0",
+    "@aws-sdk/client-sqs": "^3.529.1",
     "@ministryofjustice/frontend": "^2.1.2",
     "@sentry/node": "^7.108.0",
     "agentkeepalive": "^4.5.0",
@@ -131,7 +132,7 @@
     "uuid": "^9.0.1"
   },
   "devDependencies": {
-    "@tsconfig/node20": "^20.1.2",
+    "@tsconfig/node20": "^20.1.3",
     "@types/bunyan": "^1.8.11",
     "@types/bunyan-format": "^0.2.9",
     "@types/compression": "^1.7.5",
@@ -153,9 +154,10 @@
     "@types/superagent": "^8.1.6",
     "@types/supertest": "^6.0.2",
     "@types/uuid": "^9.0.8",
-    "@typescript-eslint/eslint-plugin": "^7.3.1",
-    "@typescript-eslint/parser": "^7.3.1",
+    "@typescript-eslint/eslint-plugin": "^7.4.0",
+    "@typescript-eslint/parser": "^7.4.0",
     "audit-ci": "^6.6.1",
+    "aws-sdk-client-mock": "^4.0.0",
     "concurrently": "^8.2.2",
     "cookie-session": "^2.1.0",
     "cypress": "^13.7.1",

--- a/server/config.ts
+++ b/server/config.ts
@@ -55,6 +55,20 @@ const applicationInfo: ApplicationInfo = {
   gitRef: get('GIT_REF', 'unknown', requiredInProduction),
 }
 
+const auditConfig = () => {
+  const auditEnabled = get('AUDIT_ENABLED', 'false') === 'true'
+  return {
+    enabled: auditEnabled,
+    queueUrl: get(
+      'AUDIT_SQS_QUEUE_URL',
+      'http://localhost:4566/000000000000/mainQueue',
+      auditEnabled && requiredInProduction,
+    ),
+    serviceName: get('AUDIT_SERVICE_NAME', 'UNASSIGNED', auditEnabled && requiredInProduction),
+    region: get('AUDIT_SQS_REGION', 'eu-west-2'),
+  }
+}
+
 export default {
   applicationInfo,
   production, // NB: this is true in _all_ deployed environments
@@ -171,6 +185,9 @@ export default {
       },
       agent: new AgentConfig(Number(get('COMPONENT_API_TIMEOUT_SECONDS', 5000))),
     },
+  },
+  sqs: {
+    audit: auditConfig(),
   },
   domain: get('INGRESS_URL', 'http://localhost:3000', requiredInProduction),
   dpsUrl: get('DPS_URL', 'http://localhost:3000', requiredInProduction),

--- a/server/data/hmppsAuditClient.test.ts
+++ b/server/data/hmppsAuditClient.test.ts
@@ -1,0 +1,110 @@
+import { mockClient } from 'aws-sdk-client-mock'
+import { SendMessageCommand, type SendMessageCommandInput, SQSClient } from '@aws-sdk/client-sqs'
+
+import HmppsAuditClient, { SqsMessage } from './hmppsAuditClient'
+
+describe('hmppsAuditClient', () => {
+  const sqsMock = mockClient(SQSClient)
+  let hmppsAuditClient: HmppsAuditClient
+
+  const auditClientConfig = {
+    queueUrl: 'http://localhost:4566/000000000000/mainQueue',
+    region: 'eu-west-2',
+    serviceName: 'hmpps-service',
+    enabled: true,
+  }
+
+  afterEach(() => {
+    sqsMock.reset()
+    jest.resetAllMocks()
+  })
+
+  describe('sendMessage', () => {
+    it('should send sqs message to audit queue', async () => {
+      sqsMock.on(SendMessageCommand).resolves({ MessageId: '123' })
+      hmppsAuditClient = new HmppsAuditClient({
+        ...auditClientConfig,
+        queueUrl: 'http://localhost:4566/000000000000/mainQueue',
+      })
+
+      const actualResponse = await hmppsAuditClient.sendMessage({
+        what: 'EXAMPLE_EVENT',
+        who: 'user1',
+        subjectId: 'subject123',
+        subjectType: 'exampleType',
+        correlationId: 'request123',
+        details: { extraDetails: 'example' },
+      })
+
+      const expectedSqsMessageBody: SqsMessage = {
+        what: 'EXAMPLE_EVENT',
+        who: 'user1',
+        when: expect.any(String),
+        service: 'hmpps-service',
+        subjectId: 'subject123',
+        subjectType: 'exampleType',
+        correlationId: 'request123',
+        details: { extraDetails: 'example' },
+      }
+
+      expect(actualResponse).toEqual({ MessageId: '123' })
+
+      const actualMessageInput = sqsMock.call(0).args[0].input as SendMessageCommandInput
+
+      expect(actualMessageInput.QueueUrl).toEqual('http://localhost:4566/000000000000/mainQueue')
+
+      const actualMessageBody = JSON.parse(actualMessageInput.MessageBody)
+      expect(actualMessageBody).toEqual(expectedSqsMessageBody)
+
+      const eventTime = Date.parse(actualMessageBody.when)
+      expect(Date.now() - eventTime).toBeLessThan(10)
+
+      expect(sqsMock.calls().length).toEqual(1)
+    })
+
+    it("shouldn't send sqs message to audit queue if client disabled", async () => {
+      sqsMock.on(SendMessageCommand).resolves({ MessageId: '123' })
+      hmppsAuditClient = new HmppsAuditClient({ ...auditClientConfig, enabled: false })
+
+      await hmppsAuditClient.sendMessage({
+        what: 'EXAMPLE_EVENT',
+        who: 'user1',
+      })
+
+      expect(sqsMock.calls().length).toEqual(0)
+    })
+
+    it("shouldn't throw an error if sqs message cannot be sent", async () => {
+      sqsMock.on(SendMessageCommand).rejects(new Error('Error sending sqs message'))
+      hmppsAuditClient = new HmppsAuditClient({ ...auditClientConfig })
+
+      const trySendMessage = async () => {
+        await hmppsAuditClient.sendMessage(
+          {
+            what: 'EXAMPLE_EVENT',
+            who: 'user1',
+          },
+          false,
+        )
+      }
+
+      await expect(trySendMessage()).resolves.not.toThrow()
+      expect(sqsMock.calls().length).toEqual(1)
+    })
+
+    it('should throw an error if sqs message cannot be sent', async () => {
+      sqsMock.on(SendMessageCommand).rejects(new Error('Error sending sqs message'))
+      hmppsAuditClient = new HmppsAuditClient({ ...auditClientConfig })
+
+      const trySendMessage = async () => {
+        await hmppsAuditClient.sendMessage({
+          what: 'EXAMPLE_EVENT',
+          who: 'user1',
+        })
+      }
+
+      await expect(trySendMessage()).rejects.toThrow('Error sending sqs message')
+      expect(sqsMock.calls().length).toEqual(1)
+    })
+  })
+})

--- a/server/data/hmppsAuditClient.ts
+++ b/server/data/hmppsAuditClient.ts
@@ -1,0 +1,71 @@
+import { SendMessageCommand, type SendMessageCommandOutput, SQSClient } from '@aws-sdk/client-sqs'
+
+import logger from '../../logger'
+
+export interface AuditEvent {
+  what: string
+  who: string
+  subjectId?: string
+  subjectType?: string
+  correlationId?: string
+  details?: object
+}
+
+export interface SqsMessage {
+  what: string
+  who: string
+  when: string
+  service: string
+  subjectId?: string
+  subjectType?: string
+  correlationId?: string
+  details?: object
+}
+
+export interface AuditClientConfig {
+  queueUrl: string
+  region: string
+  serviceName: string
+  enabled: boolean
+}
+
+export default class HmppsAuditClient {
+  private sqsClient: SQSClient
+
+  private readonly queueUrl: string
+
+  private readonly serviceName: string
+
+  private readonly enabled: boolean
+
+  constructor(config: AuditClientConfig) {
+    this.enabled = config.enabled
+    this.queueUrl = config.queueUrl
+    this.serviceName = config.serviceName
+    this.sqsClient = new SQSClient({ region: config.region })
+  }
+
+  async sendMessage(event: AuditEvent, throwOnError: boolean = true): Promise<SendMessageCommandOutput | null> {
+    if (!this.enabled) return null
+
+    const sqsMessage: SqsMessage = {
+      ...event,
+      service: this.serviceName,
+      when: new Date().toISOString(),
+    }
+
+    try {
+      const messageResponse = await this.sqsClient.send(
+        new SendMessageCommand({ MessageBody: JSON.stringify(sqsMessage), QueueUrl: this.queueUrl }),
+      )
+
+      logger.info(`HMPPS Audit SQS message sent (${messageResponse.MessageId})`)
+
+      return messageResponse
+    } catch (error) {
+      logger.error('Error sending HMPPS Audit SQS message, ', error)
+      if (throwOnError) throw error
+    }
+    return null
+  }
+}

--- a/server/services/auditService.test.ts
+++ b/server/services/auditService.test.ts
@@ -1,0 +1,57 @@
+import HmppsAuditClient from '../data/hmppsAuditClient'
+import AuditService, { Page } from './auditService'
+
+jest.mock('../data/hmppsAuditClient')
+
+describe('Audit service', () => {
+  let hmppsAuditClient: jest.Mocked<HmppsAuditClient>
+  let auditService: AuditService
+
+  beforeEach(() => {
+    hmppsAuditClient = new HmppsAuditClient(null) as jest.Mocked<HmppsAuditClient>
+    auditService = new AuditService(hmppsAuditClient)
+  })
+
+  describe('logAuditEvent', () => {
+    it('sends audit message using audit client', async () => {
+      await auditService.logAuditEvent({
+        what: 'AUDIT_EVENT',
+        who: 'user1',
+        subjectId: 'subject123',
+        subjectType: 'exampleType',
+        correlationId: 'request123',
+        details: { extraDetails: 'example' },
+      })
+
+      expect(hmppsAuditClient.sendMessage).toHaveBeenCalledWith({
+        what: 'AUDIT_EVENT',
+        who: 'user1',
+        subjectId: 'subject123',
+        subjectType: 'exampleType',
+        correlationId: 'request123',
+        details: { extraDetails: 'example' },
+      })
+    })
+  })
+
+  describe('logPageView', () => {
+    it('sends page view event audit message using audit client', async () => {
+      await auditService.logPageView(Page.HOME_PAGE, {
+        who: 'user1',
+        subjectId: 'subject123',
+        subjectType: 'exampleType',
+        correlationId: 'request123',
+        details: { extraDetails: 'example' },
+      })
+
+      expect(hmppsAuditClient.sendMessage).toHaveBeenCalledWith({
+        what: 'PAGE_VIEW_HOME_PAGE',
+        who: 'user1',
+        subjectId: 'subject123',
+        subjectType: 'exampleType',
+        correlationId: 'request123',
+        details: { extraDetails: 'example' },
+      })
+    })
+  })
+})

--- a/server/services/auditService.ts
+++ b/server/services/auditService.ts
@@ -1,0 +1,29 @@
+import HmppsAuditClient, { type AuditEvent } from '../data/hmppsAuditClient'
+
+export enum Page {
+  HOME_PAGE = 'HOME_PAGE',
+}
+
+export interface PageViewEventDetails {
+  who: string
+  subjectId?: string
+  subjectType?: string
+  correlationId?: string
+  details?: object
+}
+
+export default class AuditService {
+  constructor(private readonly hmppsAuditClient: HmppsAuditClient) {}
+
+  async logAuditEvent(event: AuditEvent): Promise<void> {
+    await this.hmppsAuditClient.sendMessage(event)
+  }
+
+  async logPageView(page: Page, eventDetails: PageViewEventDetails): Promise<void> {
+    const event: AuditEvent = {
+      ...eventDetails,
+      what: `PAGE_VIEW_${page}`,
+    }
+    await this.hmppsAuditClient.sendMessage(event)
+  }
+}


### PR DESCRIPTION
Copied from [upstream template](https://github.com/ministryofjustice/hmpps-template-typescript/pull/327) but the audit client is _not_ used in any route