### PR TITLE
CDPS-1906: Add both old and new DPS home pages to Content-Security-Policy `form-action` directive

### DIFF
--- a/feature.env
+++ b/feature.env
@@ -11,6 +11,7 @@ S3_ACCESS_KEY_ID=incentives
 S3_SECRET_ACCESS_KEY=incentives
 
 DPS_URL=http://localhost:3000
+NEW_DPS_URL=http://localhost:3000
 NOMIS_USER_ROLES_API_URL=http://localhost:9091/nomisUserRolesApi
 HMPPS_AUTH_URL=http://localhost:9091/auth
 MANAGE_USERS_API_URL=http://localhost:9091/manage-users-api

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -16,6 +16,7 @@ generic-service:
     S3_REGION: eu-west-2
     INGRESS_URL: "https://incentives-ui-dev.hmpps.service.justice.gov.uk"
     DPS_URL: "https://digital-dev.prison.service.justice.gov.uk"
+    NEW_DPS_URL: "https://dps-dev.prison.service.justice.gov.uk"
     SUPPORT_URL: "https://support-dev.hmpps.service.justice.gov.uk"
     HMPPS_AUTH_URL: "https://sign-in-dev.hmpps.service.justice.gov.uk/auth"
     HMPPS_INCENTIVES_API_URL: "https://incentives-api-dev.hmpps.service.justice.gov.uk"

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -14,6 +14,7 @@ generic-service:
     S3_REGION: eu-west-2
     INGRESS_URL: "https://incentives-ui-preprod.hmpps.service.justice.gov.uk"
     DPS_URL: "https://digital-preprod.prison.service.justice.gov.uk"
+    NEW_DPS_URL: "https://dps-preprod.prison.service.justice.gov.uk"
     SUPPORT_URL: "https://support-preprod.hmpps.service.justice.gov.uk"
     HMPPS_AUTH_URL: "https://sign-in-preprod.hmpps.service.justice.gov.uk/auth"
     HMPPS_INCENTIVES_API_URL: "https://incentives-api-preprod.hmpps.service.justice.gov.uk"

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -11,6 +11,7 @@ generic-service:
     ENVIRONMENT: prod
     INGRESS_URL: "https://incentives-ui.hmpps.service.justice.gov.uk"
     DPS_URL: "https://digital.prison.service.justice.gov.uk"
+    NEW_DPS_URL: "https://dps.prison.service.justice.gov.uk"
     SUPPORT_URL: "https://support.hmpps.service.justice.gov.uk"
     HMPPS_AUTH_URL: "https://sign-in.hmpps.service.justice.gov.uk/auth"
     HMPPS_INCENTIVES_API_URL: "https://incentives-api.hmpps.service.justice.gov.uk"

--- a/server/config.ts
+++ b/server/config.ts
@@ -191,6 +191,7 @@ export default {
   },
   ingressUrl: get('INGRESS_URL', 'http://localhost:3000', requiredInProduction),
   dpsUrl: get('DPS_URL', 'http://localhost:3000', requiredInProduction),
+  newDpsUrl: get('NEW_DPS_URL', 'http://localhost:3000', requiredInProduction),
   supportUrl: get('SUPPORT_URL', 'http://localhost:3000', requiredInProduction),
   googleAnalytics: {
     // Google Analytics 4 (GA4) measurement ID. Starts with `G-`.

--- a/server/middleware/setUpWebSecurity.ts
+++ b/server/middleware/setUpWebSecurity.ts
@@ -18,6 +18,7 @@ export default function setUpWebSecurity(): Router {
 
   const authHost = new URL(config.apis.hmppsAuth.externalUrl).hostname
   const dpsHost = new URL(config.dpsUrl).hostname
+  const newDpsHost = new URL(config.newDpsUrl).hostname
   const frontendComponentsHost = new URL(config.apis.frontendComponents.url).hostname
 
   router.use(
@@ -50,7 +51,7 @@ export default function setUpWebSecurity(): Router {
             '*.google.com',
             '*.google.co.uk',
           ],
-          formAction: ["'self'", authHost, dpsHost],
+          formAction: ["'self'", authHost, dpsHost, newDpsHost],
           connectSrc: [
             "'self'",
             '*.google-analytics.com',


### PR DESCRIPTION
… so that prisoner search will once again work from the header. CDPS team moved the feature between services, but there are redirects involved so both domains are needed.