### PR TITLE
Fix `qs` vulnerability (`moderate`)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2712,19 +2712,6 @@
         "node": "22 || 24 || 26"
       }
     },
-    "node_modules/@ministryofjustice/hmpps-auth-clients/node_modules/@ministryofjustice/hmpps-rest-client": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@ministryofjustice/hmpps-rest-client/-/hmpps-rest-client-1.2.1.tgz",
-      "integrity": "sha512-lioBIPZr9+hv+Gc+u/BSsuwPxmd2jEYeN1k5THiPogM14OmEB7yQjFD7WNSbJfkr+M4njvAUbgRvUTQgQI8oGg==",
-      "license": "MIT",
-      "dependencies": {
-        "agentkeepalive": "^4.6.0",
-        "superagent": "^10.3.0"
-      },
-      "engines": {
-        "node": "20 || 22 || 24"
-      }
-    },
     "node_modules/@ministryofjustice/hmpps-monitoring": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@ministryofjustice/hmpps-monitoring/-/hmpps-monitoring-2.1.0.tgz",
@@ -12527,9 +12514,9 @@
       "license": "MIT"
     },
     "node_modules/qs": {
-      "version": "6.14.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
-      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"

--- a/package.json
+++ b/package.json
@@ -113,6 +113,9 @@
     "typescript": "^6.0.3"
   },
   "overrides": {
+    "@cypress/request": {
+      "qs": "~6.15.2"
+    },
     "minimatch@^3.1.5": {
       "brace-expansion": "^1.1.14"
     },


### PR DESCRIPTION
**NOTE**: There is a new version of Cypress that may depend on the non-vulnerable version of `qs` - but it was just released. Once we upgrade to the newer version of `cypress` the entry under `overrides` may no longer be needed and we can remove it.

See: https://github.com/advisories/GHSA-q8mj-m7cp-5q26