### PR TITLE
Updated incentive level page widths to two-thirds

### DIFF
--- a/server/views/pages/incentiveLevel.njk
+++ b/server/views/pages/incentiveLevel.njk
@@ -7,7 +7,7 @@
 
 {% block content %}
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-one-half">
+    <div class="govuk-grid-column-two-thirds">
 
       {% include "../partials/messages.njk" %}
 

--- a/server/views/pages/incentiveLevelCreateForm.njk
+++ b/server/views/pages/incentiveLevelCreateForm.njk
@@ -7,7 +7,7 @@
 
 {% block content %}
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-one-half">
+    <div class="govuk-grid-column-two-thirds">
 
       {% include "../partials/messages.njk" %}
       {% include "../partials/formErrorSummary.njk" %}

--- a/server/views/pages/incentiveLevelEditForm.njk
+++ b/server/views/pages/incentiveLevelEditForm.njk
@@ -8,7 +8,7 @@
 
 {% block content %}
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-one-half">
+    <div class="govuk-grid-column-two-thirds">
 
       {% include "../partials/messages.njk" %}
       {% include "../partials/formErrorSummary.njk" %}

--- a/server/views/pages/incentiveLevels.njk
+++ b/server/views/pages/incentiveLevels.njk
@@ -8,7 +8,7 @@
 
 {% block content %}
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-one-half">
+    <div class="govuk-grid-column-two-thirds">
 
       {% include "../partials/messages.njk" %}
 

--- a/server/views/pages/prisonIncentiveLevel.njk
+++ b/server/views/pages/prisonIncentiveLevel.njk
@@ -7,7 +7,7 @@
 
 {% block content %}
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-one-half">
+    <div class="govuk-grid-column-two-thirds">
 
       {% include "../partials/messages.njk" %}
 

--- a/server/views/pages/prisonIncentiveLevelAddForm.njk
+++ b/server/views/pages/prisonIncentiveLevelAddForm.njk
@@ -7,7 +7,7 @@
 
 {% block content %}
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-one-half">
+    <div class="govuk-grid-column-two-thirds">
 
       {% include "../partials/messages.njk" %}
       {% include "../partials/formErrorSummary.njk" %}

--- a/server/views/pages/prisonIncentiveLevelDeactivateForm.njk
+++ b/server/views/pages/prisonIncentiveLevelDeactivateForm.njk
@@ -7,7 +7,7 @@
 
 {% block content %}
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-one-half">
+    <div class="govuk-grid-column-two-thirds">
 
       {% include "../partials/messages.njk" %}
       {% include "../partials/formErrorSummary.njk" %}

--- a/server/views/pages/prisonIncentiveLevelEditForm.njk
+++ b/server/views/pages/prisonIncentiveLevelEditForm.njk
@@ -6,7 +6,7 @@
 
 {% block content %}
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-one-half">
+    <div class="govuk-grid-column-two-thirds">
 
       {% include "../partials/messages.njk" %}
       {% include "../partials/formErrorSummary.njk" %}

--- a/server/views/pages/prisonIncentiveLevelNextAddForm.njk
+++ b/server/views/pages/prisonIncentiveLevelNextAddForm.njk
@@ -7,7 +7,7 @@
 
 {% block content %}
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-one-half">
+    <div class="govuk-grid-column-two-thirds">
 
       {% include "../partials/messages.njk" %}
       {% include "../partials/formErrorSummary.njk" %}

--- a/server/views/pages/prisonIncentiveLevels.njk
+++ b/server/views/pages/prisonIncentiveLevels.njk
@@ -8,7 +8,7 @@
 
 {% block content %}
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-one-half">
+    <div class="govuk-grid-column-two-thirds">
 
       {% include "../partials/messages.njk" %}
 


### PR DESCRIPTION
This PR updates the incentive level pages from one-half width to two-thirds width. The current UI looks quite bunched.