### PR TITLE
Fixes VB-4369 - improves guidance on VOs linked to incentive levels

### DIFF
--- a/integration_tests/e2e/prisonIncentiveLevels.cy.ts
+++ b/integration_tests/e2e/prisonIncentiveLevels.cy.ts
@@ -46,7 +46,7 @@ context('Prison incentive level management', () => {
         { 'Default for new prisoners': 'Yes' },
         { 'Remand prisoners': '£60.50 per week', 'Convicted prisoners': '£19.80 per week' },
         { 'Remand prisoners': '£605', 'Convicted prisoners': '£198' },
-        { 'Visits (VO)': '1', 'Privileged visits (PVO)': '2' },
+        { 'Visits (VO)': '1 added every 14 days', 'Privileged visits (PVO)': '2 added each month' },
       ])
 
     detailPage.returnLink.click()

--- a/server/routes/prisonIncentiveLevels.test.ts
+++ b/server/routes/prisonIncentiveLevels.test.ts
@@ -358,7 +358,7 @@ describe('Prison incentive level management', () => {
             '£605',
             '£198',
             '1 added every 14 days',
-            '2 added each month'
+            '2 added each month',
           ])
         })
     })
@@ -386,7 +386,7 @@ describe('Prison incentive level management', () => {
             '£275',
             '£55',
             '1 added every 14 days',
-            '0 added each month'
+            '0 added each month',
           ])
         })
     })

--- a/server/routes/prisonIncentiveLevels.test.ts
+++ b/server/routes/prisonIncentiveLevels.test.ts
@@ -351,13 +351,13 @@ describe('Prison incentive level management', () => {
               return valueCell.textContent.trim()
             })
             .toArray()
-          expect(values).toEqual(
-            [
-            'Yes', 
-            '£60.50 per week', 
-            '£19.80 per week', 
-            '£605', '£198', 
-            '1 added every 14 days', 
+          expect(values).toEqual([
+            'Yes',
+            '£60.50 per week',
+            '£19.80 per week',
+            '£605',
+            '£198',
+            '1 added every 14 days',
             '2 added each month'
           ])
         })
@@ -379,14 +379,13 @@ describe('Prison incentive level management', () => {
               return valueCell.textContent.trim()
             })
             .toArray()
-          expect(values).toEqual(
-            [
-            'No', 
-            '£27.50 per week', 
-            '£5.50 per week', 
-            '£275', 
-            '£55', 
-            '1 added every 14 days', 
+          expect(values).toEqual([
+            'No',
+            '£27.50 per week',
+            '£5.50 per week',
+            '£275',
+            '£55',
+            '1 added every 14 days',
             '0 added each month'
           ])
         })

--- a/server/routes/prisonIncentiveLevels.test.ts
+++ b/server/routes/prisonIncentiveLevels.test.ts
@@ -351,7 +351,15 @@ describe('Prison incentive level management', () => {
               return valueCell.textContent.trim()
             })
             .toArray()
-          expect(values).toEqual(['Yes', '£60.50 per week', '£19.80 per week', '£605', '£198', '1 added every 14 days', '2 added each month'])
+          expect(values).toEqual(
+            [
+            'Yes', 
+            '£60.50 per week', 
+            '£19.80 per week', 
+            '£605', '£198', 
+            '1 added every 14 days', 
+            '2 added each month'
+          ])
         })
     })
 
@@ -371,7 +379,16 @@ describe('Prison incentive level management', () => {
               return valueCell.textContent.trim()
             })
             .toArray()
-          expect(values).toEqual(['No', '£27.50 per week', '£5.50 per week', '£275', '£55', '1 added every 14 days', '0 added each month'])
+          expect(values).toEqual(
+            [
+            'No', 
+            '£27.50 per week', 
+            '£5.50 per week', 
+            '£275', 
+            '£55', 
+            '1 added every 14 days', 
+            '0 added each month'
+          ])
         })
     })
   })

--- a/server/routes/prisonIncentiveLevels.test.ts
+++ b/server/routes/prisonIncentiveLevels.test.ts
@@ -351,7 +351,7 @@ describe('Prison incentive level management', () => {
               return valueCell.textContent.trim()
             })
             .toArray()
-          expect(values).toEqual(['Yes', '£60.50 per week', '£19.80 per week', '£605', '£198', '1', '2'])
+          expect(values).toEqual(['Yes', '£60.50 per week', '£19.80 per week', '£605', '£198', '1 added every 14 days', '2 added each month'])
         })
     })
 
@@ -371,7 +371,7 @@ describe('Prison incentive level management', () => {
               return valueCell.textContent.trim()
             })
             .toArray()
-          expect(values).toEqual(['No', '£27.50 per week', '£5.50 per week', '£275', '£55', '1', '0'])
+          expect(values).toEqual(['No', '£27.50 per week', '£5.50 per week', '£275', '£55', '1 added every 14 days', '0 added each month'])
         })
     })
   })

--- a/server/views/pages/prisonIncentiveLevel.njk
+++ b/server/views/pages/prisonIncentiveLevel.njk
@@ -80,9 +80,9 @@
         ]
       }) }}
 
-      <p class="govuk-body">VOs are added every 14 days from the date of conviction. Unused VOs can be accumulated up to a total of 26.</p>
+      <p>VOs are added every 14 days from the date of conviction. Unused VOs can be accumulated up to a total of 26.</p>
 
