### PR TITLE
IR-1136: Tweaked start/stop schedules

### DIFF
--- a/helm_deploy/hmpps-incentives-ui/values.yaml
+++ b/helm_deploy/hmpps-incentives-ui/values.yaml
@@ -63,7 +63,9 @@ generic-service:
       - private_prisons
 
   scheduledDowntime:
-    timeZone: Europe/London
+    # NOTE: API starts at 6.49am UTC, stops at 21:58pm UTC
+    startup: '00 7 * * 1-5' # Start at 7.00am UTC Monday-Friday
+    shutdown: '50 21 * * 1-5' # Stop at 9.50pm UTC Monday-Friday
 
 generic-prometheus-alerts:
   targetApplication: hmpps-incentives-ui

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -4,6 +4,9 @@ generic-service:
   ingress:
     host: incentives-ui.hmpps.service.justice.gov.uk
 
+  scheduledDowntime:
+    enabled: false
+
   env:
     ENVIRONMENT: prod
     INGRESS_URL: "https://incentives-ui.hmpps.service.justice.gov.uk"


### PR DESCRIPTION
Use UTC and ensure API starts before UI/first retry-dlq run and stops after UI and last retry-dlq run.

- [6:49am API starts](https://github.com/ministryofjustice/hmpps-incentives-api/pull/687/files#diff-5ef4f2b0d47cd40c718eb93fc47bb057e8d41c41ae435aa4214f852ce1199282R16-R17)
- 7:00am UI starts
- [7:00am retry-dlq run every 10 minutes](https://github.com/ministryofjustice/hmpps-helm-charts/blob/f210af4475dd27689621b491a63d69bbe683de0e/charts/generic-service/values.yaml#L256)
- ...
- 9:50pm retry-dlq last run for the day
- 9:50pm UI stops
- 9:58pm API stops

Sibling of similar [API PR](https://github.com/ministryofjustice/hmpps-incentives-api/pull/687).