### PR TITLE
Secure access to incentive reviews page

### DIFF
--- a/server/data/constants.ts
+++ b/server/data/constants.ts
@@ -13,5 +13,11 @@ export const managePrisonIncentiveLevelsRole = 'ROLE_MAINTAIN_PRISON_IEP_LEVELS'
 /** User role needed to manage global incentive level details */
 export const manageIncentiveLevelsRole = 'ROLE_MAINTAIN_INCENTIVE_LEVELS' as const
 
+/** User role permitting global search and visibility of other caseloads */
+export const globalSearchRole = 'ROLE_GLOBAL_SEARCH' as const
+
+/** User role granting access to information about released people */
+export const inactiveBookingsRole = 'ROLE_INACTIVE_BOOKINGS' as const
+
 /** Usernames that will be displayed as "System" instead of looking up their name */
 export const SYSTEM_USERS = ['INCENTIVES_API']

--- a/server/routes/prisonerChangeIncentiveLevelDetails.test.ts
+++ b/server/routes/prisonerChangeIncentiveLevelDetails.test.ts
@@ -63,7 +63,7 @@ describe('GET /incentive-reviews/prisoner/change-incentive-level', () => {
       .set('authorization', `bearer ${tokenWithNecessaryRole}`)
       .expect(res => {
         expect(res.redirect).toBeTruthy()
-        expect(res.headers.location).toBe(`/incentive-reviews/prisoner/${prisonerInLeedsDetails.offenderNo}`)
+        expect(res.headers.location).toBe('/')
       })
   })
 
@@ -125,7 +125,7 @@ describe('POST /incentive-reviews/prisoner/change-incentive-level', () => {
       .send(validFormData)
       .expect(res => {
         expect(res.redirect).toBeTruthy()
-        expect(res.headers.location).toBe(`/incentive-reviews/prisoner/${prisonerInLeedsDetails.offenderNo}`)
+        expect(res.headers.location).toBe('/')
       })
   })
 

--- a/server/routes/prisonerIncentiveLevelDetails.test.ts
+++ b/server/routes/prisonerIncentiveLevelDetails.test.ts
@@ -101,18 +101,16 @@ describe('GET /incentive-reviews/prisoner/', () => {
       })
   })
 
-  it('should NOT allow user to update iep if user is NOT in case load and has CORRECT role', () => {
+  it('should NOT allow user access if user is NOT in case load despite CORRECT role', () => {
     app = appWithAllRoutes({
       mockUserService: new MockUserService(mockLeedsUserWithRole),
     })
 
     return request(app)
       .get(`/incentive-reviews/prisoner/${prisonerNumber}`)
-      .expect(200)
-      .expect('Content-Type', /html/)
+      .expect(302)
       .expect(res => {
-        expect(res.text).toContain('Incentive level history')
-        expect(res.text).not.toContain('Record incentive level')
+        expect(res.headers.location).toEqual('/')
       })
   })
 


### PR DESCRIPTION
…by checking user caseloads and roles with respect to the prisoner’s current location:

• if person is in transfer, global search role is required
• if person has been released, inactive bookings role is required
• otherwise person’s current establishment must be in user’s caseloads