### PR TITLE
INC-1335: Use non-deprecated endpoint to load DPS micro-frontend components

### DIFF
--- a/integration_tests/mockApis/wiremock.ts
+++ b/integration_tests/mockApis/wiremock.ts
@@ -8,7 +8,7 @@ const url = 'http://localhost:9091/__admin'
  */
 export interface Mapping {
   request?: Partial<
-    { method: 'GET' | 'POST' | 'PATCH' | 'PUT' | 'DELETE' } & (
+    { method: 'GET' | 'POST' | 'PATCH' | 'PUT' | 'DELETE'; queryParameters: object } & (
       | { url: string }
       | { urlPath: string }
       | { urlPathPattern: string }

--- a/server/data/frontendComponentsClient.ts
+++ b/server/data/frontendComponentsClient.ts
@@ -1,4 +1,3 @@
-import logger from '../../logger'
 import config from '../config'
 import RestClient from './restClient'
 
@@ -10,15 +9,42 @@ export interface Component {
 
 export type AvailableComponent = 'header' | 'footer'
 
+export interface CaseLoad {
+  caseLoadId: string
+  description: string
+  type: string
+  caseloadFunction: string
+  currentlyActive: boolean
+}
+
+export interface Service {
+  id: string
+  heading: string
+  description: string
+  href: string
+  navEnabled: boolean
+}
+
+export interface ComponentsResponse extends Record<AvailableComponent, Component> {
+  meta: {
+    activeCaseLoad: CaseLoad
+    caseLoads: CaseLoad[]
+    services: Service[]
+  }
+}
+
 export default class FrontendComponentsClient {
   private static restClient(token: string): RestClient {
     return new RestClient('HMPPS Components Client', config.apis.frontendComponents, token)
   }
 
-  getComponent(component: AvailableComponent, userToken: string): Promise<Component> {
-    logger.info(`Getting frontend component ${component}`)
-    return FrontendComponentsClient.restClient(userToken).get<Component>({
-      path: `/${component}`,
+  getComponents<T extends AvailableComponent[]>(
+    components: T,
+    userToken: string,
+  ): Promise<Pick<ComponentsResponse, 'meta' | T[number]>> {
+    return FrontendComponentsClient.restClient(userToken).get({
+      path: '/components',
+      query: { component: components },
       headers: { 'x-user-token': userToken },
     })
   }

--- a/server/middleware/frontendComponents.test.ts
+++ b/server/middleware/frontendComponents.test.ts
@@ -1,0 +1,67 @@
+import type { NextFunction, Request, Response } from 'express'
+import nock from 'nock'
+
+import config from '../config'
+import { mockFrontendComponentResponse } from '../testData/frontendComponents'
+import frontendComponents from './frontendComponents'
+
+describe('Frontend components middleware', () => {
+  const fakeApiClient = nock(config.apis.frontendComponents.url)
+  const frontendComponentsMiddleware = frontendComponents()
+  const userToken = 'user-token'
+
+  afterEach(() => {
+    nock.cleanAll()
+  })
+
+  it('should load frontend components', async () => {
+    fakeApiClient
+      .get('/components')
+      .query({ component: ['header', 'footer'] })
+      .matchHeader('authorization', `Bearer ${userToken}`)
+      .reply(
+        200,
+        mockFrontendComponentResponse({
+          header: {
+            html: 'header html',
+            css: ['/header.css'],
+            javascript: ['/header.js'],
+          },
+          footer: {
+            html: 'footer html',
+            css: ['/footer.css', '/footer-2.css'],
+            javascript: ['/footer.js'],
+          },
+        }),
+      )
+
+    const req = {} as Request
+    const res = { locals: { user: { token: userToken } } } as Response
+    const next: NextFunction = jest.fn()
+    await frontendComponentsMiddleware(req, res, next)
+
+    expect(next).toHaveBeenCalledWith()
+    expect(res.locals.feComponents).toEqual({
+      header: 'header html',
+      footer: 'footer html',
+      cssIncludes: ['/header.css', '/footer.css', '/footer-2.css'],
+      jsIncludes: ['/header.js', '/footer.js'],
+    })
+  })
+
+  it('should call next request handler even if frontend components failed to load', async () => {
+    fakeApiClient
+      .get('/components')
+      .query({ component: ['header', 'footer'] })
+      .matchHeader('authorization', `Bearer ${userToken}`)
+      .reply(401, { status: 401, userMessage: 'Unauthorized', developerMessage: 'Unauthorized' })
+
+    const req = {} as Request
+    const res = { locals: { user: { token: userToken } } } as Response
+    const next: NextFunction = jest.fn()
+    await frontendComponentsMiddleware(req, res, next)
+
+    expect(next).toHaveBeenCalledWith()
+    expect(res.locals.feComponents).toBeUndefined()
+  })
+})

--- a/server/middleware/frontendComponents.ts
+++ b/server/middleware/frontendComponents.ts
@@ -1,16 +1,17 @@
-import type { RequestHandler } from 'express'
+import type { NextFunction, Request, Response } from 'express'
 
 import logger from '../../logger'
 import FrontendComponentsClient from '../data/frontendComponentsClient'
 
-export default function frontendComponents(): RequestHandler {
+export default function frontendComponents() {
   const frontendComponentsClient = new FrontendComponentsClient()
-  return async (req, res, next) => {
+  return async (req: Request, res: Response, next: NextFunction): Promise<void> => {
     try {
-      const [header, footer] = await Promise.all([
-        frontendComponentsClient.getComponent('header', res.locals.user.token),
-        frontendComponentsClient.getComponent('footer', res.locals.user.token),
-      ])
+      const { header, footer } = await frontendComponentsClient.getComponents(
+        ['header', 'footer'],
+        res.locals.user.token,
+      )
+      // TODO: meta information from frontend components can be used to read active and available caseloads
       res.locals.feComponents = {
         header: header.html,
         footer: footer.html,
@@ -19,7 +20,7 @@ export default function frontendComponents(): RequestHandler {
       }
       next()
     } catch (error) {
-      logger.error(error, 'Failed to retrieve front end components')
+      logger.error(error, 'Failed to retrieve frontend components')
       next()
     }
   }

--- a/server/sanitisedError.test.ts
+++ b/server/sanitisedError.test.ts
@@ -36,14 +36,13 @@ describe('sanitised error', () => {
     expect(sanitisedError(error)).toEqual(expectedError)
   })
 
-  it('it should return the error message ', () => {
+  it('it should return the error message', () => {
     const error = {
       message: 'error description',
     } as unknown as UnsanitisedError
 
-    const expectedError = new Error('error description')
-
-    expect(sanitisedError(error)).toEqual(expectedError)
+    expect(sanitisedError(error)).toBeInstanceOf(Error)
+    expect(sanitisedError(error)).toHaveProperty('message', 'error description')
   })
 
   it('it should return an empty error for an unknown error structure', () => {

--- a/server/sanitisedError.ts
+++ b/server/sanitisedError.ts
@@ -1,5 +1,8 @@
 import type { ResponseError } from 'superagent'
 
+/**
+ * An error that may be safe to log as it omits sensitive request headers
+ */
 export interface SanitisedError<Data = unknown> extends Error {
   text?: string
   status?: number
@@ -9,8 +12,15 @@ export interface SanitisedError<Data = unknown> extends Error {
   message: string
 }
 
+/**
+ * An error as returned by superagemt, contains sensitive request headers
+ */
 export type UnsanitisedError = ResponseError
 
+/**
+ * Converts an UnsanitisedError (superagent.ResponseError) into a simpler Error object,
+ * omitting request inforation (e.g. sensitive request headers)
+ */
 export default function sanitise<Data = unknown>(error: UnsanitisedError): SanitisedError<Data> {
   const e = new Error() as SanitisedError<Data>
   e.message = error.message

--- a/server/testData/frontendComponents.ts
+++ b/server/testData/frontendComponents.ts
@@ -1,0 +1,32 @@
+import type { AvailableComponent, CaseLoad, Component, ComponentsResponse } from '../data/frontendComponentsClient'
+import { agencyDetails } from './prisonApi'
+
+const emptyComponent: Component = {
+  html: '',
+  css: [],
+  javascript: [],
+}
+
+const caseload: CaseLoad = {
+  caseLoadId: agencyDetails.agencyId,
+  description: agencyDetails.description,
+  type: agencyDetails.agencyType,
+  caseloadFunction: 'GENERAL',
+  currentlyActive: true,
+}
+
+// eslint-disable-next-line import/prefer-default-export
+export function mockFrontendComponentResponse(
+  components: Partial<Record<AvailableComponent, Component>> = {},
+): ComponentsResponse {
+  return {
+    header: emptyComponent,
+    footer: emptyComponent,
+    ...components,
+    meta: {
+      activeCaseLoad: caseload,
+      caseLoads: [caseload],
+      services: [],
+    },
+  }
+}


### PR DESCRIPTION
`/header` & `/footer` endpoints are deprecated and [`/components`](https://frontend-components.hmpps.service.justice.gov.uk/api-docs/#/default/get_components) should be used instead

copied from [hmpps-incident-reporting#201](https://github.com/ministryofjustice/hmpps-incident-reporting/pull/201)