### PR TITLE
INC-1335: Get Azure Application Insights settings from kubernetes secret directly

### DIFF
--- a/helm_deploy/hmpps-incentives-ui/values.yaml
+++ b/helm_deploy/hmpps-incentives-ui/values.yaml
@@ -32,7 +32,6 @@ generic-service:
     NODE_ENV: "production"
     REDIS_TLS_ENABLED: "true"
     TOKEN_VERIFICATION_ENABLED: "true"
-    APPLICATIONINSIGHTS_CONNECTION_STRING: "InstrumentationKey=$(APPINSIGHTS_INSTRUMENTATIONKEY);IngestionEndpoint=https://northeurope-0.in.applicationinsights.azure.com/;LiveEndpoint=https://northeurope.livediagnostics.monitor.azure.com/"
     BUNYAN_NO_COLOR: "1"
     PHASE_NAME: ""
     FEATURE_ADD_TEST_ERROR_ENDPOINT: ""
@@ -43,6 +42,8 @@ generic-service:
   envFrom:
     - secretRef:
         name: hmpps-incentives-ui
+    - secretRef:
+        name: application-insights
 
   namespace_secrets:
     elasticache-redis:


### PR DESCRIPTION
…the k8s secret itself is created by terraform from a shared DPS secret in a AWS systems manager parameter

Ref: [hmpps-template-typescript#485](https://github.com/ministryofjustice/hmpps-template-typescript/pull/485)