-      <p class="govuk-body">PVOs are added on the first day of each month. Unused PVOs expire at the end of each month.</p>
+      <p>PVOs are added on the first day of each month. Unused PVOs expire at the end of each month.</p>
 
       <div class="govuk-button-group">
         {{ govukButton({

--- a/server/views/pages/prisonIncentiveLevel.njk
+++ b/server/views/pages/prisonIncentiveLevel.njk
@@ -71,14 +71,18 @@
         rows: [
           [
             { text: "Visits (VO)" },
-            { text: prisonIncentiveLevel.visitOrders }
+            { text: prisonIncentiveLevel.visitOrders + " added every 14 days"}
           ],
           [
             { text: "Privileged visits (PVO)" },
-            { text: prisonIncentiveLevel.privilegedVisitOrders}
+            { text: prisonIncentiveLevel.privilegedVisitOrders + " added each month"}
           ]
         ]
       }) }}
+
+      <p class="govuk-body">VOs are added every 14 days from the date of conviction. Unused VOs can be accumulated up to a total of 26.</p>
+
+      <p class="govuk-body">PVOs are added on the first day of each month. Unused PVOs expire at the end of each month.</p>
 
       <div class="govuk-button-group">
         {{ govukButton({

--- a/server/views/partials/prisonIncentiveLevelEditPartial.njk
+++ b/server/views/partials/prisonIncentiveLevelEditPartial.njk
@@ -117,7 +117,7 @@
     id: form.formId + "-" + fieldId,
     name: fieldId,
     value: field.value,
-    suffix: {text: "added every 14 days"},
+    suffix: { text: "added every 14 days" },
     inputmode: "numeric",
     spellcheck: false,
     errorMessage: { text: field.error } if field.error else undefined
@@ -131,7 +131,7 @@
     id: form.formId + "-" + fieldId,
     name: fieldId,
     value: field.value,
-    suffix: {text: "added each month"},
+    suffix: { text: "added each month" },
     inputmode: "numeric",
     spellcheck: false,
     errorMessage: { text: field.error } if field.error else undefined

--- a/server/views/partials/prisonIncentiveLevelEditPartial.njk
+++ b/server/views/partials/prisonIncentiveLevelEditPartial.njk
@@ -139,8 +139,8 @@
     errorMessage: { text: field.error } if field.error else undefined
   }) }}
 
-  <p class="govuk-body">VOs are added every 14 days from the date of conviction. Unused VOs can be accumulated up to a total of 26.</p>
+  <p>VOs are added every 14 days from the date of conviction. Unused VOs can be accumulated up to a total of 26.</p>
 
-  <p class="govuk-body">PVOs are added on the first day of each month. Unused PVOs expire at the end of each month.</p>
+  <p>PVOs are added on the first day of each month. Unused PVOs expire at the end of each month.</p>
 
 {% endcall %}

--- a/server/views/partials/prisonIncentiveLevelEditPartial.njk
+++ b/server/views/partials/prisonIncentiveLevelEditPartial.njk
@@ -47,6 +47,7 @@
     id: form.formId + "-" + fieldId,
     name: fieldId,
     value: field.value,
+    suffix: { text: "per week" },
     spellcheck: false,
     errorMessage: { text: field.error } if field.error else undefined
   }) }}
@@ -60,6 +61,7 @@
     id: form.formId + "-" + fieldId,
     name: fieldId,
     value: field.value,
+    suffix: { text: "per week" },
     spellcheck: false,
     errorMessage: { text: field.error } if field.error else undefined
   }) }}

--- a/server/views/partials/prisonIncentiveLevelEditPartial.njk
+++ b/server/views/partials/prisonIncentiveLevelEditPartial.njk
@@ -117,6 +117,7 @@
     id: form.formId + "-" + fieldId,
     name: fieldId,
     value: field.value,
+    suffix: {text: "added every 14 days"},
     inputmode: "numeric",
     spellcheck: false,
     errorMessage: { text: field.error } if field.error else undefined
@@ -130,8 +131,14 @@
     id: form.formId + "-" + fieldId,
     name: fieldId,
     value: field.value,
+    suffix: {text: "added each month"},
     inputmode: "numeric",
     spellcheck: false,
     errorMessage: { text: field.error } if field.error else undefined
   }) }}
+
+  <p class="govuk-body">VOs are added every 14 days from the date of conviction. Unused VOs can be accumulated up to a total of 26.</p>
+
+  <p class="govuk-body">PVOs are added on the first day of each month. Unused PVOs expire at the end of each month.</p>
+
 {% endcall %}


### PR DESCRIPTION
The number of visiting orders (and privileged visiting orders) a prisoner receives for a given incentive level at a prison is now controlled in the incentives API.

The information presented to staff as they input those numbers is very limited - this means that some prisons have inputted very high numbers in that service. We also get queries from staff asking what the allowances are and when they will get added.

This PR improves the information shown to staff, including:
* how frequently VOs get updated
* how frequently PVOs get updated
* if and when the VOs or PVOs ‘expire'

By improving the information in the Incentive service, we can help staff understand what the VO and PVO numbers will mean for their establishment and prisoners in that establishment.