### PR TITLE
INC-1335: Fix `minio` CLI call used for local testing to work with current version

### DIFF
--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -49,7 +49,7 @@ services:
     entrypoint: |
       /bin/sh -c "
         echo Provisioning bucket with minio
-        until mc config host add local http://minio:9000 $$MINIO_ROOT_USER $$MINIO_ROOT_PASSWORD; do
+        until mc alias set local http://minio:9000 $$MINIO_ROOT_USER $$MINIO_ROOT_PASSWORD; do
           echo 'Waiting for http://minio:9000'
           sleep 3
         done

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,11 +48,10 @@ services:
     entrypoint: |
       /bin/sh -c "
         echo Provisioning bucket with minio
-        until $$(curl --output /dev/null --silent http://minio:9000); do
+        until mc alias set local http://minio:9000 $$MINIO_ROOT_USER $$MINIO_ROOT_PASSWORD; do
           echo 'Waiting for http://minio:9000'
           sleep 3
         done
-        mc config host add local http://minio:9000 $$MINIO_ROOT_USER $$MINIO_ROOT_PASSWORD
         mc mb --region eu-west-1 --ignore-existing local/incentives
         mc mirror --overwrite /tmp/s3Bucket local/incentives
         exit 0


### PR DESCRIPTION
`$ mc config host add …` → `$ mc alias set …`